### PR TITLE
docs: add npmx.dev badges and Y.js storage agent skill

### DIFF
--- a/.agents/skills/yjs-document-storage/SKILL.md
+++ b/.agents/skills/yjs-document-storage/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: yjs-document-storage
+description: Y.js document storage guidelines for concurrent-edit safety, schema evolution, and minimal CRDT overhead
+license: MIT
+metadata:
+  version: "1.0.0"
+---
+
+# Y.js Document Storage Skill
+
+Version: 1.0.0
+
+## Purpose
+
+This skill provides guidelines for encoding application data into Y.js documents. A Y.Doc is the **source of truth** for your data — once clients are syncing against a particular structure, changing that structure is a migration, not a refactor. Treat a Y.Doc layout like a database schema or wire protocol: correct now, extendable later, and shaped around how users actually concurrently edit.
+
+The goal: **maximize concurrent-edit safety** and **minimize CRDT overhead** (storage, sync payload, observer churn).
+
+## When to Apply
+
+Apply these guidelines when:
+
+- Designing the shape of a new Y.Doc
+- Adding a new field, collection, or entity to an existing Y.Doc
+- Reviewing code that calls `Y.Map.set`, `Y.Array.insert`, `new Y.Text`, or serializes structures into Y.js values
+- Debugging a sync/merge anomaly (corrupted strings, lost writes on concurrent edits, oversized documents)
+- Splitting data across Y.Docs for permissions or lazy-loading
+
+## Core Principles
+
+### 1. Y.Doc Is a Schema (CRITICAL)
+
+Design for your domain's growth axes. Use **maps keyed by ID** for collections. Reserve **top-level keys** for major concepts. Prefer **flat, typed values** over deeply nested structures. **Never** serialize a whole object as a JSON string into one Y.js value — you lose granular merging and every concurrent edit conflicts with every other edit.
+
+### 2. Group by Change, Not by Description (CRITICAL)
+
+For each pair of fields ask: *"Will two users ever edit these at the same time?"*
+
+- **Always change together** (e.g. `updatedBy` + `updatedAt`) → one atomic value.
+- **Can change independently** (e.g. `title` vs. `status`) → separate entries.
+- **User types into it** → `Y.Text`. **Selected from a set** → plain value.
+
+Match Y.js granularity to your UI's editing surface.
+
+### 3. `Array<Object>` → `Map<id, Object>` (CRITICAL)
+
+`Y.Array<Object>` is fine for append-only lists (logs, chat), but breaks for user-editable collections. A "move" is actually `delete` + `insert`, which creates a *new* item — concurrent edits to the "moved" original are lost, and two users reordering can produce duplicates. Index-based references also shift on concurrent inserts.
+
+Use `Y.Map<id, Y.Map<field, value>>` so each entity has a stable identity. For user-controlled ordering, use **fractional indexing** (string indices between neighbors) rather than integer positions, which collide when two users reorder at the same time.
+
+### 4. Known Set of Strings → Number (HIGH)
+
+Y.Map value writes are **last-writer-wins by `clientID`** (the client with the higher `clientID` wins — not the later timestamp). Concurrent writes of different string values don't corrupt each other (no character-level merge happens on a Y.Map string — that only happens with `Y.Text`). But numbers are still preferred for known enums:
+
+- **Smaller encoding** in the Yjs binary format than short strings.
+- **Cheap to change** the string labels without migrating every document.
+- **Clear intent**: "this is a choice, not typed text" — matches `Y.Text` vs. plain-value guidance in principle 9.
+
+### 5. Think About What the User Can Edit (HIGH)
+
+Not everything needs granular CRDT storage:
+
+- **UI-editable** (filters, column widths) → decomposed Y.Map / Y.Array.
+- **Write-once metadata** (createdAt, createdBy) → plain value.
+- **Small, rarely-edited data** (enum options) → JSON string is acceptable.
+
+### 6. If You Can Derive It, Don't Store It (HIGH)
+
+Remove redundant fields: ID is already the map key; parent context (e.g. `collectionId`) is the containing map; computable values (e.g. `size`) come from `.size`.
+
+### 7. Batch Writes in a Transaction (HIGH)
+
+Wrap related `set` calls in `yDoc.transact(() => { ... })` so they apply as one update — one sync message, one observer event, consistent state.
+
+### 8. Flatten Small Fixed-Shape Objects (MEDIUM)
+
+For 2–3 field objects that always change together (e.g. `{ type, id }`), encode as a single string (`"user:123"`). A nested Y.Map wastes CRDT metadata on concurrency you'll never use.
+
+### 9. `Y.Text` for Collaboratively Edited Strings (HIGH)
+
+`Y.Text` uses a character-level CRDT that merges concurrent keystrokes. Use it for strings users type into. For strings swapped wholesale (dropdown selection), use a plain value.
+
+### 10. Avoid Storing Defaults (MEDIUM)
+
+On **initial write**, skip fields whose value matches a well-known default. Don't delete a field when a user sets it back to default — the delete is itself a CRDT op with overhead and causes churn. This is an initial-payload optimization only.
+
+### 11. Split Y.Docs When Permissions Differ (CRITICAL)
+
+Permissions can't be enforced *inside* a Y.Doc — any client that can sync it reads and writes everything. Split into an **index Y.Doc** (IDs + metadata) and **per-entity Y.Docs** (content) when:
+
+- Different entities need different read/write permissions
+- You need to revoke access to specific entities
+- Entity data is large and lazy-loading matters
+
+Don't split when permissions are uniform and the overhead isn't justified.
+
+### 12. Use Awareness for Ephemeral State, Not the Y.Doc (CRITICAL)
+
+Cursor positions, text selections, typing indicators, "who's online," hover state — put these in the **Awareness** protocol, not the Y.Doc. Awareness is:
+
+- **Ephemeral**: state lives only while the client is connected; auto-cleans on disconnect.
+- **Per-session**: keyed by `clientID` by default, so no concurrent-write problem.
+- **Not persisted**: doesn't grow the document or its history.
+
+Putting ephemeral state in the Y.Doc pollutes history, accumulates tombstones forever (see #16), and syncs noise to every peer on every move.
+
+### 13. Single-Writer Keys for Counters and Shared Tallies (CRITICAL)
+
+Y.Map is LWW-by-`clientID`, so read-modify-write loses writes under concurrency — `ymap.set("count", ymap.get("count") + 1)` silently drops one increment when two clients run it at once.
+
+Pattern: give each client its own key and aggregate on read.
+
+```typescript
+// Bad: concurrent increments lose writes
+ymap.set("count", (ymap.get("count") ?? 0) + 1);
+
+// Good: each client has its own key
+const counts = ymap.get("counts") as Y.Map<number>;
+counts.set(String(ydoc.clientID), (counts.get(String(ydoc.clientID)) ?? 0) + 1);
+// Read: [...counts.values()].reduce((a, b) => a + b, 0)
+```
+
+Apply to view counts, reaction tallies, "who's in this room" sets, and any other accumulating shared value.
+
+### 14. Don't Mutate JSON Retrieved From a Shared Type (HIGH)
+
+Yjs does **not** clone values when you `set` or `get` them. Mutating a returned object changes local state without firing any update, causing silent divergence from remote peers:
+
+```typescript
+// Bad: mutates in place — no update fires, remote peers never see the change
+const meta = ymap.get("meta");
+meta.foo = "bar"; // silently diverges
+
+// Good: read, derive a new value, set it back
+const meta = { ...ymap.get("meta"), foo: "bar" };
+ymap.set("meta", meta);
+```
+
+Prefer primitives or nested `Y.Map` for mutable structures. Reserve JSON blobs for data that's always rewritten wholesale (see #5).
+
+### 15. Shared Types Can't Be Moved Once Inserted (HIGH)
+
+A `Y.Map`, `Y.Array`, or `Y.Text` is bound to its parent forever. "Moving" a shared type between containers is actually copy-and-delete, which:
+
+- Creates a **new** shared-type instance at the destination.
+- Loses any concurrent edits happening on the original.
+- Breaks references other code holds to the original.
+
+Design nesting so you don't need to relocate shared types. If data logically moves between containers, store a reference (ID) rather than the shared type itself, and keep the actual shared type in a flat top-level map.
+
+### 16. Tombstones on Y.Map Keys Are Forever (MEDIUM)
+
+Every `ymap.set(key, ...)` creates a new internal item and tombstones the previous one. Tombstones are not garbage-collected across sets — they accumulate on high-churn keys.
+
+Consequences:
+
+- A cursor-position field updated on every pointer move will bloat the doc indefinitely.
+- Long-lived documents with heavy key churn can hit real memory pressure on load (see [yjs#741](https://github.com/yjs/yjs/issues/741)).
+
+Mitigations: keep ephemeral high-frequency state in Awareness (#12); for genuinely needed high-churn keys, consider a separate Y.Doc that can be rotated/rebuilt periodically.
+
+### 17. Prefer Subdocuments Over Managing Multiple Root Y.Docs (MEDIUM)
+
+When you need the permission-split pattern from #11, **subdocuments** are a first-class Yjs feature: embed a `Y.Doc` inside a shared type in a parent doc. Subdocuments have GUID-based identity, are lazily loaded by default (`autoLoad: false`), and can be managed by providers as part of the parent doc's sync lifecycle.
+
+```typescript
+const rootDoc = new Y.Doc();
+const pageDoc = new Y.Doc(); // subdocument
+rootDoc.getMap("pages").set("page-1", pageDoc);
+pageDoc.load(); // lazy-load on demand
+```
+
+Subdocuments are cleaner than juggling two independent top-level docs when the lifecycle is "parent-known."
+
+### 18. Top-Level Shared Types Can't Be Deleted (MEDIUM)
+
+`ydoc.getMap("foo")` creates a root-level type that lives forever — you can `clear()` its contents, but the type itself can't be removed. This nudges a common pattern:
+
+```typescript
+// Fewer root types → more control over deletion
+const data = ydoc.getMap("data");
+data.set("page-1", yPageMap);
+data.delete("page-1"); // sub-entries CAN be deleted
+```
+
+Keep a single root `getMap("data")` (or a handful of well-known roots like `data`, `schema`, `meta`) and nest everything else under it, so you can prune arbitrary subtrees later.
+
+## Anti-Patterns to Avoid
+
+1. **JSON blobs in a single value** — destroys granular merging.
+2. **`Y.Array<Object>`** for concurrently edited collections — use `Y.Map<id, ...>`.
+3. **Assuming "last write wins" means "latest timestamp"** — Yjs uses higher `clientID` wins. Use single-writer keys (e.g. `ymap.set(ydoc.clientID, value)`) or an external timestamp-based LWW layer for counters/presence.
+4. **`Y.Array` for user-reorderable lists** — moves are delete+insert and lose concurrent edits. Use `Y.Map<id, ...>` with fractional-index ordering.
+5. **Integer `index` fields for ordering** — two users reordering simultaneously produce duplicate indices. Use fractional indexing.
+6. **Redundant keys** (storing `id` as a field when it's already the map key).
+7. **Per-field writes outside a transaction** — wastes sync messages, leaks half-updated state to observers.
+8. **Nested Y.Maps** for atomically-updated 2-field objects — flatten instead.
+9. **Deleting a field to revert to default** — just write the default value (both delete and set leave tombstones, and delete is extra churn).
+10. **One Y.Doc across permission boundaries** — you can't enforce authz inside a doc; any synced client reads and writes everything.
+11. **Ephemeral state in the Y.Doc** — cursors, selections, presence belong in Awareness.
+12. **Read-modify-write on shared counters** — Y.Map's LWW-by-`clientID` drops concurrent increments. Use single-writer keys.
+13. **Mutating objects returned from `ymap.get()`** — Yjs doesn't clone; mutations silently diverge.
+14. **Trying to move a shared type between parents** — copy-and-delete loses concurrent edits and breaks references.
+15. **High-churn fields on Y.Map** — tombstones accumulate forever. Use Awareness or a rotatable Y.Doc.
+16. **Sprawling root-level types** — you can't delete them. Nest under a single root map.
+
+## Guidelines
+
+### Schema Design (`rules/schema-design.md`)
+- Y.Doc as hard format — design for growth
+- Maps keyed by ID for collections
+- Flat typed values over nested structures
+- Derive, don't duplicate
+- Split docs across permission boundaries; prefer subdocuments
+- Shared types can't be moved once inserted
+- Top-level shared types can't be deleted
+- Don't mutate JSON retrieved from a shared type
+
+### Concurrency Patterns (`rules/concurrency.md`)
+- Group by how fields change together
+- `Array<Object>` → `Map<id, Object>` with fractional indexing
+- Known string sets → numbers
+- `Y.Text` only for collaboratively typed strings
+- Awareness for ephemeral state (cursors, selections, presence)
+- Single-writer keys for counters and tallies
+
+### Write Optimization (`rules/optimization.md`)
+- Batch related writes in transactions
+- Flatten small fixed-shape objects into encoded strings
+- Skip default values on initial write
+- Don't delete a field just because it returned to default
+- Tombstones on Y.Map keys are forever — avoid high-churn fields in the doc
+
+References:
+- [Y.js documentation](https://docs.yjs.dev)

--- a/.agents/skills/yjs-document-storage/rules/concurrency.md
+++ b/.agents/skills/yjs-document-storage/rules/concurrency.md
@@ -1,0 +1,193 @@
+---
+title: Concurrency-Safe Y.js Patterns
+impact: CRITICAL
+tags: yjs, concurrency, ymap, yarray, ytext, fractional-indexing
+---
+
+## Concurrency-Safe Y.js Patterns
+
+**Impact: CRITICAL**
+
+When deciding how granular your Y.js structure should be, the key question is:
+
+> **"Will two users ever edit these values at the same time — and what do we want to happen?"**
+
+Yjs's merge behavior is **different for each shared type**. Knowing which type gives you which semantics is the core of getting concurrent editing right.
+
+### Y.Map Values: Last-Writer-Wins by `clientID` (not timestamp)
+
+Per the Yjs internals: *"Maps are lists of entries. The last inserted entry for each key is used, and all other duplicates for each key are flagged as deleted."*
+
+When two clients concurrently write different values to the **same key**, Yjs deterministically picks one to win — the client with the **higher `clientID`**, not the later wall-clock timestamp. This matters:
+
+- Concurrent writes **do not merge character-by-character**. `ymap.set("role", "editor")` vs. a concurrent `ymap.set("role", "reader")` resolves to one of those two values atomically, never something like `"readitor"`.
+- LWW-by-clientID is deterministic but **not intuitive**: a later edit on the lower-`clientID` peer can lose to an earlier edit on the higher-`clientID` peer.
+- **Counters and other read-modify-write patterns silently lose writes.** If both clients read `5`, both write `6`, one write is discarded. Use per-client keys (`ymap.set(ydoc.clientID, value)`) and sum on read, or use a dedicated LWW-with-timestamp library.
+
+> `Y.Text` is the exception — it uses a character-level CRDT that *does* merge concurrent keystrokes. See below.
+
+### Group Values by How They Change, Not by What They Describe
+
+- **Always change together** (e.g. `updatedBy` + `updatedAt`): store as a single atomic value. Splitting them into separate Y.Map entries adds CRDT overhead without concurrent-edit benefit, and observers can fire with a `updatedBy` that doesn't match the current `updatedAt`.
+- **Can change independently** (e.g. a document's `title` and its `status`): store as separate entries so concurrent edits to one don't overwrite the other.
+- **User-editable text** (e.g. a title a user types into): use `Y.Text` for character-level merging.
+- **Value selected from a set** (e.g. a dropdown): use a plain value that overwrites atomically (LWW-by-clientID).
+
+Match Y.js granularity to how your UI actually works.
+
+```typescript
+// These always change together — combine into one value
+yDoc.set("lastUpdate", `${userId}|${Date.now()}`);
+// Read: const [updatedBy, updatedAt] = value.split("|");
+
+// These change independently — keep separate
+yDoc.set("name", new Y.Text()); // user types into this
+yDoc.set("role", 0); // user selects from dropdown
+yDoc.set("archived", true); // user toggles a checkbox
+```
+
+### `Array<Object>` → `Map<id, Object>`
+
+`Y.Array` is correct for append-only sequences (logs, chat messages). For user-editable collections, it has four real problems:
+
+1. **"Move" is actually delete + insert.** Once a shared type is inserted into a document it cannot be relocated. A UI-level reorder must delete the original item and insert a new one. Concurrent edits to the "moved" original are lost because the original item is gone.
+2. **Reorder collisions produce duplicates.** Two clients dragging the same item to different positions delete once and insert twice — the item now appears in two places and Yjs can't tell it's the same thing.
+3. **Index-based references are unstable.** "The item at index 3" changes meaning whenever anyone inserts at a lower index.
+4. **Range-insert interleaving.** Two clients inserting ranges at the same position can produce interleaved output.
+
+Use `Y.Map<id, Y.Map<field, value>>` so each entity has a stable ID, and concurrent edits to *different* entities never collide.
+
+```typescript
+// Bad: Y.Array for a user-editable collection — moves lose data, reorders duplicate
+const yDocuments = new Y.Array<DocumentJSON>();
+
+// Good: Y.Map keyed by id — each document is independently editable, reorders are property updates
+const yDocuments = new Y.Map<string, Y.Map<string, any>>();
+// yDocuments.set(doc.id, yDocMap)
+```
+
+### Ordering: Use Fractional Indexing, Not Integer Positions
+
+If the collection has user-controlled order, don't store `index: 0, 1, 2, ...` — two users reordering concurrently will produce colliding indices, and you can never cleanly insert between two items that share an index.
+
+**Fractional indexing** assigns each item a sortable string (or rational-number) index such that there's always a valid value between any two neighbors:
+
+```typescript
+// Good: fractional index — always room to insert between any two items
+yItem.set("index", "a0");
+yItem.set("index", "a1");
+// Insert between "a0" and "a1" → "a0m", no collision
+
+// Read: [...yMap.values()].sort((a, b) => a.get("index").localeCompare(b.get("index")))
+```
+
+Use a library like [`fractional-indexing`](https://github.com/rocicorp/fractional-indexing) for this. Even then, two users inserting at the exact same boundary can tie — resolve by appending the `clientID` as a tiebreaker.
+
+### Known Set of Strings → Number
+
+When a field is an enum — a known, finite set like `"editor" | "reader"` or `"table" | "kanban"` — prefer a numeric code to the string label.
+
+Concurrent writes don't corrupt either form (both are LWW-by-clientID on Y.Map, not character-merged). The reasons are:
+
+- **Smaller encoding** in the Yjs binary format.
+- **Cheap to rename labels** without touching documents.
+- **Intent:** numeric code signals "this is a selection, not typed text" — matches the `Y.Text` vs. plain-value split in the next section.
+
+```typescript
+// OK: string enum — correct but larger and label-coupled
+yMap.set("role", "editor");
+
+// Better: numeric enum — compact, label-independent
+const ROLES = ["editor", "reader"] as const;
+yMap.set("role", 0);
+// Read: ROLES[yMap.get("role")] → "editor"
+```
+
+### `Y.Text` Only for Collaboratively Edited Strings
+
+`Y.Text` uses a character-level CRDT that merges concurrent keystrokes into a single readable result. Use it where two users might realistically type at the same time — a document title, a paragraph of prose.
+
+For strings that are swapped wholesale — dropdown selections, enum labels — use a plain value. `Y.Text` for these is overkill (unused CRDT metadata per character) and wrong (`Y.Text` can't cleanly "replace" — it appends/deletes, producing odd histories and diffs).
+
+```typescript
+// Document title — users may type simultaneously
+const yTitle = new Y.Text();
+yTitle.insert(0, "My Document");
+yDoc.set("title", yTitle);
+
+// View type — user picks from a dropdown, no concurrent typing
+yView.set("type", 0); // 0 = "table"
+```
+
+### Awareness, Not the Y.Doc, for Ephemeral State
+
+Cursor positions, text selections, typing indicators, "who's viewing," hover state — this kind of per-session signal should live in the **Awareness** protocol, not the Y.Doc.
+
+Awareness is a separate channel that Yjs providers expose alongside document sync:
+
+- **Ephemeral:** state exists only while a client is connected, and auto-cleans when the client disconnects.
+- **Per-client state:** Awareness maps `clientID → state`, so each client writes its own slot — no concurrent-write conflicts on the same key.
+- **Not persisted:** Awareness doesn't go into the Y.Doc's update stream or history.
+
+```typescript
+// Good: cursor in Awareness
+provider.awareness.setLocalStateField("cursor", { x, y, selection });
+
+// Read other users' cursors
+for (const [clientID, state] of provider.awareness.getStates()) {
+  renderRemoteCursor(clientID, state.cursor);
+}
+```
+
+Putting ephemeral state in the Y.Doc has three real costs: history pollution (every cursor move is a permanent edit), **tombstone accumulation** (see `optimization.md` on Y.Map tombstones), and sync amplification (every move syncs to every peer forever, not just currently-connected ones).
+
+Rule of thumb: if the state should disappear when the tab closes, it belongs in Awareness.
+
+### Single-Writer Keys for Counters and Shared Tallies
+
+Because Y.Map is last-writer-wins by `clientID`, **read-modify-write loses writes** under concurrency:
+
+```typescript
+// Bad: concurrent increments silently drop one
+ymap.set("count", (ymap.get("count") ?? 0) + 1);
+// Both clients read 5, both write 6, one increment is lost
+```
+
+The fix is to give each client its own sub-key and aggregate on read:
+
+```typescript
+// Good: each client writes only to its own slot
+const counts = ymap.get("counts") as Y.Map<number>;
+const myKey = String(ydoc.clientID);
+counts.set(myKey, (counts.get(myKey) ?? 0) + 1);
+
+// Read: sum across all clients
+const total = [...counts.values()].reduce((a, b) => a + b, 0);
+```
+
+Apply this to:
+
+- **View/reaction counters** — each client tallies its own contribution.
+- **"Who's in this room" sets** — each client writes its presence to `clientID`, others read the map.
+- **Per-client state that shouldn't overwrite other clients** — settings, drafts, saved positions.
+
+For counters that need to survive disconnects but still need proper last-write-wins semantics (e.g. across multiple sessions of the same user), use an external library like [`y-lwwmap`](https://github.com/rozek/y-lwwmap) that attaches explicit timestamps.
+
+### Match Granularity to the Editing Surface
+
+Not every field needs a CRDT entry of its own:
+
+- **UI-editable fields** (filters, column widths, sort orders) → decomposed `Y.Map` / `Y.Array` for concurrent safety.
+- **Write-once metadata** (`createdAt`, `createdBy`) → a plain value is fine.
+- **Small, rarely-edited data** (enum option lists) → a JSON string is acceptable.
+
+```typescript
+// Filters: users edit via UI → use Y.Map for concurrent safety
+const yFilters = new Y.Map<string, Y.Map<string, any>>();
+
+// Enum options: rarely edited, small → JSON string is fine
+ySchema.set("enum", JSON.stringify(enumOptions));
+
+// createdAt: set once, never edited → plain value
+yDoc.set("createdAt", Date.now());
+```

--- a/.agents/skills/yjs-document-storage/rules/optimization.md
+++ b/.agents/skills/yjs-document-storage/rules/optimization.md
@@ -1,0 +1,97 @@
+---
+title: Write Optimization for Y.Docs
+impact: HIGH
+tags: yjs, optimization, transactions, defaults, flattening
+---
+
+## Write Optimization for Y.Docs
+
+**Impact: HIGH**
+
+Every Y.js entry carries CRDT metadata, every `set` fires a sync message, every change fires an observer event. These optimizations cut payload size, reduce churn, and keep observers from seeing half-updated state — **without** sacrificing the concurrent-edit safety rules in `concurrency.md`.
+
+### Batch Related Writes in a Single Transaction
+
+Wrap related `Y.Map.set()` calls in `yDoc.transact(() => { ... })` so they apply as one atomic update. Result: one sync message, one observer event, and a consistent state for any observer.
+
+```typescript
+// Bad: each set fires a separate sync + observer event
+yDoc.set("updatedBy", "user:123");
+yDoc.set("updatedAt", Date.now());
+yProps.set("title", "New Title");
+
+// Good: one atomic update, one sync message, one observer event
+doc.transact(() => {
+  yDoc.set("updatedBy", "user:123");
+  yDoc.set("updatedAt", Date.now());
+  yProps.set("title", "New Title");
+});
+```
+
+Apply this any time two or more `set` calls belong to the same logical change. Without it, observers can see a `updatedBy` that doesn't match the `updatedAt`, and you pay 3× the sync payload.
+
+### Flatten Small Fixed-Shape Objects
+
+For small objects with 2–3 fields that **always change together** (like `{ type: string, id: string }`), flatten into a single encoded string rather than a nested Y.Map.
+
+Each Y.Map key is an independent CRDT entry. If the fields never change independently, the extra entries just add overhead — you're paying for concurrency support you'll never use.
+
+```typescript
+// Bad: nested Y.Map for a 2-field object that changes atomically
+const yRef = new Y.Map();
+yRef.set("type", "user");
+yRef.set("id", "123");
+
+// Good: single encoded string
+yMap.set("createdBy", "user:123");
+// Read: const [type, id] = value.split(":");
+```
+
+This is the same "group by how it changes" heuristic from `concurrency.md`, applied to objects rather than scalar fields. Only flatten when you're sure the fields are always written together.
+
+### Avoid Storing Defaults on Initial Write
+
+When initially populating a Y.Doc, skip fields whose value matches the well-known default (e.g. `visible: true` for columns, `desc: false` for sorts). Fewer entries on first write = smaller initial sync payload and smaller document.
+
+This is an optimization for the **initial write only**. Once a field exists in the doc, update it normally.
+
+```typescript
+// Initial write — skip defaults
+if (!column.visible) yColumn.set("visible", false); // only write if non-default
+// Read: yColumn.get("visible") ?? true
+```
+
+### Don't Delete a Field to Revert to Default
+
+Once a field exists, don't delete it just because the user set it back to the default value. The delete is itself a CRDT operation with overhead and causes unnecessary churn (observers fire, sync messages go out).
+
+```typescript
+// Later update — write normally even if it's the default value
+yColumn.set("visible", true); // user toggled it back — just write it
+```
+
+The "skip defaults" optimization only pays off at initial population. After that, normal writes are cheaper than delete-then-write.
+
+### Tombstones on Y.Map Keys Are Forever
+
+Every `ymap.set(key, newValue)` internally creates a new item and **tombstones the previous item** for that key. Tombstones on Y.Map are **not garbage-collected across successive sets** — they accumulate for the life of the document.
+
+Consequences:
+
+- A key updated once a minute for a year carries ~525k tombstones, even though only the latest value is observable.
+- Long-lived documents with heavy per-key churn can hit significant memory pressure on load. See [yjs#741](https://github.com/yjs/yjs/issues/741) for a real case where a 200 MB doc spikes to ~15 GB during `encodeStateAsUpdate` due to tombstones.
+
+**How to avoid high-churn keys in the Y.Doc:**
+
+- **Ephemeral high-frequency state → Awareness.** Cursor positions, typing indicators, "last seen at" pings. See `concurrency.md` on Awareness.
+- **Monotonically-updated signals** (e.g. "last activity timestamp") → emit at coarser granularity (every minute, not every keystroke), or store in a separate rotatable Y.Doc you can rebuild on schedule.
+- **Write-heavy counters** → single-writer keys in a Y.Map counts sub-map (see `concurrency.md`), rather than repeatedly overwriting one key.
+
+Tombstones on *different* keys don't share this problem — they're per-key. A Y.Map with 10k different keys each set once is cheap. A Y.Map with one key set 10k times is not.
+
+### Plan for Document Deletion Up Front
+
+You can't delete a top-level shared type (see `schema-design.md`). Combined with the tombstone-forever behavior above, this means a Y.Doc that was originally designed with lots of root-level types or one high-churn root key has no clean path to "shrink" later — you'd have to create a new document and migrate.
+
+Before deciding where a high-churn field should live, ask: "will this ever need to be reset without migrating every client?" If yes, nest it somewhere you can `delete()`, or put it in a subdocument you can replace.
+

--- a/.agents/skills/yjs-document-storage/rules/schema-design.md
+++ b/.agents/skills/yjs-document-storage/rules/schema-design.md
@@ -1,0 +1,170 @@
+---
+title: Schema Design for Y.Docs
+impact: CRITICAL
+tags: yjs, schema, structure, permissions
+---
+
+## Schema Design for Y.Docs
+
+**Impact: CRITICAL**
+
+A Y.js document is the **source of truth** for your data. Once clients are syncing against a particular structure, changing that structure is a migration — not a refactor. Treat your Y.Doc layout the way you'd treat a database schema or wire protocol: it needs to be **correct now** and **extendable later**.
+
+Design for your domain's growth axes. Think about what entities will be added, what fields will appear on existing entities, and what relationships might form. Choose structures that allow these additions without breaking existing documents.
+
+### Maps Keyed by ID for Collections
+
+Adding a new entity is just a new key — no migration needed.
+
+```typescript
+// Bad: entire collection as one JSON blob — adding a field means rewriting everything
+yMap.set("schema", JSON.stringify(fullSchemaObject));
+
+// Good: each property is its own entry — adding a new property is just a new key
+const ySchema = doc.getMap("schema");
+ySchema.set(propertyId, yPropertyMap); // each property independently editable
+```
+
+### Reserve Top-Level Keys for Major Concepts
+
+Use top-level keys like `"documents"`, `"schema"`, `"views"` for the major concepts of your domain. Avoid polluting the root namespace with fields that belong inside a nested entity.
+
+### Prefer Flat Typed Values
+
+Flat maps are easier to extend with new fields than nested objects that must be versioned as a whole.
+
+### Never Serialize Entire Objects as JSON Strings
+
+Serializing whole objects as one Y.js value defeats the purpose of using a CRDT:
+
+- You lose granular merging.
+- Any concurrent edit to any field inside the blob conflicts with every other edit.
+- Adding a field requires rewriting the whole blob.
+
+Small, rarely-edited data (e.g. enum option lists) is the only acceptable exception — see `optimization.md` on defaults and `concurrency.md` on editing surface.
+
+### If You Can Derive It, Don't Store It
+
+Remove fields that can be inferred from structure:
+
+- **ID as map key** — don't also store `id` inside the map value.
+- **Parent context** — a document inside a collection's `documents` map doesn't need `collectionId`.
+- **Computable values** — don't store `size` when it equals `documents.size`.
+
+```typescript
+// Bad: redundant data
+yDocuments.set(doc.id, { id: doc.id, collectionId: collection.id, ... });
+
+// Good: derive id from key, collectionId from parent
+yDocuments.set(doc.id, { /* id and collectionId omitted */ ... });
+// Read: hydrateDocument(docId, collectionId, yMap)
+```
+
+### Split Across Y.Docs When Permissions Differ
+
+**Permissions cannot be enforced within a single Y.Doc.** Any client that can sync the doc can read and write everything in it. If different parts of your data need different access levels, split them into separate Y.Docs.
+
+A common pattern: one **index Y.Doc** holding only ID references and lightweight metadata, and one **Y.Doc per entity** for the actual content.
+
+```typescript
+// Index doc — all workspace members sync this
+const indexDoc = new Y.Doc();
+const yPages = indexDoc.getMap("pages"); // { pageId → { title, icon, ... } }
+
+// Per-page doc — only users with page access sync this
+const pageDoc = new Y.Doc();
+const yContent = pageDoc.getMap("content"); // full page content
+```
+
+**When to split:**
+
+- Different entities have different read/write permissions (shared index vs. private pages).
+- You need to revoke access to specific entities without affecting others.
+- Entity data is large and not all clients need all of it (lazy-loading).
+
+**When NOT to split:**
+
+- All users have the same permissions across all data — one Y.Doc is simpler.
+- The overhead of managing multiple docs and their sync lifecycle isn't justified.
+
+### Prefer Subdocuments Over Multiple Root Y.Docs
+
+When the split lifecycle is **parent-known** (i.e. the parent doc can reference the children), use Yjs **subdocuments** rather than juggling independent top-level `Y.Doc` instances. A subdocument is a `Y.Doc` embedded inside a shared type in a parent doc:
+
+```typescript
+const rootDoc = new Y.Doc();
+const pageDoc = new Y.Doc();            // subdocument
+rootDoc.getMap("pages").set("page-1", pageDoc);
+
+// Subdocuments are NOT auto-loaded by default — call .load() when needed
+pageDoc.load();
+```
+
+Benefits:
+
+- **GUID-based identity.** Every `Y.Doc` gets a `doc.guid`; providers sync by GUID, so a subdocument can appear in multiple places or be rehydrated against the same remote state.
+- **Lazy loading.** Subdocuments start empty and only sync content after `.load()` (or set `new Y.Doc({ autoLoad: true })` to load eagerly).
+- **Unified provider lifecycle.** A provider that understands subdocuments can sync the collection through one connection rather than N separate providers.
+
+Subdocuments don't solve permissions by themselves — you still need a provider/backend that enforces access per-GUID — but they give you a clean structural home for the split.
+
+### Shared Types Can't Be Moved Once Inserted
+
+A `Y.Map`, `Y.Array`, or `Y.Text` is bound to its parent forever. You cannot relocate a shared type from one container to another.
+
+```typescript
+// This throws — can't move a shared type
+yarray.insert(0, [ymap.get("my other array") as Y.Array]);
+```
+
+"Moving" is physically a copy-and-delete, with two real consequences:
+
+- The destination gets a **new** shared-type instance; any concurrent edits on the original (now-deleted) one are lost.
+- External references to the original shared type become detached.
+
+**Design implication:** if entities logically move between containers, don't nest the shared type inside the container — instead keep shared types in a flat top-level map and reference them by ID from container-level indexes:
+
+```typescript
+// Good: flat storage, containers hold IDs not shared types
+const yPages = ydoc.getMap("pages");          // pageId → Y.Map(page content)
+const yFolders = ydoc.getMap("folders");      // folderId → Y.Map({ pageIds: Y.Array<string> })
+
+// "Moving" a page between folders is just updating ID lists — the page Y.Map never moves
+```
+
+### Top-Level Shared Types Can't Be Deleted
+
+`ydoc.getMap("foo")` creates a root-level type. You can `.clear()` its contents, but the type itself lives for the life of the Y.Doc. A doc with many root-level keys accumulates them permanently.
+
+**Pattern:** keep a single (or small, fixed set of) root-level map(s) and nest everything else beneath them. Sub-entries in a nested map **can** be deleted.
+
+```typescript
+// Bad: every entity is a root-level type — none can ever be deleted
+ydoc.getMap("page-1");
+ydoc.getMap("page-2");
+ydoc.getMap("page-3");
+
+// Good: one root, deletable children
+const data = ydoc.getMap("data");
+data.set("page-1", yPage1);
+data.delete("page-1"); // ✓ works
+```
+
+### Don't Mutate JSON Retrieved From a Shared Type
+
+Yjs does **not** clone values passed to `set` or returned from `get`. The same JS object lives in both your local variable and the internal Y.Map state. Mutating it:
+
+- Does **not** fire an observer or produce a sync update.
+- Produces silent divergence — your local copy changes, remote peers never see it.
+
+```typescript
+// Bad: mutates in place — Yjs doesn't notice, remote peers never see the change
+const meta = ymap.get("meta");
+meta.foo = "bar";
+
+// Good: derive a new value and set it back
+ymap.set("meta", { ...ymap.get("meta"), foo: "bar" });
+```
+
+For values that need per-field granular updates, don't store them as JSON at all — use a nested `Y.Map`.
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ This is a **Y.js Server & Provider** that aims to be storage, transport, and run
 
 <!-- /automd -->
 
+[![Open on npmx.dev](https://npmx.dev/api/registry/badge/version/teleportal)](https://npmx.dev/package/teleportal)
+[![Open on npmx.dev](https://npmx.dev/api/registry/badge/license/teleportal)](https://npmx.dev/package/teleportal)
+[![Open on npmx.dev](https://npmx.dev/api/registry/badge/size/teleportal)](https://npmx.dev/package/teleportal)
+[![Open on npmx.dev](https://npmx.dev/api/registry/badge/downloads-month/teleportal)](https://npmx.dev/package/teleportal)
+[![Open on npmx.dev](https://npmx.dev/api/registry/badge/dependencies/teleportal)](https://npmx.dev/package/teleportal)
+
 ## Features
 
 ### Core Features


### PR DESCRIPTION
## Summary
- Adds five npmx.dev badges (version, license, size, downloads-month, dependencies) to the README beneath the existing automd block.
- Introduces a new \`yjs-document-storage\` agent skill under \`.agents/skills/\` with a SKILL.md plus rule docs covering concurrency, optimization, and schema design.

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Confirm skill files are discoverable by the agent tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Y.js document storage skill documentation covering schema design rules, concurrency-safe patterns, write-optimization guidelines, failure-mode prevention strategies, and anti-patterns with TypeScript examples
  * Updated README with package registry badges displaying version, license, package size, monthly download counts, and dependency status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->