### PR TITLE
feat: cluster-aware presence protocol with crash-safe awareness clearing

### DIFF
--- a/src/devtools/utils/message-utils.ts
+++ b/src/devtools/utils/message-utils.ts
@@ -35,6 +35,9 @@ export function getMessageTypeLabel(message: MessageType): string {
   if (message.type === "ack") {
     return "ack";
   }
+  if (message.type === "presence") {
+    return message.payload.type;
+  }
   if (message.type === "rpc") {
     // Include request type (request/response/stream) for better clarity
     const requestType = message.requestType;
@@ -60,6 +63,7 @@ export function getMessageTypeColor(message: MessageType): string {
   }
 
   if (message.type === "ack") return "devtools-bg-gray-500";
+  if (message.type === "presence") return "devtools-bg-purple-500";
 
   const type = getMessageTypeLabel(message);
 
@@ -161,6 +165,9 @@ export async function formatMessagePayload(
   switch (message.type) {
     case "ack": {
       return `ACK(id: ${message.id}, acknowledged: ${message.payload.messageId})`;
+    }
+    case "presence": {
+      return JSON.stringify(message.payload, null, 2);
     }
     case "awareness": {
       switch (message.payload.type) {

--- a/src/lib/protocol/decode.ts
+++ b/src/lib/protocol/decode.ts
@@ -5,6 +5,7 @@ import {
   AwarenessMessage,
   type BinaryMessage,
   DocMessage,
+  PresenceMessage,
   RpcMessage,
   type RawReceivedMessage,
 } from "./message-types";
@@ -17,6 +18,8 @@ import type {
   DecodedAuthMessage,
   DecodedAwarenessRequest,
   DecodedAwarenessUpdateMessage,
+  PresenceMessageBinary,
+  PresenceStep,
   DecodedSyncDone,
   DecodedSyncStep1,
   DecodedSyncStep2,
@@ -85,6 +88,14 @@ export function decodeMessage(
       }
       case 0x02: {
         return new AckMessage(decodeAckMessageWithDecoder(decoder), undefined);
+      }
+      case 0x03: {
+        return new PresenceMessage(
+          documentName,
+          decodePresenceMessageWithDecoder(decoder),
+          undefined,
+          update as PresenceMessageBinary,
+        );
       }
       case 0x04: {
         return decodeRpcMessageWithDecoder(
@@ -232,6 +243,44 @@ function decodeAckMessageWithDecoder(
     type: "ack",
     messageId: toBase64(decoding.readVarUint8Array(decoder)),
   };
+}
+
+function decodePresenceMessageWithDecoder(
+  decoder: decoding.Decoder,
+): PresenceStep {
+  const subType = decoding.readUint8(decoder);
+  if (subType === 0) {
+    return {
+      type: "presence-announce",
+      awarenessId: decoding.readVarUint(decoder),
+    };
+  }
+  if (subType === 1 || subType === 2) {
+    const awarenessId = decoding.readVarUint(decoder);
+    const clientId = decoding.readVarString(decoder);
+    const userId = decoding.readVarString(decoder);
+    const data = decoding.readAny(decoder) as Record<string, unknown>;
+    return {
+      type: subType === 1 ? "presence-join" : "presence-leave",
+      awarenessId,
+      clientId,
+      userId,
+      data,
+    };
+  }
+  if (subType === 3) {
+    const count = decoding.readVarUint(decoder);
+    const clients = [];
+    for (let i = 0; i < count; i++) {
+      const awarenessId = decoding.readVarUint(decoder);
+      const clientId = decoding.readVarString(decoder);
+      const userId = decoding.readVarString(decoder);
+      const data = decoding.readAny(decoder) as Record<string, unknown>;
+      clients.push({ awarenessId, clientId, userId, data });
+    }
+    return { type: "presence-heartbeat", clients };
+  }
+  throw new Error("Invalid presence sub-type", { cause: { subType } });
 }
 
 function decodeRpcMessageWithDecoder(

--- a/src/lib/protocol/decode.ts
+++ b/src/lib/protocol/decode.ts
@@ -259,13 +259,18 @@ function decodePresenceMessageWithDecoder(
     const awarenessId = decoding.readVarUint(decoder);
     const clientId = decoding.readVarString(decoder);
     const userId = decoding.readVarString(decoder);
-    const data = decoding.readAny(decoder) as Record<string, unknown>;
+    const data: unknown = decoding.readAny(decoder);
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      throw new Error("Invalid presence data: expected an object", {
+        cause: { data },
+      });
+    }
     return {
       type: subType === 1 ? "presence-join" : "presence-leave",
       awarenessId,
       clientId,
       userId,
-      data,
+      data: data as Record<string, unknown>,
     };
   }
   if (subType === 3) {
@@ -275,8 +280,13 @@ function decodePresenceMessageWithDecoder(
       const awarenessId = decoding.readVarUint(decoder);
       const clientId = decoding.readVarString(decoder);
       const userId = decoding.readVarString(decoder);
-      const data = decoding.readAny(decoder) as Record<string, unknown>;
-      clients.push({ awarenessId, clientId, userId, data });
+      const data: unknown = decoding.readAny(decoder);
+      if (typeof data !== "object" || data === null || Array.isArray(data)) {
+        throw new Error("Invalid presence data: expected an object", {
+          cause: { data },
+        });
+      }
+      clients.push({ awarenessId, clientId, userId, data: data as Record<string, unknown> });
     }
     return { type: "presence-heartbeat", clients };
   }

--- a/src/lib/protocol/encode.ts
+++ b/src/lib/protocol/encode.ts
@@ -120,6 +120,55 @@ export function encodeMessage(
         );
         break;
       }
+      case "presence": {
+        // message type
+        encoding.writeUint8(encoder, 3);
+
+        switch (message.payload.type) {
+          case "presence-announce": {
+            // sub-type
+            encoding.writeUint8(encoder, 0);
+            encoding.writeVarUint(encoder, message.payload.awarenessId);
+            break;
+          }
+          case "presence-join":
+          case "presence-leave": {
+            // sub-type
+            encoding.writeUint8(
+              encoder,
+              message.payload.type === "presence-join" ? 1 : 2,
+            );
+            encoding.writeVarUint(encoder, message.payload.awarenessId);
+            encoding.writeVarString(encoder, message.payload.clientId);
+            encoding.writeVarString(encoder, message.payload.userId);
+            encoding.writeAny(
+              encoder,
+              message.payload.data as encoding.AnyEncodable,
+            );
+            break;
+          }
+          case "presence-heartbeat": {
+            // sub-type
+            encoding.writeUint8(encoder, 3);
+            encoding.writeVarUint(encoder, message.payload.clients.length);
+            for (const peer of message.payload.clients) {
+              encoding.writeVarUint(encoder, peer.awarenessId);
+              encoding.writeVarString(encoder, peer.clientId);
+              encoding.writeVarString(encoder, peer.userId);
+              encoding.writeAny(encoder, peer.data as encoding.AnyEncodable);
+            }
+            break;
+          }
+          default: {
+            // @ts-expect-error - this should be unreachable due to type checking
+            message.payload.type;
+            throw new Error("Invalid presence payload.type", {
+              cause: { message },
+            });
+          }
+        }
+        break;
+      }
       case "rpc": {
         encoding.writeUint8(encoder, 4);
 

--- a/src/lib/protocol/message-types.ts
+++ b/src/lib/protocol/message-types.ts
@@ -8,6 +8,11 @@ import type {
   DecodedAuthMessage,
   DecodedAwarenessRequest,
   DecodedAwarenessUpdateMessage,
+  DecodedPresenceAnnounce,
+  DecodedPresenceHeartbeat,
+  DecodedPresenceJoin,
+  DecodedPresenceLeave,
+  PresenceMessageBinary,
   DecodedSyncDone,
   DecodedSyncStep1,
   DecodedSyncStep2,
@@ -29,6 +34,7 @@ export type BinaryMessage =
   | AwarenessUpdateMessage
   | AwarenessRequestMessage
   | EncodedAckMessage
+  | PresenceMessageBinary
   | EncodedRpcMessage;
 
 /**
@@ -39,6 +45,7 @@ export type Message<Context extends Record<string, unknown> = any> =
   | AwarenessMessage<Context>
   | DocMessage<Context>
   | AckMessage<Context>
+  | PresenceMessage<Context>
   | RpcMessage<Context>;
 
 /**
@@ -176,6 +183,35 @@ export class AckMessage<
     context?: Context,
   ) {
     super();
+    this.context = context ?? ({} as Context);
+  }
+}
+
+/**
+ * A presence message announcing that a client joined or left a session.
+ *
+ * Presence is always cleartext (it carries no document content), so it conveys a
+ * client's awareness clientID to the server even for end-to-end encrypted
+ * documents — where the awareness payload itself is opaque to the server.
+ */
+export class PresenceMessage<
+  Context extends Record<string, unknown>,
+> extends CustomMessage<Context, PresenceMessageBinary> {
+  public type = "presence" as const;
+  public context: Context;
+  public encrypted: boolean = false;
+
+  constructor(
+    public document: string,
+    public payload:
+      | DecodedPresenceAnnounce
+      | DecodedPresenceJoin
+      | DecodedPresenceLeave
+      | DecodedPresenceHeartbeat,
+    context?: Context,
+    encoded?: PresenceMessageBinary,
+  ) {
+    super(encoded);
     this.context = context ?? ({} as Context);
   }
 }

--- a/src/lib/protocol/presence.test.ts
+++ b/src/lib/protocol/presence.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "bun:test";
+import { decodeMessage } from "./decode";
+import { PresenceMessage } from "./message-types";
+
+describe("presence message encoding", () => {
+  it("round-trips a presence-announce", () => {
+    const message = new PresenceMessage("doc-1", {
+      type: "presence-announce",
+      awarenessId: 123_456_789,
+    });
+
+    const decoded = decodeMessage(message.encoded);
+
+    expect(decoded.type).toBe("presence");
+    expect(decoded.document).toBe("doc-1");
+    expect(decoded.encrypted).toBe(false);
+    expect(decoded.payload).toEqual({
+      type: "presence-announce",
+      awarenessId: 123_456_789,
+    });
+  });
+
+  it("round-trips a presence-join with a data bag", () => {
+    const message = new PresenceMessage("doc-2", {
+      type: "presence-join",
+      awarenessId: 42,
+      clientId: "conn-abc",
+      userId: "user-1",
+      data: { userName: "Alice", color: "#f00", nested: { ok: true } },
+    });
+
+    const decoded = decodeMessage(message.encoded);
+
+    expect(decoded.payload).toEqual({
+      type: "presence-join",
+      awarenessId: 42,
+      clientId: "conn-abc",
+      userId: "user-1",
+      data: { userName: "Alice", color: "#f00", nested: { ok: true } },
+    });
+  });
+
+  it("round-trips a presence-leave (with empty data)", () => {
+    const message = new PresenceMessage("doc-3", {
+      type: "presence-leave",
+      awarenessId: 7,
+      clientId: "conn-xyz",
+      userId: "user-2",
+      data: {},
+    });
+
+    const decoded = decodeMessage(message.encoded);
+
+    expect(decoded.payload).toEqual({
+      type: "presence-leave",
+      awarenessId: 7,
+      clientId: "conn-xyz",
+      userId: "user-2",
+      data: {},
+    });
+  });
+
+  it("round-trips a presence-heartbeat with multiple clients", () => {
+    const message = new PresenceMessage("doc-4", {
+      type: "presence-heartbeat",
+      clients: [
+        {
+          awarenessId: 1,
+          clientId: "conn-a",
+          userId: "user-a",
+          data: { userName: "Alice", nested: { ok: true } },
+        },
+        {
+          awarenessId: 2,
+          clientId: "conn-b",
+          userId: "user-b",
+          data: {},
+        },
+      ],
+    });
+
+    const decoded = decodeMessage(message.encoded);
+
+    expect(decoded.type).toBe("presence");
+    expect(decoded.payload).toEqual({
+      type: "presence-heartbeat",
+      clients: [
+        {
+          awarenessId: 1,
+          clientId: "conn-a",
+          userId: "user-a",
+          data: { userName: "Alice", nested: { ok: true } },
+        },
+        { awarenessId: 2, clientId: "conn-b", userId: "user-b", data: {} },
+      ],
+    });
+  });
+
+  it("round-trips a presence-heartbeat with an empty roster", () => {
+    const message = new PresenceMessage("doc-5", {
+      type: "presence-heartbeat",
+      clients: [],
+    });
+
+    const decoded = decodeMessage(message.encoded);
+
+    expect(decoded.payload).toEqual({ type: "presence-heartbeat", clients: [] });
+  });
+});

--- a/src/lib/protocol/types.ts
+++ b/src/lib/protocol/types.ts
@@ -122,6 +122,77 @@ export type DecodedAckMessage = {
 };
 
 /**
+ * A presence message, signalling a client joining or leaving a session.
+ * Always sent in cleartext (it carries no document content).
+ */
+export type PresenceMessageBinary = Tag<Uint8Array, "presence">;
+
+/**
+ * Sent by a client to announce the numeric awareness clientID it operates under.
+ * This is the only way the server learns a client's awareness clientID for
+ * end-to-end encrypted documents, where the awareness payload is opaque.
+ */
+export type DecodedPresenceAnnounce = {
+  type: "presence-announce";
+  /** The y-awareness clientID (equals the client's Y.Doc clientID). */
+  awarenessId: number;
+};
+
+/**
+ * Broadcast by the server when a client joins (after it announces) or leaves a
+ * session. `data` is an integrator-configurable bag (see `presenceConfig`).
+ */
+export type DecodedPresenceJoin = {
+  type: "presence-join";
+  /** The y-awareness clientID of the client (used by peers to track/clear it). */
+  awarenessId: number;
+  /** The server-assigned session/connection clientId. */
+  clientId: string;
+  /** The user the client is authenticated as. */
+  userId: string;
+  /** Integrator-supplied context safe to share with peers. */
+  data: Record<string, unknown>;
+};
+
+export type DecodedPresenceLeave = Omit<DecodedPresenceJoin, "type"> & {
+  type: "presence-leave";
+};
+
+/** A single peer entry carried in a presence-heartbeat roster snapshot. */
+export type PresenceHeartbeatClient = {
+  /** The y-awareness clientID of the client. */
+  awarenessId: number;
+  /** The server-assigned session/connection clientId. */
+  clientId: string;
+  /** The user the client is authenticated as. */
+  userId: string;
+  /** Integrator-supplied context safe to share with peers. */
+  data: Record<string, unknown>;
+};
+
+/**
+ * Published node-to-node (over pub/sub) at a fixed interval. Carries a snapshot
+ * of the publishing node's own local clients so other nodes can keep a fresh,
+ * crash-safe roster: receivers refresh the node's liveness and reconcile its
+ * client set, and a node whose heartbeats stop is expired by TTL. The source
+ * node id travels in the pub/sub envelope, not in the payload.
+ */
+export type DecodedPresenceHeartbeat = {
+  type: "presence-heartbeat";
+  /** The publishing node's current local clients. */
+  clients: PresenceHeartbeatClient[];
+};
+
+/**
+ * Any presence payload.
+ */
+export type PresenceStep =
+  | DecodedPresenceAnnounce
+  | DecodedPresenceJoin
+  | DecodedPresenceLeave
+  | DecodedPresenceHeartbeat;
+
+/**
  * Any Y.js update which concerns a document.
  */
 export type DocStep =

--- a/src/providers/connection.ts
+++ b/src/providers/connection.ts
@@ -606,8 +606,13 @@ export abstract class Connection<
     }
 
     if (this.state.type === "connected") {
-      // Track non-ack, non-awareness messages as in-flight
-      if (message.type !== "ack" && message.type !== "awareness") {
+      // Track in-flight messages that expect an ack. Ack, awareness and presence
+      // messages are fire-and-forget and are never acked.
+      if (
+        message.type !== "ack" &&
+        message.type !== "awareness" &&
+        message.type !== "presence"
+      ) {
         const wasEmpty = this.#inFlightMessages.size === 0;
         this.#inFlightMessages.set(message.id, message);
         // Emit event when messages become in-flight
@@ -618,7 +623,11 @@ export abstract class Connection<
 
       this.sendMessage(message).catch(async (err) => {
         // Remove from in-flight if send fails
-        if (message.type !== "ack" && message.type !== "awareness") {
+        if (
+          message.type !== "ack" &&
+          message.type !== "awareness" &&
+          message.type !== "presence"
+        ) {
           this.#inFlightMessages.delete(message.id);
           // Emit event with current in-flight status
           this.call("messages-in-flight", this.#inFlightMessages.size > 0);

--- a/src/providers/provider.test.ts
+++ b/src/providers/provider.test.ts
@@ -2,12 +2,18 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
   DocMessage,
   Message,
+  PresenceMessage,
   RpcMessage,
   type ClientContext,
   type MilestoneSnapshot,
   type StateVector,
   type Transport,
 } from "teleportal";
+import {
+  Awareness,
+  applyAwarenessUpdate,
+  encodeAwarenessUpdate,
+} from "y-protocols/awareness";
 import * as Y from "yjs";
 import {
   type MilestoneCreateResponse,
@@ -1221,5 +1227,126 @@ describe("Provider events", () => {
       expect(eventLog.some((e) => e.type === "update")).toBe(true);
       expect(eventLog.some((e) => e.type === "received-message")).toBe(true);
     });
+  });
+});
+
+describe("Provider presence", () => {
+  let provider: Provider<MockTransport>;
+  let mockConnection: MockConnection;
+  let mockTransport: MockTransport;
+  let ydoc: Y.Doc;
+
+  beforeEach(() => {
+    ydoc = new Y.Doc();
+    mockConnection = new MockConnection();
+    mockTransport = new MockTransport();
+  });
+
+  afterEach(() => {
+    provider?.destroy();
+    mockConnection?.destroy();
+    ydoc?.destroy();
+  });
+
+  const createProvider = async () => {
+    mockConnection.triggerConnect();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    provider = await Provider.create({
+      connection: mockConnection,
+      document: "test-doc",
+      ydoc,
+      getTransport: () => mockTransport,
+      enableOfflinePersistence: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return provider;
+  };
+
+  it("announces its awareness clientID on connect", async () => {
+    await createProvider();
+
+    const announce = mockConnection.sentMessages.find(
+      (m): m is PresenceMessage<ClientContext> =>
+        m.type === "presence" &&
+        (m as any).payload?.type === "presence-announce",
+    );
+    expect(announce).toBeDefined();
+    expect(announce!.payload).toEqual({
+      type: "presence-announce",
+      awarenessId: provider.awareness.clientID,
+    });
+  });
+
+  it("clears a peer's awareness and emits peer-leave on presence-leave", async () => {
+    await createProvider();
+
+    // Inject a remote peer's awareness state into the local Awareness.
+    const peerDoc = new Y.Doc();
+    const peerAwareness = new Awareness(peerDoc);
+    peerAwareness.setLocalState({ name: "bob" });
+    applyAwarenessUpdate(
+      provider.awareness,
+      encodeAwarenessUpdate(peerAwareness, [peerAwareness.clientID]),
+      "remote",
+    );
+    expect(provider.awareness.getStates().has(peerAwareness.clientID)).toBe(
+      true,
+    );
+
+    const leaves: any[] = [];
+    provider.on("peer-leave", (peer) => leaves.push(peer));
+
+    mockConnection.simulateMessage(
+      new PresenceMessage("test-doc", {
+        type: "presence-leave",
+        awarenessId: peerAwareness.clientID,
+        clientId: "conn-bob",
+        userId: "user-bob",
+        data: { userName: "Bob" },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Awareness cleared locally (no key required).
+    expect(provider.awareness.getStates().has(peerAwareness.clientID)).toBe(
+      false,
+    );
+    expect(leaves).toHaveLength(1);
+    expect(leaves[0]).toEqual({
+      awarenessId: peerAwareness.clientID,
+      clientId: "conn-bob",
+      userId: "user-bob",
+      data: { userName: "Bob" },
+    });
+
+    peerAwareness.destroy();
+    peerDoc.destroy();
+  });
+
+  it("emits peer-join on presence-join", async () => {
+    await createProvider();
+
+    const joins: any[] = [];
+    provider.on("peer-join", (peer) => joins.push(peer));
+
+    mockConnection.simulateMessage(
+      new PresenceMessage("test-doc", {
+        type: "presence-join",
+        awarenessId: 4242,
+        clientId: "conn-carol",
+        userId: "user-carol",
+        data: { userName: "Carol" },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(joins).toEqual([
+      {
+        awarenessId: 4242,
+        clientId: "conn-carol",
+        userId: "user-carol",
+        data: { userName: "Carol" },
+      },
+    ]);
   });
 });

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,12 +1,13 @@
 import { EventClient } from "@tanstack/devtools-event-client";
 import { IndexeddbPersistence } from "y-indexeddb";
-import { Awareness } from "y-protocols/awareness";
+import { Awareness, removeAwarenessStates } from "y-protocols/awareness";
 import * as Y from "yjs";
 
 import {
   Message,
   Milestone,
   Observable,
+  PresenceMessage,
   RawReceivedMessage,
   RpcMessage,
   type ClientContext,
@@ -110,6 +111,21 @@ export class FileOperationError extends Error {
   }
 }
 
+/**
+ * A peer join/leave notification surfaced to integrators. `data` is whatever the
+ * server's `presenceConfig.getPresenceData` chose to share (e.g. a display name).
+ */
+export type PresenceEvent = {
+  /** The peer's y-awareness clientID. */
+  awarenessId: number;
+  /** The peer's server-assigned session/connection clientId. */
+  clientId: string;
+  /** The user the peer is authenticated as. */
+  userId: string;
+  /** Integrator-supplied context shared by the server. */
+  data: Record<string, unknown>;
+};
+
 export type DefaultTransportProperties = {
   synced: Promise<void>;
   handler: {
@@ -206,6 +222,13 @@ export class Provider<
   connected: () => void;
   disconnected: () => void;
   update: (state: ConnectionState<ConnectionContext>) => void;
+  /** Emitted when a peer joins the session (after it announces its presence). */
+  "peer-join": (peer: PresenceEvent) => void;
+  /**
+   * Emitted when a peer leaves the session. Its awareness state has already been
+   * cleared locally by the time this fires.
+   */
+  "peer-leave": (peer: PresenceEvent) => void;
 }> {
   public doc: Y.Doc;
   public awareness: Awareness;
@@ -320,6 +343,9 @@ export class Provider<
           connection,
         });
         // RPC messages and ACKs are routed in #initRpcHandlers()
+        if (message.type === "presence") {
+          this.#handlePresenceMessage(message as PresenceMessage<any>);
+        }
       }),
     );
     this.abortController.signal.addEventListener(
@@ -344,6 +370,35 @@ export class Provider<
         });
       }),
     );
+  }
+
+  /**
+   * Handle a server presence notification: a leaving peer's awareness is cleared
+   * locally (no key needed, so this works for encrypted documents), then the
+   * join/leave is surfaced to integrators.
+   */
+  #handlePresenceMessage(message: PresenceMessage<any>) {
+    const payload = message.payload;
+    if (payload.type === "presence-announce") {
+      // Announces are client -> server only; ignore if echoed back.
+      return;
+    }
+    if (payload.type === "presence-heartbeat") {
+      // Heartbeats are node-to-node only and never reach clients; ignore.
+      return;
+    }
+    const peer: PresenceEvent = {
+      awarenessId: payload.awarenessId,
+      clientId: payload.clientId,
+      userId: payload.userId,
+      data: payload.data,
+    };
+    if (payload.type === "presence-leave") {
+      removeAwarenessStates(this.awareness, [payload.awarenessId], "presence");
+      this.call("peer-leave", peer);
+    } else {
+      this.call("peer-join", peer);
+    }
   }
 
   private initOfflinePersistence() {
@@ -377,6 +432,16 @@ export class Provider<
     this.#initInProgress = true;
     try {
       this.#underlyingConnection.send(await this.transport.handler.start());
+
+      // Announce the awareness clientID we operate under (cleartext), so the
+      // server can tell peers to clear our awareness when we leave — this is the
+      // only such channel for end-to-end encrypted documents.
+      this.#underlyingConnection.send(
+        new PresenceMessage(this.document, {
+          type: "presence-announce",
+          awarenessId: this.awareness.clientID,
+        }),
+      );
 
       this.abortController.signal.addEventListener(
         "abort",

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -14,6 +14,36 @@ export type ClientMessageDirection = "in" | "out";
 
 export type DocumentMessageSource = "client" | "replication";
 
+/**
+ * Configuration for client presence (join/leave) notifications broadcast to a
+ * session's peers.
+ */
+export type PresenceConfig<Context extends ServerContext = ServerContext> = {
+  /**
+   * Project a client's server context into the `data` bag broadcast to peers on
+   * join/leave. Return only what is safe to share (e.g. a display name). May be
+   * async (e.g. to look up a profile). Defaults to `() => ({})`.
+   */
+  getPresenceData?: (
+    context: Context,
+  ) => Record<string, unknown> | Promise<Record<string, unknown>>;
+
+  /**
+   * How often (ms) each node re-broadcasts a snapshot of its own local clients
+   * over pub/sub so other nodes can keep a fresh, crash-safe roster. Defaults to
+   * 30_000 (30s).
+   */
+  heartbeatIntervalMs?: number;
+
+  /**
+   * How long (ms) a remote node's presence is trusted without a heartbeat.
+   * When exceeded, the node is presumed gone and its clients are cleared from
+   * peers. Should be a small multiple of `heartbeatIntervalMs`. Defaults to
+   * 90_000 (90s, ~2 missed heartbeats).
+   */
+  presenceTtlMs?: number;
+};
+
 export type SessionEvents<Context extends ServerContext = ServerContext> = {
   /**
    * Emitted when a client joins this session.

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -333,6 +333,25 @@ describe("Server", () => {
       ).rejects.toThrow("Encryption state mismatch");
     });
 
+    it("attaches to an existing session of either encryption mode when ignoreEncryptionMismatch is set", async () => {
+      // Presence messages are always cleartext (encrypted: false) but must
+      // attach to an encrypted session without throwing — otherwise the
+      // encryption-mismatch error tears down the client connection.
+      const encryptedSession = await server.getOrOpenSession("enc-doc", {
+        encrypted: true,
+        context: { userId: "user-1", room: "room", clientId: "client-1" },
+      });
+
+      const session = await server.getOrOpenSession("enc-doc", {
+        encrypted: false,
+        context: { userId: "user-1", room: "room", clientId: "client-1" },
+        ignoreEncryptionMismatch: true,
+      });
+
+      expect(session).toBe(encryptedSession);
+      expect(session.encrypted).toBe(true);
+    });
+
     it("should call getStorage with correct parameters", async () => {
       let calledWith: any = null;
       const customGetStorage = (ctx: any) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -29,7 +29,11 @@ import {
 import { Observable } from "../lib/utils";
 import { register } from "../monitoring/metrics";
 import { Client } from "./client";
-import type { ClientDisconnectReason, ServerEvents } from "./events";
+import type {
+  ClientDisconnectReason,
+  PresenceConfig,
+  ServerEvents,
+} from "./events";
 import { Session } from "./session";
 
 export type ServerOptions<Context extends ServerContext> = {
@@ -82,6 +86,12 @@ export type ServerOptions<Context extends ServerContext> = {
   milestoneTriggerConfig?: {
     defaultTriggers?: MilestoneTrigger[];
   };
+
+  /**
+   * Configuration for client presence (join/leave) notifications broadcast to
+   * a session's peers.
+   */
+  presenceConfig?: PresenceConfig<NoInfer<Context>>;
 
   /**
    * RPC handlers for the server.
@@ -253,11 +263,18 @@ export class Server<Context extends ServerContext> extends Observable<
       id = "session-" + uuidv4(),
       client,
       context,
+      ignoreEncryptionMismatch = false,
     }: {
       encrypted: boolean;
       id?: string;
       client?: Client<Context>;
       context: Context;
+      /**
+       * Skip the encryption-state validation against an existing/pending
+       * session. Used for cleartext presence metadata, which must attach to the
+       * existing session regardless of its encryption mode and never defines it.
+       */
+      ignoreEncryptionMismatch?: boolean;
     },
   ) {
     if (!documentId) {
@@ -273,7 +290,7 @@ export class Server<Context extends ServerContext> extends Observable<
     const existing = this.#sessions.get(compositeDocumentId);
     if (existing) {
       // Validate that the encryption state matches the existing session
-      if (existing.encrypted !== encrypted) {
+      if (existing.encrypted !== encrypted && !ignoreEncryptionMismatch) {
         const error = new Error(
           `Encryption state mismatch: existing session for document "${compositeDocumentId}" has encrypted=${existing.encrypted}, but requested encrypted=${encrypted}`,
         );
@@ -302,7 +319,7 @@ export class Server<Context extends ServerContext> extends Observable<
       const session = await pending;
 
       // Validate encryption state matches
-      if (session.encrypted !== encrypted) {
+      if (session.encrypted !== encrypted && !ignoreEncryptionMismatch) {
         const error = new Error(
           `Encryption state mismatch: pending session for document "${compositeDocumentId}" has encrypted=${session.encrypted}, but requested encrypted=${encrypted}`,
         );
@@ -347,6 +364,7 @@ export class Server<Context extends ServerContext> extends Observable<
           onCleanupScheduled: this.#handleSessionCleanup.bind(this),
           metricsCollector: this.#metrics,
           documentSizeConfig: this.#options.documentSizeConfig,
+          presenceConfig: this.#options.presenceConfig,
           rpcHandlers: this.#options.rpcHandlers,
           server: this,
         });
@@ -724,6 +742,9 @@ export class Server<Context extends ServerContext> extends Observable<
                 encrypted: message.encrypted,
                 client,
                 context: message.context,
+                // Presence is always cleartext metadata; it must attach to the
+                // existing session regardless of the document's encryption mode.
+                ignoreEncryptionMismatch: message.type === "presence",
               });
               wideEvent.session_id = session.id;
 

--- a/src/server/session.test.ts
+++ b/src/server/session.test.ts
@@ -1,20 +1,44 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+} from "bun:test";
 import { getLogger } from "@logtape/logtape";
 import * as Y from "yjs";
 import type {
+  AwarenessUpdateMessage,
   Message,
   ServerContext,
   StateVector,
   SyncStep2Update,
   Update,
 } from "teleportal";
-import { DocMessage, InMemoryPubSub } from "teleportal";
+import {
+  AwarenessMessage,
+  DocMessage,
+  InMemoryPubSub,
+  PresenceMessage,
+} from "teleportal";
 import type {
   Document,
   DocumentMetadata,
   DocumentStorage,
   EncodedContentMap,
 } from "teleportal/storage";
+import {
+  Awareness,
+  applyAwarenessUpdate,
+  encodeAwarenessUpdate,
+  removeAwarenessStates,
+} from "y-protocols/awareness";
+import {
+  createEncryptionKey,
+  decryptUpdate,
+  encryptUpdate,
+} from "teleportal/encryption-key";
 import { Session } from "./session";
 import { Server } from "./server";
 import { Client } from "./client";
@@ -161,6 +185,41 @@ function createTestUpdate(content = "test"): Update {
   const doc = new Y.Doc();
   doc.getText("content").insert(0, content);
   return Y.encodeStateAsUpdateV2(doc) as Update;
+}
+
+/**
+ * Apply the messages a peer received from the server to a local Awareness,
+ * mimicking what the provider does on the client: awareness-update is applied
+ * (decrypting first for e2ee), while presence-leave clears the departed peer.
+ */
+async function applyServerMessagesToObserver(
+  observer: Awareness,
+  messages: Message<ServerContext>[],
+  decrypt?: (u: Uint8Array) => Promise<Uint8Array>,
+) {
+  for (const msg of messages) {
+    if (
+      msg.type === "awareness" &&
+      (msg as any).payload?.type === "awareness-update"
+    ) {
+      try {
+        const raw = (msg as any).payload.update as Uint8Array;
+        const update = decrypt ? await decrypt(raw) : raw;
+        applyAwarenessUpdate(observer, update, "remote");
+      } catch {
+        // A faithful e2ee client rejects undecryptable awareness updates.
+      }
+    } else if (
+      msg.type === "presence" &&
+      (msg as any).payload?.type === "presence-leave"
+    ) {
+      removeAwarenessStates(
+        observer,
+        [(msg as any).payload.awarenessId],
+        "remote",
+      );
+    }
+  }
 }
 
 describe("Session", () => {
@@ -714,6 +773,258 @@ describe("Session", () => {
         // Should not send to originating client
         expect(client1.sentMessages.length).toBe(0);
       });
+
+      it("should clear a peer's awareness state when it disconnects", async () => {
+        session.addClient(client1 as any);
+        session.addClient(client2 as any);
+
+        // client1 publishes its awareness state...
+        const doc1 = new Y.Doc();
+        const awareness1 = new Awareness(doc1);
+        awareness1.setLocalState({ cursor: { x: 1, y: 2 } });
+        const update = encodeAwarenessUpdate(awareness1, [
+          awareness1.clientID,
+        ]) as AwarenessUpdateMessage;
+        await session.apply(
+          new AwarenessMessage(
+            "test-doc",
+            { type: "awareness-update", update },
+            { clientId: "client-1", userId: "user-1", room: "room" },
+          ),
+          client1 as any,
+        );
+        // ...and announces the awareness clientID it operates under.
+        await session.apply(
+          new PresenceMessage(
+            "test-doc",
+            { type: "presence-announce", awarenessId: awareness1.clientID },
+            { clientId: "client-1", userId: "user-1", room: "room" },
+          ),
+          client1 as any,
+        );
+
+        // client2 saw the awareness update.
+        const observerDoc = new Y.Doc();
+        const observer = new Awareness(observerDoc);
+        observer.setLocalState(null);
+        await applyServerMessagesToObserver(observer, client2.sentMessages);
+        expect(observer.getStates().has(awareness1.clientID)).toBe(true);
+
+        // Disconnect client1 — the session broadcasts a presence-leave.
+        const prevCount = client2.sentMessages.length;
+        session.removeClient(client1 as any);
+        // The leave broadcast is fire-and-forget; give it a tick to run.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(client2.sentMessages.length).toBeGreaterThan(prevCount);
+
+        await applyServerMessagesToObserver(
+          observer,
+          client2.sentMessages.slice(prevCount),
+        );
+        expect(observer.getStates().has(awareness1.clientID)).toBe(false);
+
+        awareness1.destroy();
+        doc1.destroy();
+        observer.destroy();
+        observerDoc.destroy();
+      });
+
+      // The server cannot read an encrypted client's awareness clientID (it's
+      // inside the AES-GCM ciphertext) and has no key to author a tombstone.
+      // Presence carries the awareness clientID in cleartext, so a departed
+      // encrypted peer is still cleared on remaining clients.
+      it("clears an encrypted peer's awareness on disconnect", async () => {
+        const encSession = new Session<ServerContext>({
+          documentId: "enc-doc",
+          namespacedDocumentId: "enc-doc",
+          id: "session-enc",
+          encrypted: true,
+          storage,
+          pubSub,
+          nodeId,
+          onCleanupScheduled: () => {},
+          server: mockServer,
+        });
+        const c1 = new MockClient<ServerContext>("enc-client-1");
+        const c2 = new MockClient<ServerContext>("enc-client-2");
+        encSession.addClient(c1 as any);
+        encSession.addClient(c2 as any);
+
+        const key = await createEncryptionKey();
+
+        // client1 publishes an ENCRYPTED awareness update (AES-GCM ciphertext)...
+        const doc1 = new Y.Doc();
+        const awareness1 = new Awareness(doc1);
+        awareness1.setLocalState({ cursor: { x: 1, y: 2 } });
+        const plain = encodeAwarenessUpdate(awareness1, [
+          awareness1.clientID,
+        ]) as AwarenessUpdateMessage;
+        const cipher = (await encryptUpdate(key, plain)) as AwarenessUpdateMessage;
+        await encSession.apply(
+          new AwarenessMessage(
+            "enc-doc",
+            { type: "awareness-update", update: cipher },
+            { clientId: "enc-client-1", userId: "user-1", room: "room" },
+            true,
+          ),
+          c1 as any,
+        );
+        // ...and announces its awareness clientID in cleartext.
+        await encSession.apply(
+          new PresenceMessage(
+            "enc-doc",
+            { type: "presence-announce", awarenessId: awareness1.clientID },
+            { clientId: "enc-client-1", userId: "user-1", room: "room" },
+          ),
+          c1 as any,
+        );
+
+        // A faithful remote encrypted peer decrypts awareness updates and acts
+        // on presence-leave.
+        const observerDoc = new Y.Doc();
+        const observer = new Awareness(observerDoc);
+        observer.setLocalState(null);
+        const decrypt = (u: Uint8Array) => decryptUpdate(key, u as any);
+        await applyServerMessagesToObserver(
+          observer,
+          c2.sentMessages,
+          decrypt,
+        );
+        expect(observer.getStates().has(awareness1.clientID)).toBe(true);
+
+        // Disconnect client1.
+        const prevCount = c2.sentMessages.length;
+        encSession.removeClient(c1 as any);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(c2.sentMessages.length).toBeGreaterThan(prevCount);
+
+        await applyServerMessagesToObserver(
+          observer,
+          c2.sentMessages.slice(prevCount),
+          decrypt,
+        );
+        expect(observer.getStates().has(awareness1.clientID)).toBe(false);
+
+        awareness1.destroy();
+        doc1.destroy();
+        observer.destroy();
+        observerDoc.destroy();
+        await encSession[Symbol.asyncDispose]();
+      });
+    });
+
+    describe("presence messages", () => {
+      const announce = (
+        clientId: string,
+        awarenessId: number,
+        userId = "user-1",
+      ) =>
+        new PresenceMessage(
+          "test-doc",
+          { type: "presence-announce", awarenessId },
+          { clientId, userId, room: "room" },
+        );
+
+      const presenceMsgs = (client: MockClient<ServerContext>) =>
+        client.sentMessages.filter(
+          (m): m is PresenceMessage<ServerContext> => m.type === "presence",
+        );
+
+      it("broadcasts a join to already-announced peers (not the sender)", async () => {
+        session.addClient(client1 as any);
+        session.addClient(client2 as any);
+
+        // client-2 is already present and announced.
+        await session.apply(announce("client-2", 222), client2 as any);
+        const prev = presenceMsgs(client2).length;
+
+        await session.apply(announce("client-1", 111), client1 as any);
+
+        // The announcing client is never told about its own join.
+        expect(
+          presenceMsgs(client1).some(
+            (m) => (m.payload as any).clientId === "client-1",
+          ),
+        ).toBe(false);
+        // The already-announced peer learns of the join, with both ids + userId.
+        const joins = presenceMsgs(client2).slice(prev);
+        expect(joins).toHaveLength(1);
+        expect(joins[0]!.payload).toMatchObject({
+          type: "presence-join",
+          awarenessId: 111,
+          clientId: "client-1",
+          userId: "user-1",
+        });
+      });
+
+      it("sends the current roster to a newly-announced client", async () => {
+        session.addClient(client1 as any);
+        session.addClient(client2 as any);
+
+        await session.apply(announce("client-1", 111), client1 as any);
+        await session.apply(announce("client-2", 222), client2 as any);
+
+        // client-2 should learn about the already-present client-1.
+        const roster = presenceMsgs(client2).filter(
+          (m) => (m.payload as any).awarenessId === 111,
+        );
+        expect(roster).toHaveLength(1);
+        expect(roster[0]!.payload).toMatchObject({
+          type: "presence-join",
+          clientId: "client-1",
+        });
+      });
+
+      it("broadcasts a presence-leave with ids, userId and async data on disconnect", async () => {
+        const presenceSession = new Session<ServerContext>({
+          documentId: "test-doc",
+          namespacedDocumentId: "test-doc",
+          id: "session-presence",
+          encrypted: false,
+          storage,
+          pubSub,
+          nodeId,
+          onCleanupScheduled: () => {},
+          presenceConfig: {
+            getPresenceData: async (ctx) => ({ userName: `name:${ctx.userId}` }),
+          },
+          server: mockServer,
+        });
+        presenceSession.addClient(client1 as any);
+        presenceSession.addClient(client2 as any);
+
+        await presenceSession.apply(announce("client-1", 111), client1 as any);
+        const prevCount = client2.sentMessages.length;
+
+        presenceSession.removeClient(client1 as any);
+        await new Promise((r) => setTimeout(r, 0));
+
+        const leaves = presenceMsgs(client2).filter(
+          (m) => (m.payload as any).type === "presence-leave",
+        );
+        expect(client2.sentMessages.length).toBeGreaterThan(prevCount);
+        expect(leaves).toHaveLength(1);
+        expect(leaves[0]!.payload).toEqual({
+          type: "presence-leave",
+          awarenessId: 111,
+          clientId: "client-1",
+          userId: "user-1",
+          data: { userName: "name:user-1" },
+        });
+
+        await presenceSession[Symbol.asyncDispose]();
+      });
+
+      it("does not broadcast a leave for a client that never announced", async () => {
+        session.addClient(client1 as any);
+        session.addClient(client2 as any);
+
+        const prevCount = client2.sentMessages.length;
+        session.removeClient(client1 as any);
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(client2.sentMessages.length).toBe(prevCount);
+      });
     });
 
     describe("unknown payload types", () => {
@@ -730,6 +1041,177 @@ describe("Session", () => {
 
         await expect(session.apply(message)).resolves.toBeUndefined();
       });
+    });
+  });
+
+  describe("cross-node presence", () => {
+    const DOC = "xnode-doc";
+    const TOPIC = `document/${DOC}` as const;
+
+    const makeSession = (
+      id: string,
+      sessionNodeId: string,
+      bus: InMemoryPubSub,
+      presenceConfig: {
+        heartbeatIntervalMs?: number;
+        presenceTtlMs?: number;
+      } = { heartbeatIntervalMs: 0 },
+    ) =>
+      new Session<ServerContext>({
+        documentId: DOC,
+        namespacedDocumentId: DOC,
+        id,
+        encrypted: false,
+        storage,
+        pubSub: bus,
+        nodeId: sessionNodeId,
+        onCleanupScheduled: () => {},
+        presenceConfig,
+        server: mockServer,
+      });
+
+    const announce = (clientId: string, awarenessId: number, userId = "user-1") =>
+      new PresenceMessage(
+        DOC,
+        { type: "presence-announce", awarenessId },
+        { clientId, userId, room: "room" },
+      );
+
+    const heartbeat = (
+      clients: Array<{
+        awarenessId: number;
+        clientId: string;
+        userId: string;
+        data: Record<string, unknown>;
+      }>,
+    ) => new PresenceMessage(DOC, { type: "presence-heartbeat", clients });
+
+    // The in-memory pub/sub does not await the (async) subscriber, so give
+    // replicated presence handling a tick to run.
+    const tick = () => new Promise((r) => setTimeout(r, 10));
+
+    const presenceOf = (
+      client: MockClient<ServerContext>,
+      payloadType: string,
+      awarenessId: number,
+    ) =>
+      client.sentMessages.filter(
+        (m): m is PresenceMessage<ServerContext> =>
+          m.type === "presence" &&
+          (m.payload as any).type === payloadType &&
+          (m.payload as any).awarenessId === awarenessId,
+      );
+
+    it("includes a cross-node peer in a newcomer's join roster", async () => {
+      const bus = new InMemoryPubSub();
+      const nodeA = makeSession("session-a", "node-a", bus);
+      const nodeB = makeSession("session-b", "node-b", bus);
+      await nodeA.load();
+      await nodeB.load();
+
+      // a1 is present on node A; its join replicates to node B's roster.
+      const a1 = new MockClient<ServerContext>("a1");
+      nodeA.addClient(a1 as any);
+      await nodeA.apply(announce("a1", 111), a1 as any);
+      await tick();
+
+      // b1 joins on node B *after* a1, so its only source for a1 is the roster.
+      const b1 = new MockClient<ServerContext>("b1");
+      nodeB.addClient(b1 as any);
+      await nodeB.apply(announce("b1", 222), b1 as any);
+
+      const roster = presenceOf(b1, "presence-join", 111);
+      expect(roster).toHaveLength(1);
+      expect(roster[0]!.payload).toMatchObject({
+        clientId: "a1",
+        userId: "user-1",
+      });
+
+      await nodeA[Symbol.asyncDispose]();
+      await nodeB[Symbol.asyncDispose]();
+      await bus[Symbol.asyncDispose]();
+    });
+
+    it("reconciles a node's heartbeat snapshot (join, then leave on removal)", async () => {
+      const bus = new InMemoryPubSub();
+      const nodeB = makeSession("session-b", "node-b", bus);
+      await nodeB.load();
+      const b1 = new MockClient<ServerContext>("b1");
+      nodeB.addClient(b1 as any);
+
+      // Heartbeat from node A advertising a1 -> b1 sees a join.
+      await bus.publish(
+        TOPIC,
+        heartbeat([
+          { awarenessId: 111, clientId: "a1", userId: "user-a", data: {} },
+        ]).encoded,
+        "node-a",
+      );
+      await tick();
+      expect(presenceOf(b1, "presence-join", 111)).toHaveLength(1);
+
+      // Next snapshot omits a1 (e.g. a missed leave) -> b1 sees a leave.
+      const prev = b1.sentMessages.length;
+      await bus.publish(TOPIC, heartbeat([]).encoded, "node-a");
+      await tick();
+
+      const leaves = b1.sentMessages
+        .slice(prev)
+        .filter(
+          (m) =>
+            m.type === "presence" &&
+            (m.payload as any).type === "presence-leave" &&
+            (m.payload as any).awarenessId === 111,
+        );
+      expect(leaves).toHaveLength(1);
+
+      await nodeB[Symbol.asyncDispose]();
+      await bus[Symbol.asyncDispose]();
+    });
+
+    it("expires a silent node and clears its clients (crash safety)", async () => {
+      const base = new Date("2026-01-01T00:00:00.000Z");
+      setSystemTime(base);
+      try {
+        const bus = new InMemoryPubSub();
+        const nodeB = makeSession("session-b", "node-b", bus, {
+          heartbeatIntervalMs: 0,
+          presenceTtlMs: 1000,
+        });
+        await nodeB.load();
+        const b1 = new MockClient<ServerContext>("b1");
+        nodeB.addClient(b1 as any);
+
+        await bus.publish(
+          TOPIC,
+          heartbeat([
+            { awarenessId: 111, clientId: "a1", userId: "user-a", data: {} },
+          ]).encoded,
+          "node-a",
+        );
+        await tick();
+        expect(presenceOf(b1, "presence-join", 111)).toHaveLength(1);
+
+        const prev = b1.sentMessages.length;
+        // Advance past the TTL and run maintenance: node A is presumed gone.
+        setSystemTime(new Date(base.getTime() + 2000));
+        await nodeB.runPresenceMaintenance();
+
+        const leaves = b1.sentMessages
+          .slice(prev)
+          .filter(
+            (m) =>
+              m.type === "presence" &&
+              (m.payload as any).type === "presence-leave" &&
+              (m.payload as any).awarenessId === 111,
+          );
+        expect(leaves).toHaveLength(1);
+
+        await nodeB[Symbol.asyncDispose]();
+        await bus[Symbol.asyncDispose]();
+      } finally {
+        setSystemTime();
+      }
     });
   });
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1,8 +1,12 @@
 import { emitWideEvent } from "./logger";
 import {
   decodeMessage,
+  type DecodedPresenceHeartbeat,
+  type DecodedPresenceJoin,
+  type DecodedPresenceLeave,
   DocMessage,
   type Message,
+  PresenceMessage,
   type PubSub,
   type ServerContext,
   type SyncStep2Update,
@@ -31,7 +35,11 @@ import {
 import { Observable } from "../lib/utils";
 import { Client } from "./client";
 import { TtlDedupe } from "./dedupe";
-import type { DocumentMessageSource, SessionEvents } from "./events";
+import type {
+  DocumentMessageSource,
+  PresenceConfig,
+  SessionEvents,
+} from "./events";
 import type { Server } from "./server";
 
 export class Session<Context extends ServerContext> extends Observable<
@@ -73,6 +81,39 @@ export class Session<Context extends ServerContext> extends Observable<
   readonly #CLEANUP_DELAY_MS = 60_000;
   #rpcHandlers: RpcHandlerRegistry;
   #server: Server<Context>;
+  #presenceConfig: PresenceConfig<Context> | undefined;
+  /**
+   * The presence of each connected (local) client, keyed by session client id.
+   * Records the numeric awareness clientID a client announced (cleartext, so it
+   * works for encrypted documents), its server context, and the resolved
+   * presence `data` (computed once at announce), so the session can tell peers
+   * which awareness state to clear when the client leaves and can advertise the
+   * client in heartbeats without re-running `getPresenceData`.
+   */
+  #clientPresence = new Map<
+    string,
+    { awarenessId: number; context: Context; data: Record<string, unknown> }
+  >();
+  /**
+   * Presence of clients connected to *other* nodes, keyed by node id, then by
+   * client id. Built from pub/sub presence join/leave and heartbeat snapshots,
+   * so a newcomer learns about cross-node peers. Each node carries a `lastSeen`
+   * timestamp; a node whose heartbeats stop is TTL-expired and its clients are
+   * cleared from local peers (self-healing across node crashes).
+   */
+  #remotePresence = new Map<
+    string,
+    {
+      lastSeen: number;
+      clients: Map<
+        string,
+        { awarenessId: number; userId: string; data: Record<string, unknown> }
+      >;
+    }
+  >();
+  #heartbeatIntervalMs: number;
+  #presenceTtlMs: number;
+  #presenceTimerId: ReturnType<typeof setInterval> | undefined;
 
   constructor(args: {
     documentId: string;
@@ -86,6 +127,7 @@ export class Session<Context extends ServerContext> extends Observable<
     onCleanupScheduled: (session: Session<Context>) => void;
     metricsCollector?: MetricsCollector;
     documentSizeConfig?: { warningThreshold?: number; limit?: number };
+    presenceConfig?: PresenceConfig<Context>;
     rpcHandlers?: RpcHandlerRegistry;
     server: Server<Context>;
   }) {
@@ -99,6 +141,10 @@ export class Session<Context extends ServerContext> extends Observable<
     this.#nodeId = args.nodeId;
     this.#metrics = args.metricsCollector;
     this.#documentSizeConfig = args.documentSizeConfig;
+    this.#presenceConfig = args.presenceConfig;
+    this.#heartbeatIntervalMs =
+      args.presenceConfig?.heartbeatIntervalMs ?? 30_000;
+    this.#presenceTtlMs = args.presenceConfig?.presenceTtlMs ?? 90_000;
     this.#rpcHandlers = args.rpcHandlers ?? {};
     this.#server = args.server;
     this.#dedupe = args.dedupe ?? new TtlDedupe();
@@ -154,20 +200,27 @@ export class Session<Context extends ServerContext> extends Observable<
           }
 
           try {
-            const shouldAccept = this.#dedupe.shouldAccept(
-              this.namespacedDocumentId,
-              message.id,
-            );
-
-            if (!shouldAccept) {
-              this.#emitDocumentMessage(
-                message,
-                undefined,
-                "replication",
-                sourceId,
-                true,
+            // Presence messages skip dedup: heartbeats are periodic and
+            // content-hashed, so identical snapshots would collide inside the
+            // dedup TTL window and be dropped. Presence handlers are idempotent
+            // (join upserts, leave removes, heartbeat replaces), so re-applying
+            // is safe.
+            if (message.type !== "presence") {
+              const shouldAccept = this.#dedupe.shouldAccept(
+                this.namespacedDocumentId,
+                message.id,
               );
-              return;
+
+              if (!shouldAccept) {
+                this.#emitDocumentMessage(
+                  message,
+                  undefined,
+                  "replication",
+                  sourceId,
+                  true,
+                );
+                return;
+              }
             }
 
             await this.apply(message, undefined, {
@@ -200,6 +253,23 @@ export class Session<Context extends ServerContext> extends Observable<
       });
       throw error;
     }
+
+    this.#startPresenceMaintenance();
+  }
+
+  /**
+   * Periodically (a) advertise this node's local clients to other nodes and
+   * (b) expire remote nodes that have gone silent. Idempotent.
+   */
+  #startPresenceMaintenance() {
+    if (this.#presenceTimerId !== undefined || this.#heartbeatIntervalMs <= 0) {
+      return;
+    }
+    this.#presenceTimerId = setInterval(() => {
+      void this.runPresenceMaintenance();
+    }, this.#heartbeatIntervalMs);
+    // Don't keep the process alive solely for presence heartbeats.
+    (this.#presenceTimerId as { unref?: () => void }).unref?.();
   }
 
   /**
@@ -233,6 +303,8 @@ export class Session<Context extends ServerContext> extends Observable<
     this.#clients.delete(id);
 
     if (client) {
+      this.#broadcastClientLeave(id);
+
       this.call("client-leave", {
         clientId: id,
         documentId: this.documentId,
@@ -247,6 +319,320 @@ export class Session<Context extends ServerContext> extends Observable<
 
       client.destroy();
     }
+  }
+
+  /**
+   * Resolve the integrator-configured presence `data` for a client context,
+   * tolerating a throwing or rejecting projection.
+   */
+  async #getPresenceData(context: Context): Promise<Record<string, unknown>> {
+    if (!this.#presenceConfig?.getPresenceData) {
+      return {};
+    }
+    try {
+      return await this.#presenceConfig.getPresenceData(context);
+    } catch (error) {
+      emitWideEvent("error", {
+        event_type: "presence_data_failed",
+        timestamp: new Date().toISOString(),
+        document_id: this.documentId,
+        session_id: this.id,
+        client_id: context.clientId,
+        error,
+      });
+      return {};
+    }
+  }
+
+  /**
+   * Record a client's announced awareness clientID and tell peers it joined.
+   *
+   * The announce is the only cleartext channel carrying the numeric awareness
+   * clientID, so this is what makes presence (and awareness clearing) work for
+   * end-to-end encrypted documents. The announcing client is also sent the
+   * current same-node roster so it learns existing peers' presence data.
+   */
+  async #handlePresenceAnnounce(
+    client: { id: string; send: (m: Message<Context>) => Promise<void> },
+    awarenessId: number,
+    context: Context,
+  ) {
+    // Resolve the presence data once and cache it, so heartbeats and the leave
+    // broadcast don't re-run the (possibly async/DB-backed) projection.
+    const data = await this.#getPresenceData(context);
+    this.#clientPresence.set(client.id, { awarenessId, context, data });
+
+    // Tell the newcomer about everyone already present (same node)...
+    for (const [otherId, other] of this.#clientPresence) {
+      if (otherId === client.id) {
+        continue;
+      }
+      const message = new PresenceMessage<Context>(this.documentId, {
+        type: "presence-join",
+        awarenessId: other.awarenessId,
+        clientId: otherId,
+        userId: other.context.userId,
+        data: other.data,
+      });
+      await client.send(message).catch(() => {});
+    }
+
+    // ...and about peers on other nodes (learned via pub/sub join/heartbeat).
+    for (const node of this.#remotePresence.values()) {
+      for (const [otherId, other] of node.clients) {
+        const message = new PresenceMessage<Context>(this.documentId, {
+          type: "presence-join",
+          awarenessId: other.awarenessId,
+          clientId: otherId,
+          userId: other.userId,
+          data: other.data,
+        });
+        await client.send(message).catch(() => {});
+      }
+    }
+
+    // Tell already-announced peers that the newcomer joined. Peers that have
+    // not announced yet are skipped — they will receive the newcomer in their
+    // own roster when they announce, which avoids a duplicate join. Other nodes
+    // get the join via pub/sub.
+    const joinMessage = new PresenceMessage<Context>(this.documentId, {
+      type: "presence-join",
+      awarenessId,
+      clientId: client.id,
+      userId: context.userId,
+      data,
+    });
+    const sends: Promise<unknown>[] = [];
+    for (const otherId of this.#clientPresence.keys()) {
+      if (otherId === client.id) {
+        continue;
+      }
+      const peer = this.#clients.get(otherId);
+      if (peer) {
+        sends.push(peer.send(joinMessage));
+      }
+    }
+    sends.push(
+      this.#pubSub.publish(
+        `document/${this.namespacedDocumentId}` as const,
+        joinMessage.encoded,
+        this.#nodeId,
+      ),
+    );
+    await Promise.all(sends).catch((error) => {
+      emitWideEvent("error", {
+        event_type: "presence_join_broadcast_failed",
+        timestamp: new Date().toISOString(),
+        document_id: this.documentId,
+        session_id: this.id,
+        client_id: client.id,
+        error,
+      });
+    });
+  }
+
+  /**
+   * Tell peers a client left so they clear its awareness locally. Works for
+   * encrypted documents because the awareness clientID travels in cleartext.
+   */
+  #broadcastClientLeave(clientId: string) {
+    const presence = this.#clientPresence.get(clientId);
+    this.#clientPresence.delete(clientId);
+    if (!presence) {
+      return;
+    }
+    const message = new PresenceMessage<Context>(this.documentId, {
+      type: "presence-leave",
+      awarenessId: presence.awarenessId,
+      clientId,
+      userId: presence.context.userId,
+      data: presence.data,
+    });
+    void Promise.all([
+      this.broadcast(message, clientId),
+      this.#pubSub.publish(
+        `document/${this.namespacedDocumentId}` as const,
+        message.encoded,
+        this.#nodeId,
+      ),
+    ]).catch((error) => {
+      emitWideEvent("error", {
+        event_type: "presence_leave_broadcast_failed",
+        timestamp: new Date().toISOString(),
+        document_id: this.documentId,
+        session_id: this.id,
+        client_id: clientId,
+        error,
+      });
+    });
+  }
+
+  /**
+   * Locally fan out a server-authored presence-join/leave (clearing the peer's
+   * awareness on leave is done client-side from this message).
+   */
+  #broadcastPresence(
+    payload: DecodedPresenceJoin | DecodedPresenceLeave,
+  ): Promise<void> {
+    return this.broadcast(new PresenceMessage<Context>(this.documentId, payload));
+  }
+
+  /**
+   * Record/refresh a single remote client (from a pub/sub presence-join), so the
+   * cross-node roster stays current between heartbeats.
+   */
+  #upsertRemoteClient(
+    nodeId: string,
+    payload: DecodedPresenceJoin,
+  ) {
+    const node = this.#remotePresence.get(nodeId) ?? {
+      lastSeen: Date.now(),
+      clients: new Map<
+        string,
+        { awarenessId: number; userId: string; data: Record<string, unknown> }
+      >(),
+    };
+    node.lastSeen = Date.now();
+    node.clients.set(payload.clientId, {
+      awarenessId: payload.awarenessId,
+      userId: payload.userId,
+      data: payload.data,
+    });
+    this.#remotePresence.set(nodeId, node);
+  }
+
+  /**
+   * Forget a single remote client (from a pub/sub presence-leave).
+   */
+  #removeRemoteClient(nodeId: string, clientId: string) {
+    const node = this.#remotePresence.get(nodeId);
+    if (!node) {
+      return;
+    }
+    node.lastSeen = Date.now();
+    node.clients.delete(clientId);
+    if (node.clients.size === 0) {
+      this.#remotePresence.delete(nodeId);
+    }
+  }
+
+  /**
+   * Reconcile a node's full roster snapshot (from a pub/sub presence-heartbeat)
+   * against what we last knew for it: fan out joins for newly-seen clients,
+   * leaves for clients that disappeared, then store the snapshot and refresh the
+   * node's liveness. Self-heals any join/leave message that was lost.
+   */
+  async #reconcileRemoteSnapshot(
+    nodeId: string,
+    clients: DecodedPresenceHeartbeat["clients"],
+  ) {
+    const previous = this.#remotePresence.get(nodeId)?.clients ?? new Map();
+    const next = new Map<
+      string,
+      { awarenessId: number; userId: string; data: Record<string, unknown> }
+    >();
+    const sends: Promise<void>[] = [];
+
+    for (const peer of clients) {
+      next.set(peer.clientId, {
+        awarenessId: peer.awarenessId,
+        userId: peer.userId,
+        data: peer.data,
+      });
+      if (!previous.has(peer.clientId)) {
+        sends.push(
+          this.#broadcastPresence({
+            type: "presence-join",
+            awarenessId: peer.awarenessId,
+            clientId: peer.clientId,
+            userId: peer.userId,
+            data: peer.data,
+          }),
+        );
+      }
+    }
+
+    for (const [clientId, peer] of previous) {
+      if (!next.has(clientId)) {
+        sends.push(
+          this.#broadcastPresence({
+            type: "presence-leave",
+            awarenessId: peer.awarenessId,
+            clientId,
+            userId: peer.userId,
+            data: peer.data,
+          }),
+        );
+      }
+    }
+
+    this.#remotePresence.set(nodeId, { lastSeen: Date.now(), clients: next });
+    await Promise.all(sends);
+  }
+
+  /**
+   * Build a heartbeat snapshot of this node's local clients.
+   */
+  #localPresenceSnapshot(): DecodedPresenceHeartbeat["clients"] {
+    return [...this.#clientPresence.entries()].map(([clientId, presence]) => ({
+      awarenessId: presence.awarenessId,
+      clientId,
+      userId: presence.context.userId,
+      data: presence.data,
+    }));
+  }
+
+  /**
+   * One presence-maintenance tick (driven by the interval): advertise this
+   * node's local clients to other nodes, then expire any remote node that has
+   * stopped sending heartbeats (e.g. crashed) and clear its clients locally.
+   * Public so it can be driven deterministically in tests.
+   */
+  async runPresenceMaintenance() {
+    const sends: Promise<unknown>[] = [];
+
+    if (this.#clientPresence.size > 0) {
+      const heartbeat = new PresenceMessage<Context>(this.documentId, {
+        type: "presence-heartbeat",
+        clients: this.#localPresenceSnapshot(),
+      });
+      sends.push(
+        this.#pubSub.publish(
+          `document/${this.namespacedDocumentId}` as const,
+          heartbeat.encoded,
+          this.#nodeId,
+        ),
+      );
+    }
+
+    const now = Date.now();
+    for (const [nodeId, node] of this.#remotePresence) {
+      if (now - node.lastSeen <= this.#presenceTtlMs) {
+        continue;
+      }
+      this.#remotePresence.delete(nodeId);
+      for (const [clientId, peer] of node.clients) {
+        sends.push(
+          this.#broadcastPresence({
+            type: "presence-leave",
+            awarenessId: peer.awarenessId,
+            clientId,
+            userId: peer.userId,
+            data: peer.data,
+          }),
+        );
+      }
+    }
+
+    await Promise.all(sends).catch((error) => {
+      emitWideEvent("error", {
+        event_type: "presence_maintenance_failed",
+        timestamp: new Date().toISOString(),
+        document_id: this.documentId,
+        session_id: this.id,
+        error,
+      });
+    });
   }
 
   /**
@@ -440,7 +826,9 @@ export class Session<Context extends ServerContext> extends Observable<
     client?: { id: string; send: (m: Message<Context>) => Promise<void> },
     replicationMeta?: { sourceNodeId: string; deduped: boolean },
   ) {
-    if (message.encrypted !== this.encrypted) {
+    // Presence messages are always cleartext metadata (they carry no document
+    // content), so they are exempt from the document's encryption requirement.
+    if (message.type !== "presence" && message.encrypted !== this.encrypted) {
       const error = new Error(
         "Message encryption and document encryption are mismatched",
       );
@@ -800,6 +1188,47 @@ export class Session<Context extends ServerContext> extends Observable<
 
           return;
         }
+        case "presence": {
+          if (message.payload.type === "presence-announce") {
+            // A client announcing its awareness clientID (cleartext). Record it
+            // and notify peers; never relay the announce itself.
+            if (client) {
+              await this.#handlePresenceAnnounce(
+                client,
+                message.payload.awarenessId,
+                message.context,
+              );
+            }
+            return;
+          }
+
+          // presence-join / presence-leave / presence-heartbeat are
+          // server-authored. They only reach apply via pub/sub replication from
+          // another node (client undefined). Update our cross-node roster for
+          // that node and fan join/leave out to this node's clients.
+          if (client) {
+            return;
+          }
+          const sourceNodeId = replicationMeta?.sourceNodeId;
+          if (message.payload.type === "presence-heartbeat") {
+            if (sourceNodeId) {
+              await this.#reconcileRemoteSnapshot(
+                sourceNodeId,
+                message.payload.clients,
+              );
+            }
+            return;
+          }
+          if (sourceNodeId) {
+            if (message.payload.type === "presence-join") {
+              this.#upsertRemoteClient(sourceNodeId, message.payload);
+            } else {
+              this.#removeRemoteClient(sourceNodeId, message.payload.clientId);
+            }
+          }
+          await this.broadcast(message);
+          return;
+        }
         default: {
           await Promise.all([
             this.broadcast(message, client?.id),
@@ -845,6 +1274,7 @@ export class Session<Context extends ServerContext> extends Observable<
     });
 
     this.#cancelCleanup();
+    this.#stopPresenceMaintenance();
 
     try {
       if (this.#unsubscribe) {
@@ -866,6 +1296,9 @@ export class Session<Context extends ServerContext> extends Observable<
       namespacedDocumentId: this.namespacedDocumentId,
       sessionId: this.id,
     });
+
+    this.#clientPresence.clear();
+    this.#remotePresence.clear();
 
     this.destroy();
 
@@ -890,6 +1323,13 @@ export class Session<Context extends ServerContext> extends Observable<
     if (this.#cleanupTimeoutId !== undefined) {
       clearTimeout(this.#cleanupTimeoutId);
       this.#cleanupTimeoutId = undefined;
+    }
+  }
+
+  #stopPresenceMaintenance() {
+    if (this.#presenceTimerId !== undefined) {
+      clearInterval(this.#presenceTimerId);
+      this.#presenceTimerId = undefined;
     }
   }
 

--- a/src/transports/ydoc/index.ts
+++ b/src/transports/ydoc/index.ts
@@ -351,6 +351,11 @@ export function getYDocSink<Context extends ClientContext>({
               // not the Y.doc transport.
               break;
             }
+            case "presence": {
+              // Presence (client join/leave) messages are handled by the
+              // provider, not the Y.doc transport.
+              break;
+            }
             default: {
               // Exhaustive check for message types - all types should be handled above
               const _exhaustive: never = chunk;


### PR DESCRIPTION
When a client disconnects, its awareness state (cursor/selection) is now cleared on remaining peers immediately instead of waiting out the y-protocols ~30s timeout — and crucially this works for end-to-end encrypted documents too, where the server cannot read the awareness payload.

Rather than have the server author awareness tombstones (impossible for e2ee, since the awareness clientID lives inside the ciphertext), this introduces a small cleartext **presence protocol**:

- **Protocol** (`teleportal/protocol`): a `presence` message type with `announce` / `join` / `leave` sub-types plus a node-to-node `heartbeat`. On connect a client announces the awareness clientID it operates under (cleartext, so the server learns it even for encrypted docs); the server broadcasts join/leave to peers; the provider clears a departed peer's awareness locally and emits `peer-join` / `peer-leave`. The integrator `data` bag is serialized with lib0 `writeAny`/`readAny`.

- **Cross-node, crash-safe roster** (`Session`): each node keeps a remote roster keyed by `(nodeId, clientId)`, kept current by pub/sub join/leave and a periodic per-node heartbeat snapshot. A node whose heartbeats stop is TTL-expired and its clients are cleared from peers, so a crashed node never leaves ghost peers behind. Newcomers receive both local and remote peers in their join roster. Heartbeat interval (30s) and TTL (90s) are configurable via `presenceConfig`, and the presence `data` projection is resolved once per client at announce and reused.

- **Encryption fix** (`Server.getOrOpenSession`): cleartext presence messages are exempt from the session encryption-state check, so announcing on an encrypted document no longer tears down the connection.

Tests cover presence wire round-trips (including heartbeats), provider join/leave + awareness clearing for plaintext and encrypted docs, and cross-node roster propagation, heartbeat reconciliation, and TTL expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added peer presence lifecycle events (join/leave) with custom data support
  * Implemented presence heartbeat and cross-node replication
  * Presence messages now bypass in-flight tracking for immediate delivery

* **Tests**
  * Added presence message encoding/decoding test coverage
  * Added provider and session presence event tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
