### PR TITLE
feat: attribution storage, read RPC protocol, and milestone attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ There are several sub-packages built with documentation:
 - [`teleportal/http`](./src/http/README.md) - HTTP handlers
 - [`teleportal/protocol`](./src/lib/protocol/README.md) - Protocol encoding/decoding
 - [`teleportal/protocol/encryption`](./src/lib/protocol/encryption/README.md) - Encryption protocol
+- [`teleportal/protocols/attribution`](./src/protocols/attribution/README.md) - Attribution (authorship) read RPC methods
 - [`teleportal/providers`](./src/providers/README.md) - Provider and connection architecture
 - [`teleportal/transports`](./src/transports/README.md) - Transport middleware
 - [`teleportal/token`](./src/token/README.md) - JWT token utilities

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "./token": "./dist/token/index.mjs",
     "./merkle-tree": "./dist/merkle-tree/index.mjs",
     "./devtools": "./dist/devtools/index.mjs",
-    "./agent": "./dist/agent/index.mjs"
+    "./agent": "./dist/agent/index.mjs",
+    "./attribution": "./dist/lib/attribution/index.mjs"
   },
   "main": "./dist/lib/index.mjs",
   "types": "./dist/lib/index.d.mts",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "./protocol": "./dist/lib/protocol/index.mjs",
     "./protocols/milestone": "./dist/protocols/milestone/index.mjs",
     "./protocols/file": "./dist/protocols/file/index.mjs",
+    "./protocols/attribution": "./dist/protocols/attribution/index.mjs",
     "./protocol/encryption": "./dist/lib/protocol/encryption/index.mjs",
     "./providers": "./dist/providers/index.mjs",
     "./transports/redis": "./dist/transports/redis/index.mjs",

--- a/playground/bun/server.ts
+++ b/playground/bun/server.ts
@@ -6,6 +6,7 @@ import { createStorage } from "unstorage";
 import dbDriver from "unstorage/drivers/db0";
 
 import { importEncryptionKey } from "teleportal/encryption-key";
+import { getAttributionRpcHandlers } from "teleportal/protocols/attribution";
 import { getFileRpcHandlers } from "teleportal/protocols/file";
 import { getMilestoneRpcHandlers } from "teleportal/protocols/milestone";
 import { Server, checkPermissionWithTokenManager } from "teleportal/server";
@@ -109,6 +110,8 @@ const server = new Server<TokenPayload & { clientId: string }>({
   rpcHandlers: {
     ...milestoneHandlers,
     ...fileHandlers,
+    // Read-only attribution queries (authorship timeline + ContentMap).
+    ...getAttributionRpcHandlers(),
   },
   checkPermission: checkPermissionWithTokenManager(tokenManager),
   // pubSub: new RedisPubSub({

--- a/playground/src/components/attributionPanel.tsx
+++ b/playground/src/components/attributionPanel.tsx
@@ -1,0 +1,442 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as Y from "yjs";
+import type { Milestone } from "teleportal";
+import type { Provider } from "teleportal/providers";
+import type { ActivityEntry, ContentMap } from "teleportal/attribution";
+import { resolveRangeAttribution } from "teleportal/protocols/attribution";
+import { colorForUser, getIdentity, setIdentity } from "../utils/identity";
+
+interface AttributionPanelProps {
+  provider: Provider | null;
+  selectedMilestone: Milestone | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface CompositionSlice {
+  userId: string;
+  chars: number;
+}
+
+interface Contribution {
+  userId: string;
+  edits: number;
+}
+
+/** Accumulate, per author, how many characters of `node`'s text they wrote. */
+function walkText(
+  node: Y.XmlText | Y.XmlElement | Y.XmlFragment,
+  map: ContentMap,
+  byUser: Map<string, number>,
+  totals: { total: number },
+) {
+  if (node instanceof Y.XmlText) {
+    const len = node.length;
+    if (len === 0) return;
+    totals.total += len;
+    for (const seg of resolveRangeAttribution(node, 0, len, map)) {
+      const userId = seg.userId ?? "unknown";
+      byUser.set(userId, (byUser.get(userId) ?? 0) + (seg.to - seg.from));
+    }
+    return;
+  }
+  for (const child of node.toArray()) {
+    walkText(child as Y.XmlText | Y.XmlElement, map, byUser, totals);
+  }
+}
+
+/** Collapse an activity timeline into a per-author edit count. */
+function toContributions(activity: ActivityEntry[]): Contribution[] {
+  const counts = new Map<string, number>();
+  for (const entry of activity) {
+    const userId = entry.userId ?? "unknown";
+    counts.set(userId, (counts.get(userId) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([userId, edits]) => ({ userId, edits }))
+    .sort((a, b) => b.edits - a.edits);
+}
+
+function relativeTime(ts: number): string {
+  const delta = Date.now() - ts;
+  if (delta < 60_000) return "just now";
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+  return new Date(ts).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function Avatar({ userId, size = 24 }: { userId: string; size?: number }) {
+  return (
+    <span
+      className="inline-flex items-center justify-center rounded-full text-white font-semibold shrink-0"
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: colorForUser(userId),
+        fontSize: size * 0.45,
+      }}
+      title={userId}
+    >
+      {userId.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+function CompositionBar({
+  slices,
+  total,
+}: {
+  slices: CompositionSlice[];
+  total: number;
+}) {
+  const attributed = slices.reduce((n, s) => n + s.chars, 0);
+  const unattributed = Math.max(0, total - attributed);
+  return (
+    <div className="flex h-3 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+      {slices.map((s) => (
+        <div
+          key={s.userId}
+          style={{
+            width: `${(s.chars / total) * 100}%`,
+            backgroundColor: colorForUser(s.userId),
+          }}
+          title={`${s.userId}: ${s.chars} chars`}
+        />
+      ))}
+      {unattributed > 0 && (
+        <div
+          style={{ width: `${(unattributed / total) * 100}%` }}
+          className="bg-gray-300 dark:bg-gray-600"
+          title={`Unattributed: ${unattributed} chars`}
+        />
+      )}
+    </div>
+  );
+}
+
+function ContributorChips({
+  contributions,
+}: {
+  contributions: Contribution[];
+}) {
+  if (contributions.length === 0) {
+    return (
+      <p className="text-xs text-gray-400 dark:text-gray-500">
+        No attributed edits yet.
+      </p>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {contributions.map((c) => (
+        <span
+          key={c.userId}
+          className="inline-flex items-center gap-1.5 pl-1 pr-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-xs text-gray-700 dark:text-gray-300"
+        >
+          <Avatar userId={c.userId} size={16} />
+          {c.userId}
+          <span className="text-gray-400 dark:text-gray-500">{c.edits}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function AttributionPanel({
+  provider,
+  selectedMilestone,
+  isOpen,
+  onClose,
+}: AttributionPanelProps) {
+  const [composition, setComposition] = useState<CompositionSlice[]>([]);
+  const [totalChars, setTotalChars] = useState(0);
+  const [activity, setActivity] = useState<ActivityEntry[]>([]);
+  const [milestoneContributors, setMilestoneContributors] = useState<
+    Contribution[] | null
+  >(null);
+  const [changeset, setChangeset] = useState<Contribution[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState(false);
+  const identity = getIdentity();
+
+  const refresh = useCallback(async () => {
+    if (!provider) return;
+    setError(null);
+    try {
+      const [map, timeline] = await Promise.all([
+        provider.getAttributionMap(),
+        provider.getActivity(),
+      ]);
+
+      if (map) {
+        const byUser = new Map<string, number>();
+        const totals = { total: 0 };
+        walkText(provider.doc.getXmlFragment("document"), map, byUser, totals);
+        setComposition(
+          [...byUser.entries()]
+            .map(([userId, chars]) => ({ userId, chars }))
+            .sort((a, b) => b.chars - a.chars),
+        );
+        setTotalChars(totals.total);
+      } else {
+        setComposition([]);
+        setTotalChars(0);
+      }
+
+      setActivity([...timeline].sort((a, b) => b.from - a.from));
+    } catch (error_) {
+      setError(
+        error_ instanceof Error ? error_.message : "Failed to load attribution",
+      );
+    }
+  }, [provider]);
+
+  const refreshMilestone = useCallback(async () => {
+    if (!provider || !selectedMilestone) {
+      setMilestoneContributors(null);
+      setChangeset(null);
+      return;
+    }
+    try {
+      const here = await provider.getMilestoneActivity(selectedMilestone.id);
+      setMilestoneContributors(toContributions(here));
+
+      // Compare against the milestone created immediately before this one.
+      const all = (await provider.listMilestones()).sort(
+        (a, b) => a.createdAt - b.createdAt,
+      );
+      const idx = all.findIndex((m) => m.id === selectedMilestone.id);
+      const prev = idx > 0 ? all[idx - 1] : null;
+      if (prev) {
+        const delta = await provider.getChangesetActivity(
+          prev.id,
+          selectedMilestone.id,
+        );
+        setChangeset(toContributions(delta));
+      } else {
+        setChangeset(null);
+      }
+    } catch (error_) {
+      setError(
+        error_ instanceof Error ? error_.message : "Failed to load milestone",
+      );
+    }
+  }, [provider, selectedMilestone]);
+
+  // Refresh on open, and live-update (debounced) as the document changes.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (!isOpen || !provider) return;
+    refresh();
+    refreshMilestone();
+
+    const onUpdate = () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        refresh();
+      }, 1200);
+    };
+    provider.doc.on("updateV2", onUpdate);
+    return () => {
+      provider.doc.off("updateV2", onUpdate);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [isOpen, provider, refresh, refreshMilestone]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="w-80 flex-shrink-0 bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800 flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center h-16 px-4 border-b border-gray-200 dark:border-gray-800 shrink-0">
+        <button
+          onClick={onClose}
+          className="p-2 mr-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+          aria-label="Close authorship panel"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+        <div className="flex-1">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Authorship
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Who wrote what
+          </p>
+        </div>
+        <button
+          onClick={refresh}
+          className="p-2 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+          aria-label="Refresh"
+          title="Refresh"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* You are */}
+      <div className="mx-4 mt-4 p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700 shrink-0">
+        {editingName ? (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const value = new FormData(e.currentTarget).get("name") as string;
+              setIdentity(value);
+              globalThis.location.reload();
+            }}
+            className="flex items-center gap-2"
+          >
+            <input
+              name="name"
+              defaultValue={identity.name}
+              autoFocus
+              className="flex-1 min-w-0 px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded dark:bg-gray-800 dark:text-white"
+            />
+            <button
+              type="submit"
+              className="px-2 py-1 text-xs font-medium text-white bg-blue-600 hover:bg-blue-700 rounded"
+            >
+              Switch
+            </button>
+          </form>
+        ) : (
+          <div className="flex items-center gap-2">
+            <Avatar userId={identity.name} size={28} />
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                You are
+              </p>
+              <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+                {identity.name}
+              </p>
+            </div>
+            <button
+              onClick={() => setEditingName(true)}
+              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Switch user
+            </button>
+          </div>
+        )}
+        <p className="mt-2 text-[11px] leading-snug text-gray-400 dark:text-gray-500">
+          Open a second tab and switch the name to collaborate as another
+          author.
+        </p>
+      </div>
+
+      {error && (
+        <div className="mx-4 mt-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg shrink-0">
+          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-6">
+        {/* Composition */}
+        <section>
+          <h3 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
+            Document composition
+          </h3>
+          {totalChars === 0 ? (
+            <p className="text-xs text-gray-400 dark:text-gray-500">
+              Start typing to see authorship appear here.
+            </p>
+          ) : (
+            <>
+              <CompositionBar slices={composition} total={totalChars} />
+              <div className="mt-3 space-y-1.5">
+                {composition.map((s) => (
+                  <div
+                    key={s.userId}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    <Avatar userId={s.userId} size={18} />
+                    <span className="flex-1 truncate text-gray-700 dark:text-gray-300">
+                      {s.userId}
+                    </span>
+                    <span className="text-gray-500 dark:text-gray-400 tabular-nums">
+                      {Math.round((s.chars / totalChars) * 100)}%
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </section>
+
+        {/* Milestone-scoped */}
+        {selectedMilestone && (
+          <section className="p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+            <h3 className="text-xs font-medium text-amber-800 dark:text-amber-300 uppercase tracking-wider mb-2">
+              {selectedMilestone.name || "Selected version"}
+            </h3>
+            <p className="text-[11px] text-amber-700/80 dark:text-amber-300/70 mb-1">
+              Contributors to this version
+            </p>
+            <ContributorChips contributions={milestoneContributors ?? []} />
+            {changeset && (
+              <>
+                <p className="text-[11px] text-amber-700/80 dark:text-amber-300/70 mt-3 mb-1">
+                  Changes since the previous version
+                </p>
+                <ContributorChips contributions={changeset} />
+              </>
+            )}
+          </section>
+        )}
+
+        {/* Activity timeline */}
+        <section>
+          <h3 className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
+            Recent activity
+          </h3>
+          {activity.length === 0 ? (
+            <p className="text-xs text-gray-400 dark:text-gray-500">
+              No activity recorded yet.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {activity.slice(0, 40).map((entry, i) => (
+                <div key={i} className="flex items-center gap-2.5">
+                  <Avatar userId={entry.userId ?? "unknown"} size={22} />
+                  <span className="flex-1 truncate text-sm text-gray-700 dark:text-gray-300">
+                    {entry.userId ?? "unknown"} edited
+                  </span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
+                    {relativeTime(entry.from)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/playground/src/components/documentEditor.tsx
+++ b/playground/src/components/documentEditor.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, Suspense } from "react";
 import { Editor } from "./editor";
-import { Document, fileService } from "../services/fileService";
+import { fileService } from "../services/fileService";
 import { useProvider } from "../utils/providers";
 import { MilestonePanel } from "./milestonePanel";
+import { AttributionPanel } from "./attributionPanel";
+import { getIdentity } from "../utils/identity";
 import { Milestone } from "teleportal";
 
 interface DocumentEditorProps {
@@ -21,9 +23,11 @@ export function DocumentEditor({
   const [, forceUpdate] = useState<number>(0);
   const { provider } = useProvider(document?.id, document?.encryptedKey);
   const [isMilestonePanelOpen, setIsMilestonePanelOpen] = useState(false);
+  const [isAttributionPanelOpen, setIsAttributionPanelOpen] = useState(false);
   const [selectedMilestone, setSelectedMilestone] = useState<Milestone | null>(
     null,
   );
+  const identity = getIdentity();
 
   useEffect(() => {
     const unsubscribe = fileService.on("documents", () => {
@@ -38,6 +42,7 @@ export function DocumentEditor({
   useEffect(() => {
     setSelectedMilestone(null);
     setIsMilestonePanelOpen(false);
+    setIsAttributionPanelOpen(false);
   }, [documentId]);
 
   if (!documentId || !document) {
@@ -126,8 +131,32 @@ export function DocumentEditor({
                 </svg>
               )}
             </div>
-            {/* Versions button - pushed to the right */}
-            <div className="flex items-center ml-auto shrink-0">
+            {/* Versions + Authorship buttons - pushed to the right */}
+            <div className="flex items-center ml-auto shrink-0 gap-2">
+              <button
+                onClick={() => setIsAttributionPanelOpen((v) => !v)}
+                className={`px-3 py-2 text-sm font-medium border rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap ${
+                  isAttributionPanelOpen
+                    ? "text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700"
+                    : "text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+                }`}
+                title="See who wrote what"
+              >
+                <svg
+                  className="w-4 h-4 shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-1.13a4 4 0 10-4-4 4 4 0 004 4zm6 0a4 4 0 10-3-6.65"
+                  />
+                </svg>
+                <span className="hidden md:inline">Authorship</span>
+              </button>
               <button
                 onClick={() => setIsMilestonePanelOpen(true)}
                 className="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"
@@ -175,12 +204,21 @@ export function DocumentEditor({
                 <Editor
                   selectedMilestone={selectedMilestone}
                   provider={provider}
+                  user={identity}
                   key={provider.doc.clientID}
                 />
               </Suspense>
             )}
           </div>
         </div>
+
+        {/* Authorship Panel - pushes content instead of overlaying */}
+        <AttributionPanel
+          provider={provider}
+          selectedMilestone={selectedMilestone}
+          isOpen={isAttributionPanelOpen}
+          onClose={() => setIsAttributionPanelOpen(false)}
+        />
 
         {/* Milestone Panel - pushes content instead of overlaying */}
         <MilestonePanel

--- a/playground/src/utils/identity.ts
+++ b/playground/src/utils/identity.ts
@@ -1,0 +1,73 @@
+/**
+ * Per-tab user identity for the attribution demo.
+ *
+ * Stored in sessionStorage (not localStorage) so that two tabs in the same
+ * browser can act as two different authors — open a second tab, change the
+ * name, and edits from each tab are attributed to a distinct user.
+ */
+
+const KEY = "teleportal-identity";
+
+const ADJECTIVES = [
+  "Swift",
+  "Curious",
+  "Bold",
+  "Calm",
+  "Bright",
+  "Keen",
+  "Quiet",
+  "Lucky",
+];
+const ANIMALS = [
+  "Otter",
+  "Falcon",
+  "Fox",
+  "Heron",
+  "Lynx",
+  "Wren",
+  "Bear",
+  "Moth",
+];
+
+function randomName(): string {
+  // Avoid Math.random bias concerns — this is purely cosmetic demo identity.
+  const a = ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)];
+  const b = ANIMALS[Math.floor(Math.random() * ANIMALS.length)];
+  return `${a} ${b}`;
+}
+
+/**
+ * A stable, vivid color for any user id, so every client renders the same
+ * author in the same color across the timeline, cursors, and composition bar.
+ */
+export function colorForUser(userId: string): string {
+  let hue = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hue = (hue * 31 + userId.charCodeAt(i)) % 360;
+  }
+  return `hsl(${hue}, 70%, 50%)`;
+}
+
+export interface Identity {
+  name: string;
+  color: string;
+}
+
+export function getIdentity(): Identity {
+  let name = sessionStorage.getItem(KEY);
+  if (!name) {
+    name = randomName();
+    sessionStorage.setItem(KEY, name);
+  }
+  return { name, color: colorForUser(name) };
+}
+
+/**
+ * Update this tab's identity. The active connection is tied to the identity's
+ * token, so the caller is expected to reload to reconnect as the new user.
+ */
+export function setIdentity(name: string): Identity {
+  const trimmed = name.trim() || randomName();
+  sessionStorage.setItem(KEY, trimmed);
+  return { name: trimmed, color: colorForUser(trimmed) };
+}

--- a/playground/src/utils/providers.tsx
+++ b/playground/src/utils/providers.tsx
@@ -12,6 +12,7 @@ import { getFileClientHandlers } from "teleportal/protocols/file";
 import { getEncryptedTransport } from "./encrypted";
 import { ClientContext, Transport } from "teleportal";
 import { EncryptionClient } from "../../../src/transports/encrypted/client";
+import { getIdentity } from "./identity";
 
 const tokenManager = createTokenManager({
   secret: "your-secret-key-here", // In production, use a strong secret
@@ -44,7 +45,9 @@ class ProviderManager {
     if (!this.websocketConnection) {
       this.websocketConnection = tokenManager
         .createToken(
-          "nick",
+          // The token subject becomes the authenticated userId, which the server
+          // records as the author of every edit from this tab.
+          getIdentity().name,
           "docs",
           // TODO probably make token gen configurable callback
           new DocumentAccessBuilder()

--- a/src/devtools/utils/message-utils.ts
+++ b/src/devtools/utils/message-utils.ts
@@ -6,6 +6,11 @@ import {
   type Message,
   type RawReceivedMessage,
 } from "teleportal";
+import {
+  type ContentMap,
+  type IdMap,
+  decodeContentMap,
+} from "teleportal/attribution";
 import { decryptUpdate } from "teleportal/encryption-key";
 import {
   decodeEncryptedUpdate,
@@ -13,6 +18,7 @@ import {
   decodeFromSyncStep2,
 } from "teleportal/protocol/encryption";
 import { Provider } from "teleportal/providers";
+import type { EncodedContentMap } from "teleportal/storage";
 import * as Y from "yjs";
 
 export type MessageType = Message | RawReceivedMessage;
@@ -102,6 +108,50 @@ function itemToJSON(item: Y.Item): Record<any, any> {
     keep: item.keep,
     lastId: item.lastId,
   };
+}
+
+function idMapToJSON(idMap: IdMap): Record<string, unknown[]> {
+  const result: Record<string, unknown[]> = {};
+  for (const [client, ranges] of idMap.clients.entries()) {
+    result[String(client)] = ranges.getIds().map((range) => ({
+      clock: range.clock,
+      len: range.len,
+      attrs: Object.fromEntries(range.attrs.map((a) => [a.name, a.val])),
+    }));
+  }
+  return result;
+}
+
+function contentMapToJSON(contentMap: ContentMap) {
+  return {
+    inserts: idMapToJSON(contentMap.inserts),
+    deletes: idMapToJSON(contentMap.deletes),
+  };
+}
+
+function formatRpcPayload(
+  message: MessageType & { type: "rpc" },
+): unknown {
+  const { payload } = message;
+
+  if (payload.type === "error") return payload;
+
+  if (
+    message.rpcMethod === "attributionGet" &&
+    message.requestType === "response"
+  ) {
+    const data = payload.payload as { contentMap: EncodedContentMap | null };
+    if (!data.contentMap) return { ...payload, payload: { contentMap: null } };
+
+    try {
+      const decoded = decodeContentMap(data.contentMap);
+      return { ...payload, payload: { contentMap: contentMapToJSON(decoded) } };
+    } catch {
+      return { ...payload, payload: { contentMap: toBase64(data.contentMap) } };
+    }
+  }
+
+  return payload;
 }
 
 export async function formatMessagePayload(
@@ -330,7 +380,11 @@ export async function formatMessagePayload(
       }
     }
     case "rpc": {
-      return JSON.stringify(message.payload, null, 2);
+      return JSON.stringify(
+        formatRpcPayload(message),
+        null,
+        2,
+      );
     }
     default: {
       // @ts-expect-error - this should be unreachable due to type checking

--- a/src/lib/attribution/attribution.test.ts
+++ b/src/lib/attribution/attribution.test.ts
@@ -1,0 +1,392 @@
+import { describe, expect, it } from "bun:test";
+import * as Y from "yjs";
+import {
+  ContentAttribute,
+  IdSet,
+  createContentAttribute,
+  createContentIds,
+  createContentIdsFromUpdate,
+  createContentMapFromContentIds,
+  decodeContentIds,
+  decodeContentMap,
+  encodeContentIds,
+  encodeContentMap,
+  excludeContentIds,
+  excludeContentMap,
+  filterContentMap,
+  getActivity,
+  intersectContentIds,
+  mergeContentIds,
+  mergeContentMaps,
+  resolveItemAttribution,
+} from "./index";
+
+describe("IdSet", () => {
+  it("adds and retrieves ranges", () => {
+    const set = new IdSet();
+    set.add(1, 0, 5);
+    set.add(1, 5, 3);
+    set.add(2, 0, 10);
+
+    expect(set.has(1, 0)).toBe(true);
+    expect(set.has(1, 4)).toBe(true);
+    expect(set.has(1, 7)).toBe(true);
+    expect(set.has(1, 8)).toBe(false);
+    expect(set.has(2, 9)).toBe(true);
+    expect(set.has(3, 0)).toBe(false);
+  });
+
+  it("merges adjacent ranges from same client", () => {
+    const set = new IdSet();
+    set.add(1, 0, 5);
+    set.add(1, 5, 5);
+
+    const ranges = set.clients.get(1)!.getIds();
+    expect(ranges.length).toBe(1);
+    expect(ranges[0].clock).toBe(0);
+    expect(ranges[0].len).toBe(10);
+  });
+
+  it("slices correctly", () => {
+    const set = new IdSet();
+    set.add(1, 5, 10); // clock 5-14
+
+    const slices = set.slice(1, 3, 15);
+    expect(slices.length).toBe(3);
+    expect(slices[0]).toEqual({ clock: 3, len: 2, exists: false });
+    expect(slices[1]).toEqual({ clock: 5, len: 10, exists: true });
+    expect(slices[2]).toEqual({ clock: 15, len: 3, exists: false });
+  });
+
+  it("handles delete", () => {
+    const set = new IdSet();
+    set.add(1, 0, 10);
+    set.delete(1, 3, 4); // remove 3-6
+
+    expect(set.has(1, 2)).toBe(true);
+    expect(set.has(1, 3)).toBe(false);
+    expect(set.has(1, 6)).toBe(false);
+    expect(set.has(1, 7)).toBe(true);
+  });
+});
+
+describe("ContentIds", () => {
+  it("merges content IDs", () => {
+    const a = createContentIds();
+    a.inserts.add(1, 0, 5);
+    const b = createContentIds();
+    b.inserts.add(1, 5, 5);
+    b.inserts.add(2, 0, 3);
+
+    const merged = mergeContentIds([a, b]);
+    expect(merged.inserts.has(1, 0)).toBe(true);
+    expect(merged.inserts.has(1, 9)).toBe(true);
+    expect(merged.inserts.has(2, 2)).toBe(true);
+  });
+
+  it("excludes content IDs", () => {
+    const a = createContentIds();
+    a.inserts.add(1, 0, 10);
+    const b = createContentIds();
+    b.inserts.add(1, 3, 4);
+
+    const diff = excludeContentIds(a, b);
+    expect(diff.inserts.has(1, 2)).toBe(true);
+    expect(diff.inserts.has(1, 3)).toBe(false);
+    expect(diff.inserts.has(1, 7)).toBe(true);
+  });
+
+  it("intersects content IDs", () => {
+    const a = createContentIds();
+    a.inserts.add(1, 0, 10);
+    const b = createContentIds();
+    b.inserts.add(1, 5, 10);
+
+    const result = intersectContentIds(a, b);
+    expect(result.inserts.has(1, 4)).toBe(false);
+    expect(result.inserts.has(1, 5)).toBe(true);
+    expect(result.inserts.has(1, 9)).toBe(true);
+    expect(result.inserts.has(1, 10)).toBe(false);
+  });
+});
+
+describe("createContentIdsFromUpdate", () => {
+  it("extracts insert ranges from a Y.js update", () => {
+    const doc = new Y.Doc();
+    doc.getText("test").insert(0, "hello world");
+    const update = Y.encodeStateAsUpdateV2(doc);
+
+    const ids = createContentIdsFromUpdate(update);
+    const clientID = doc.clientID;
+
+    expect(ids.inserts.has(clientID, 0)).toBe(true);
+    expect(ids.inserts.has(clientID, 10)).toBe(true);
+    expect(ids.inserts.has(clientID, 11)).toBe(false);
+    expect(ids.deletes.isEmpty()).toBe(true);
+  });
+
+  it("extracts delete set from a Y.js update", () => {
+    const doc = new Y.Doc();
+    doc.getText("test").insert(0, "hello");
+    doc.getText("test").delete(0, 3);
+    const update = Y.encodeStateAsUpdateV2(doc);
+
+    const ids = createContentIdsFromUpdate(update);
+    expect(ids.deletes.has(doc.clientID, 0)).toBe(true);
+    expect(ids.deletes.has(doc.clientID, 2)).toBe(true);
+    expect(ids.deletes.has(doc.clientID, 3)).toBe(false);
+  });
+
+  it("handles multi-client updates", () => {
+    const doc1 = new Y.Doc();
+    const doc2 = new Y.Doc();
+    doc1.getText("t").insert(0, "aaa");
+    Y.applyUpdateV2(doc2, Y.encodeStateAsUpdateV2(doc1));
+    doc2.getText("t").insert(3, "bbb");
+    Y.applyUpdateV2(doc1, Y.encodeStateAsUpdateV2(doc2));
+
+    const update = Y.encodeStateAsUpdateV2(doc1);
+    const ids = createContentIdsFromUpdate(update);
+
+    expect(ids.inserts.has(doc1.clientID, 0)).toBe(true);
+    expect(ids.inserts.has(doc1.clientID, 2)).toBe(true);
+    expect(ids.inserts.has(doc2.clientID, 0)).toBe(true);
+    expect(ids.inserts.has(doc2.clientID, 2)).toBe(true);
+  });
+});
+
+describe("ContentMap", () => {
+  it("creates content map from content IDs with attribution", () => {
+    const ids = createContentIds();
+    ids.inserts.add(1, 0, 5);
+    ids.deletes.add(1, 10, 3);
+
+    const map = createContentMapFromContentIds(
+      ids,
+      [
+        createContentAttribute("insert", "user-1"),
+        createContentAttribute("insertAt", 1_000_000),
+      ],
+      [
+        createContentAttribute("delete", "user-1"),
+        createContentAttribute("deleteAt", 1_000_000),
+      ],
+    );
+
+    expect(map.inserts.has(1, 0)).toBe(true);
+    expect(map.deletes.has(1, 10)).toBe(true);
+
+    const insertSlice = map.inserts.slice(1, 0, 5);
+    expect(insertSlice.length).toBe(1);
+    expect(insertSlice[0].attrs).toBeDefined();
+    expect(insertSlice[0].attrs!.length).toBe(2);
+    expect(insertSlice[0].attrs![0].name).toBe("insert");
+    expect(insertSlice[0].attrs![0].val).toBe("user-1");
+  });
+
+  it("merges multiple content maps", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(1, 5, 5);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-2"),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+    expect(merged.inserts.has(1, 0)).toBe(true);
+    expect(merged.inserts.has(1, 9)).toBe(true);
+  });
+
+  it("filters content map by predicate", () => {
+    const ids = createContentIds();
+    ids.inserts.add(1, 0, 5);
+    ids.inserts.add(2, 0, 5);
+    const map1 = createContentMapFromContentIds(
+      { inserts: (() => { const s = new IdSet(); s.add(1, 0, 5); return s; })(), deletes: new IdSet() },
+      [createContentAttribute("insert", "user-1")],
+    );
+    const map2 = createContentMapFromContentIds(
+      { inserts: (() => { const s = new IdSet(); s.add(2, 0, 5); return s; })(), deletes: new IdSet() },
+      [createContentAttribute("insert", "user-2")],
+    );
+
+    const merged = mergeContentMaps([map1, map2]);
+    const filtered = filterContentMap(merged, (attrs) =>
+      attrs.some((a) => a.name === "insert" && a.val === "user-1"),
+    );
+
+    expect(filtered.inserts.has(1, 0)).toBe(true);
+    expect(filtered.inserts.clients.has(2)).toBe(false);
+  });
+
+  it("excludes content map by content IDs", () => {
+    const ids = createContentIds();
+    ids.inserts.add(1, 0, 10);
+    const map = createContentMapFromContentIds(ids, [
+      createContentAttribute("insert", "user-1"),
+    ]);
+
+    const exclude = createContentIds();
+    exclude.inserts.add(1, 3, 4);
+
+    const result = excludeContentMap(map, exclude);
+    expect(result.inserts.has(1, 2)).toBe(true);
+    expect(result.inserts.has(1, 3)).toBe(false);
+    expect(result.inserts.has(1, 7)).toBe(true);
+  });
+});
+
+describe("encoding round-trip", () => {
+  it("encodes and decodes ContentIds", () => {
+    const ids = createContentIds();
+    ids.inserts.add(1, 0, 5);
+    ids.inserts.add(1, 10, 3);
+    ids.inserts.add(2, 0, 7);
+    ids.deletes.add(1, 20, 2);
+
+    const encoded = encodeContentIds(ids);
+    const decoded = decodeContentIds(encoded);
+
+    expect(decoded.inserts.has(1, 0)).toBe(true);
+    expect(decoded.inserts.has(1, 4)).toBe(true);
+    expect(decoded.inserts.has(1, 5)).toBe(false);
+    expect(decoded.inserts.has(1, 10)).toBe(true);
+    expect(decoded.inserts.has(2, 6)).toBe(true);
+    expect(decoded.deletes.has(1, 20)).toBe(true);
+    expect(decoded.deletes.has(1, 21)).toBe(true);
+    expect(decoded.deletes.has(1, 22)).toBe(false);
+  });
+
+  it("encodes and decodes ContentMap with attributes", () => {
+    const ids = createContentIds();
+    ids.inserts.add(42, 0, 10);
+    ids.deletes.add(42, 100, 5);
+
+    const map = createContentMapFromContentIds(
+      ids,
+      [
+        createContentAttribute("insert", "user-abc"),
+        createContentAttribute("insertAt", 1_700_000_000),
+      ],
+      [
+        createContentAttribute("delete", "user-abc"),
+        createContentAttribute("deleteAt", 1_700_000_000),
+      ],
+    );
+
+    const encoded = encodeContentMap(map);
+    const decoded = decodeContentMap(encoded);
+
+    expect(decoded.inserts.has(42, 0)).toBe(true);
+    expect(decoded.inserts.has(42, 9)).toBe(true);
+    expect(decoded.deletes.has(42, 100)).toBe(true);
+
+    const insertSlice = decoded.inserts.slice(42, 0, 10);
+    expect(insertSlice.length).toBe(1);
+    expect(insertSlice[0].attrs!.length).toBe(2);
+    expect(insertSlice[0].attrs![0].name).toBe("insert");
+    expect(insertSlice[0].attrs![0].val).toBe("user-abc");
+    expect(insertSlice[0].attrs![1].name).toBe("insertAt");
+    expect(insertSlice[0].attrs![1].val).toBe(1_700_000_000);
+  });
+
+  it("handles empty ContentIds", () => {
+    const ids = createContentIds();
+    const encoded = encodeContentIds(ids);
+    const decoded = decodeContentIds(encoded);
+    expect(decoded.inserts.isEmpty()).toBe(true);
+    expect(decoded.deletes.isEmpty()).toBe(true);
+  });
+});
+
+describe("queries", () => {
+  it("resolves item attribution", () => {
+    const ids = createContentIds();
+    ids.inserts.add(42, 0, 10);
+
+    const map = createContentMapFromContentIds(ids, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1_700_000_000),
+    ]);
+
+    const result = resolveItemAttribution(map, 42, 5);
+    expect(result).toEqual({ userId: "user-1", timestamp: 1_700_000_000 });
+
+    expect(resolveItemAttribution(map, 42, 10)).toBeNull();
+    expect(resolveItemAttribution(map, 99, 0)).toBeNull();
+  });
+
+  it("gets activity timeline", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-2"),
+      createContentAttribute("insertAt", 2000),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+    const activity = getActivity(merged);
+
+    expect(activity.length).toBe(2);
+    expect(activity[0].userId).toBe("user-1");
+    expect(activity[0].from).toBe(1000);
+    expect(activity[1].userId).toBe("user-2");
+    expect(activity[1].from).toBe(2000);
+  });
+
+  it("filters activity by userId", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-2"),
+      createContentAttribute("insertAt", 2000),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+    const activity = getActivity(merged, { userId: "user-1" });
+
+    expect(activity.length).toBe(1);
+    expect(activity[0].userId).toBe("user-1");
+  });
+
+  it("filters activity by time range", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-2"),
+      createContentAttribute("insertAt", 2000),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+    const activity = getActivity(merged, { from: 1500, to: 2500 });
+
+    expect(activity.length).toBe(1);
+    expect(activity[0].userId).toBe("user-2");
+  });
+});

--- a/src/lib/attribution/content-ids.ts
+++ b/src/lib/attribution/content-ids.ts
@@ -1,0 +1,291 @@
+/**
+ * IdSet and ContentIds — reimplemented from Y.js v14 (src/utils/ids.js).
+ *
+ * An IdSet is a compact representation of Y.js CRDT operation IDs.
+ * Each operation in Y.js has a unique ID = (clientID, clock).
+ * An IdSet stores ranges of (clientID, clock, length) per client,
+ * representing contiguous runs of operations.
+ *
+ * ContentIds = { inserts: IdSet, deletes: IdSet } — the full set of
+ * operations in a Y.js update, split by insert vs delete.
+ */
+
+export class IdRange {
+  constructor(
+    public clock: number,
+    public len: number,
+  ) {}
+}
+
+export class IdRanges {
+  private _ids: IdRange[];
+  private _sorted = false;
+
+  constructor(ids: IdRange[] = []) {
+    this._ids = ids;
+    this._sorted = ids.length <= 1;
+  }
+
+  add(clock: number, length: number) {
+    const ids = this._ids;
+    if (ids.length > 0) {
+      const last = ids.at(-1)!;
+      if (last.clock + last.len === clock) {
+        last.len += length;
+        return;
+      }
+    }
+    ids.push(new IdRange(clock, length));
+    this._sorted = false;
+  }
+
+  getIds(): IdRange[] {
+    if (!this._sorted) {
+      this._ids.sort((a, b) => a.clock - b.clock);
+      const merged: IdRange[] = [];
+      for (const range of this._ids) {
+        if (merged.length > 0) {
+          const last = merged.at(-1)!;
+          if (last.clock + last.len >= range.clock) {
+            last.len = Math.max(last.len, range.clock + range.len - last.clock);
+            continue;
+          }
+        }
+        merged.push(new IdRange(range.clock, range.len));
+      }
+      this._ids = merged;
+      this._sorted = true;
+    }
+    return this._ids;
+  }
+
+  copy(): IdRanges {
+    return new IdRanges(
+      this.getIds().map((r) => new IdRange(r.clock, r.len)),
+    );
+  }
+}
+
+/**
+ * Binary search for the index of the range containing `clock`,
+ * or the insertion point if not found.
+ */
+function findIndexInIdRanges(ids: IdRange[], clock: number): number {
+  let lo = 0;
+  let hi = ids.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    const range = ids[mid];
+    if (clock < range.clock) {
+      hi = mid - 1;
+    } else if (clock >= range.clock + range.len) {
+      lo = mid + 1;
+    } else {
+      return mid;
+    }
+  }
+  return -1;
+}
+
+export interface MaybeIdRange {
+  clock: number;
+  len: number;
+  exists: boolean;
+}
+
+export class IdSet {
+  clients: Map<number, IdRanges> = new Map();
+
+  isEmpty(): boolean {
+    if (this.clients.size === 0) return true;
+    for (const ranges of this.clients.values()) {
+      if (ranges.getIds().length > 0) return false;
+    }
+    return true;
+  }
+
+  add(client: number, clock: number, len: number) {
+    let ranges = this.clients.get(client);
+    if (!ranges) {
+      ranges = new IdRanges();
+      this.clients.set(client, ranges);
+    }
+    ranges.add(clock, len);
+  }
+
+  has(client: number, clock: number): boolean {
+    const ranges = this.clients.get(client);
+    if (!ranges) return false;
+    return findIndexInIdRanges(ranges.getIds(), clock) >= 0;
+  }
+
+  /**
+   * Returns which portions of [clock, clock+len) exist in this set.
+   * Each MaybeIdRange indicates a sub-range and whether it exists.
+   */
+  slice(client: number, clock: number, len: number): MaybeIdRange[] {
+    const ranges = this.clients.get(client);
+    if (!ranges) {
+      return [{ clock, len, exists: false }];
+    }
+    const ids = ranges.getIds();
+    const result: MaybeIdRange[] = [];
+    let pos = clock;
+    const end = clock + len;
+
+    for (const range of ids) {
+      if (range.clock >= end) break;
+      const rangeEnd = range.clock + range.len;
+      if (rangeEnd <= pos) continue;
+
+      // Gap before this range
+      if (pos < range.clock) {
+        const gapEnd = Math.min(range.clock, end);
+        result.push({ clock: pos, len: gapEnd - pos, exists: false });
+        pos = gapEnd;
+      }
+
+      // Overlap with this range
+      if (pos < end && pos < rangeEnd) {
+        const overlapEnd = Math.min(rangeEnd, end);
+        result.push({ clock: pos, len: overlapEnd - pos, exists: true });
+        pos = overlapEnd;
+      }
+    }
+
+    // Trailing gap
+    if (pos < end) {
+      result.push({ clock: pos, len: end - pos, exists: false });
+    }
+
+    return result;
+  }
+
+  forEach(f: (client: number, clock: number, len: number) => void) {
+    for (const [client, ranges] of this.clients.entries()) {
+      for (const range of ranges.getIds()) {
+        f(client, range.clock, range.len);
+      }
+    }
+  }
+
+  delete(client: number, clock: number, len: number) {
+    const ranges = this.clients.get(client);
+    if (!ranges) return;
+    deleteRangeFromRanges(ranges, clock, len);
+  }
+}
+
+function deleteRangeFromRanges(ranges: IdRanges, clock: number, len: number) {
+  const ids = ranges.getIds();
+  const end = clock + len;
+  const newIds: IdRange[] = [];
+
+  for (const range of ids) {
+    const rangeEnd = range.clock + range.len;
+    if (rangeEnd <= clock || range.clock >= end) {
+      // No overlap
+      newIds.push(range);
+    } else {
+      // Left remainder
+      if (range.clock < clock) {
+        newIds.push(new IdRange(range.clock, clock - range.clock));
+      }
+      // Right remainder
+      if (rangeEnd > end) {
+        newIds.push(new IdRange(end, rangeEnd - end));
+      }
+    }
+  }
+
+  // Replace the internal array (rebuild IdRanges)
+  const replacement = new IdRanges(newIds);
+  replacement.getIds(); // ensure sorted
+  // Copy back
+  Object.assign(ranges, replacement);
+}
+
+// --- Set operations ---
+
+export function mergeIdSets(sets: IdSet[]): IdSet {
+  const merged = new IdSet();
+  for (const set of sets) {
+    for (const [client, ranges] of set.clients.entries()) {
+      for (const range of ranges.getIds()) {
+        merged.add(client, range.clock, range.len);
+      }
+    }
+  }
+  return merged;
+}
+
+export function diffIdSet(set: IdSet, exclude: IdSet): IdSet {
+  const result = new IdSet();
+  for (const [client, ranges] of set.clients.entries()) {
+    for (const range of ranges.getIds()) {
+      const slices = exclude.slice(client, range.clock, range.len);
+      for (const s of slices) {
+        if (!s.exists) {
+          result.add(client, s.clock, s.len);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+export function intersectIdSets(a: IdSet, b: IdSet): IdSet {
+  const result = new IdSet();
+  for (const [client, ranges] of a.clients.entries()) {
+    for (const range of ranges.getIds()) {
+      const slices = b.slice(client, range.clock, range.len);
+      for (const s of slices) {
+        if (s.exists) {
+          result.add(client, s.clock, s.len);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+// --- ContentIds ---
+
+export interface ContentIds {
+  inserts: IdSet;
+  deletes: IdSet;
+}
+
+export function createContentIds(
+  inserts?: IdSet,
+  deletes?: IdSet,
+): ContentIds {
+  return {
+    inserts: inserts ?? new IdSet(),
+    deletes: deletes ?? new IdSet(),
+  };
+}
+
+export function mergeContentIds(ids: ContentIds[]): ContentIds {
+  return {
+    inserts: mergeIdSets(ids.map((c) => c.inserts)),
+    deletes: mergeIdSets(ids.map((c) => c.deletes)),
+  };
+}
+
+export function excludeContentIds(
+  content: ContentIds,
+  exclude: ContentIds,
+): ContentIds {
+  return {
+    inserts: diffIdSet(content.inserts, exclude.inserts),
+    deletes: diffIdSet(content.deletes, exclude.deletes),
+  };
+}
+
+export function intersectContentIds(a: ContentIds, b: ContentIds): ContentIds {
+  return {
+    inserts: intersectIdSets(a.inserts, b.inserts),
+    deletes: intersectIdSets(a.deletes, b.deletes),
+  };
+}

--- a/src/lib/attribution/content-map.ts
+++ b/src/lib/attribution/content-map.ts
@@ -1,0 +1,373 @@
+/**
+ * ContentMap and related types — reimplemented from Y.js v14 (src/utils/meta.js + ids.js).
+ *
+ * A ContentMap maps CRDT operation ID ranges to attribution metadata (ContentAttributes).
+ * It extends the IdSet concept (from content-ids.ts) by attaching attributes to each range.
+ *
+ * Example: ContentMap saying "user-123 inserted items (client=42, clock=0..10) at timestamp 1700000000":
+ *   inserts: IdMap { 42 → [{clock: 0, len: 10, attrs: [{name: "insert", val: "user-123"}, {name: "insertAt", val: 1700000000}]}] }
+ */
+
+import {
+  type ContentIds,
+  type IdRange,
+  IdRanges,
+  IdSet,
+  type MaybeIdRange,
+} from "./content-ids";
+
+// --- ContentAttribute ---
+
+export class ContentAttribute<V = unknown> {
+  constructor(
+    public name: string,
+    public val: V,
+  ) {}
+}
+
+export function createContentAttribute<V>(
+  name: string,
+  val: V,
+): ContentAttribute<V> {
+  return new ContentAttribute(name, val);
+}
+
+// --- AttrRange ---
+
+export class AttrRange {
+  constructor(
+    public clock: number,
+    public len: number,
+    public attrs: ContentAttribute[],
+  ) {}
+
+  copyWith(clock: number, len: number): AttrRange {
+    return new AttrRange(clock, len, this.attrs);
+  }
+}
+
+export interface MaybeAttrRange {
+  clock: number;
+  len: number;
+  attrs?: ContentAttribute[];
+}
+
+// --- AttrRanges ---
+
+export class AttrRanges {
+  private _ids: AttrRange[];
+  private _sorted = false;
+
+  constructor(ids: AttrRange[] = []) {
+    this._ids = ids;
+    this._sorted = ids.length <= 1;
+  }
+
+  add(clock: number, length: number, attrs: ContentAttribute[]) {
+    const ids = this._ids;
+    if (ids.length > 0) {
+      const last = ids.at(-1)!;
+      if (last.clock + last.len === clock && attrsEqual(last.attrs, attrs)) {
+        last.len += length;
+        return;
+      }
+    }
+    ids.push(new AttrRange(clock, length, attrs));
+    this._sorted = false;
+  }
+
+  getIds(): AttrRange[] {
+    if (!this._sorted) {
+      this._ids.sort((a, b) => a.clock - b.clock);
+      const merged: AttrRange[] = [];
+      for (const range of this._ids) {
+        if (merged.length > 0) {
+          const last = merged.at(-1)!;
+          const lastEnd = last.clock + last.len;
+          if (lastEnd >= range.clock && attrsEqual(last.attrs, range.attrs)) {
+            last.len = Math.max(
+              last.len,
+              range.clock + range.len - last.clock,
+            );
+            continue;
+          }
+          if (lastEnd > range.clock && !attrsEqual(last.attrs, range.attrs)) {
+            last.len = range.clock - last.clock;
+            if (last.len <= 0) {
+              merged.pop();
+            }
+          }
+        }
+        merged.push(new AttrRange(range.clock, range.len, range.attrs));
+      }
+      this._ids = merged;
+      this._sorted = true;
+    }
+    return this._ids;
+  }
+
+  copy(): AttrRanges {
+    return new AttrRanges(
+      this.getIds().map((r) => new AttrRange(r.clock, r.len, [...r.attrs])),
+    );
+  }
+}
+
+function attrsEqual(a: ContentAttribute[], b: ContentAttribute[]): boolean {
+  if (a.length !== b.length) return false;
+  for (const [i, element_] of a.entries()) {
+    if (element_.name !== b[i].name || element_.val !== b[i].val) return false;
+  }
+  return true;
+}
+
+// --- IdMap ---
+
+export class IdMap {
+  clients: Map<number, AttrRanges> = new Map();
+
+  isEmpty(): boolean {
+    if (this.clients.size === 0) return true;
+    for (const ranges of this.clients.values()) {
+      if (ranges.getIds().length > 0) return false;
+    }
+    return true;
+  }
+
+  add(client: number, clock: number, len: number, attrs: ContentAttribute[]) {
+    let ranges = this.clients.get(client);
+    if (!ranges) {
+      ranges = new AttrRanges();
+      this.clients.set(client, ranges);
+    }
+    ranges.add(clock, len, attrs);
+  }
+
+  has(client: number, clock: number): boolean {
+    const ranges = this.clients.get(client);
+    if (!ranges) return false;
+    const ids = ranges.getIds();
+    for (const range of ids) {
+      if (clock >= range.clock && clock < range.clock + range.len) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns which portions of [clock, clock+len) exist in this map,
+   * with their associated attributes.
+   */
+  slice(client: number, clock: number, len: number): MaybeAttrRange[] {
+    const ranges = this.clients.get(client);
+    if (!ranges) {
+      return [{ clock, len }];
+    }
+    const ids = ranges.getIds();
+    const result: MaybeAttrRange[] = [];
+    let pos = clock;
+    const end = clock + len;
+
+    for (const range of ids) {
+      if (range.clock >= end) break;
+      const rangeEnd = range.clock + range.len;
+      if (rangeEnd <= pos) continue;
+
+      if (pos < range.clock) {
+        const gapEnd = Math.min(range.clock, end);
+        result.push({ clock: pos, len: gapEnd - pos });
+        pos = gapEnd;
+      }
+
+      if (pos < end && pos < rangeEnd) {
+        const overlapEnd = Math.min(rangeEnd, end);
+        result.push({ clock: pos, len: overlapEnd - pos, attrs: range.attrs });
+        pos = overlapEnd;
+      }
+    }
+
+    if (pos < end) {
+      result.push({ clock: pos, len: end - pos });
+    }
+
+    return result;
+  }
+
+  forEach(
+    f: (
+      client: number,
+      clock: number,
+      len: number,
+      attrs: ContentAttribute[],
+    ) => void,
+  ) {
+    for (const [client, ranges] of this.clients.entries()) {
+      for (const range of ranges.getIds()) {
+        f(client, range.clock, range.len, range.attrs);
+      }
+    }
+  }
+}
+
+// --- ContentMap ---
+
+export interface ContentMap {
+  inserts: IdMap;
+  deletes: IdMap;
+}
+
+export function createContentMap(
+  inserts?: IdMap,
+  deletes?: IdMap,
+): ContentMap {
+  return {
+    inserts: inserts ?? new IdMap(),
+    deletes: deletes ?? new IdMap(),
+  };
+}
+
+/**
+ * Create a ContentMap from ContentIds by tagging all insert ranges with insertAttrs
+ * and all delete ranges with deleteAttrs.
+ */
+export function createContentMapFromContentIds(
+  contentIds: ContentIds,
+  insertAttrs: ContentAttribute[],
+  deleteAttrs: ContentAttribute[] = insertAttrs,
+): ContentMap {
+  const inserts = new IdMap();
+  contentIds.inserts.forEach((client, clock, len) => {
+    inserts.add(client, clock, len, insertAttrs);
+  });
+
+  const deletes = new IdMap();
+  contentIds.deletes.forEach((client, clock, len) => {
+    deletes.add(client, clock, len, deleteAttrs);
+  });
+
+  return { inserts, deletes };
+}
+
+export function mergeContentMaps(maps: ContentMap[]): ContentMap {
+  return createContentMap(
+    mergeIdMaps(maps.map((m) => m.inserts)),
+    mergeIdMaps(maps.map((m) => m.deletes)),
+  );
+}
+
+function mergeIdMaps(maps: IdMap[]): IdMap {
+  const merged = new IdMap();
+  for (const map of maps) {
+    for (const [client, ranges] of map.clients.entries()) {
+      for (const range of ranges.getIds()) {
+        merged.add(client, range.clock, range.len, range.attrs);
+      }
+    }
+  }
+  return merged;
+}
+
+/**
+ * Filter a ContentMap by predicates on the attribute arrays.
+ * Only ranges where the predicate returns true are kept.
+ */
+export function filterContentMap(
+  contentMap: ContentMap,
+  insertPredicate: (attrs: ContentAttribute[]) => boolean,
+  deletePredicate: (attrs: ContentAttribute[]) => boolean = insertPredicate,
+): ContentMap {
+  return createContentMap(
+    filterIdMap(contentMap.inserts, insertPredicate),
+    filterIdMap(contentMap.deletes, deletePredicate),
+  );
+}
+
+function filterIdMap(
+  idMap: IdMap,
+  predicate: (attrs: ContentAttribute[]) => boolean,
+): IdMap {
+  const filtered = new IdMap();
+  for (const [client, ranges] of idMap.clients.entries()) {
+    for (const range of ranges.getIds()) {
+      if (predicate(range.attrs)) {
+        filtered.add(client, range.clock, range.len, range.attrs);
+      }
+    }
+  }
+  return filtered;
+}
+
+/**
+ * Exclude ranges from a ContentMap that are present in the exclude ContentIds.
+ * This prevents double-attribution when merging updates that share operations.
+ */
+export function excludeContentMap(
+  content: ContentMap,
+  exclude: ContentIds,
+): ContentMap {
+  return createContentMap(
+    excludeIdMapByIdSet(content.inserts, exclude.inserts),
+    excludeIdMapByIdSet(content.deletes, exclude.deletes),
+  );
+}
+
+function excludeIdMapByIdSet(idMap: IdMap, exclude: IdSet): IdMap {
+  const result = new IdMap();
+  for (const [client, ranges] of idMap.clients.entries()) {
+    for (const range of ranges.getIds()) {
+      const slices = exclude.slice(client, range.clock, range.len);
+      for (const s of slices) {
+        if (!s.exists) {
+          result.add(client, s.clock, s.len, range.attrs);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Intersect a ContentMap with ContentIds, keeping only ranges that exist in both.
+ */
+export function intersectContentMap(
+  contentMap: ContentMap,
+  contentIds: ContentIds,
+): ContentMap {
+  return createContentMap(
+    intersectIdMapByIdSet(contentMap.inserts, contentIds.inserts),
+    intersectIdMapByIdSet(contentMap.deletes, contentIds.deletes),
+  );
+}
+
+function intersectIdMapByIdSet(idMap: IdMap, idSet: IdSet): IdMap {
+  const result = new IdMap();
+  for (const [client, ranges] of idMap.clients.entries()) {
+    for (const range of ranges.getIds()) {
+      const slices = idSet.slice(client, range.clock, range.len);
+      for (const s of slices) {
+        if (s.exists) {
+          result.add(client, s.clock, s.len, range.attrs);
+        }
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Create ContentIds from a ContentMap (discarding the attributes).
+ */
+export function createContentIdsFromContentMap(
+  contentMap: ContentMap,
+): ContentIds {
+  const inserts = new IdSet();
+  contentMap.inserts.forEach((client, clock, len) => {
+    inserts.add(client, clock, len);
+  });
+
+  const deletes = new IdSet();
+  contentMap.deletes.forEach((client, clock, len) => {
+    deletes.add(client, clock, len);
+  });
+
+  return { inserts, deletes };
+}

--- a/src/lib/attribution/encoding.ts
+++ b/src/lib/attribution/encoding.ts
@@ -1,0 +1,233 @@
+/**
+ * Binary encoding/decoding for ContentIds and ContentMap.
+ *
+ * Uses delta-encoded format matching Y.js v14's IdSetEncoderV2/IdSetDecoderV2.
+ * When teleportal upgrades to v14, these encoded blobs are wire-compatible with
+ * Y.encodeContentMap / Y.decodeContentMap.
+ *
+ * Format (IdSet):
+ *   VarUint: numClients
+ *   For each client (sorted by clientID):
+ *     VarUint: clientID
+ *     VarUint: numberOfRanges
+ *     For each range (delta-encoded):
+ *       VarUint: clock delta from previous
+ *       VarUint: length - 1
+ *
+ * Format (IdMap / ContentMap):
+ *   Same as IdSet but each range also has:
+ *     VarUint: numberOfAttributes
+ *     For each attribute:
+ *       VarUint: attrIndex (into deduplication table)
+ *       If new attr (index >= table size):
+ *         VarUint: nameIndex (into name dedup table)
+ *         If new name (index >= table size):
+ *           VarString: name
+ *         Any: value
+ */
+
+import * as encoding from "lib0/encoding";
+import * as decoding from "lib0/decoding";
+import { type ContentIds, IdRange, IdRanges, IdSet } from "./content-ids";
+import {
+  AttrRange,
+  AttrRanges,
+  ContentAttribute,
+  type ContentMap,
+  IdMap,
+  createContentMap,
+} from "./content-map";
+
+// --- IdSet encoding ---
+
+function writeIdSet(encoder: encoding.Encoder, idSet: IdSet) {
+  const clients = [...idSet.clients.entries()].sort(
+    ([a], [b]) => a - b,
+  );
+  encoding.writeVarUint(encoder, clients.length);
+
+  for (const [client, ranges] of clients) {
+    encoding.writeVarUint(encoder, client);
+    const ids = ranges.getIds();
+    encoding.writeVarUint(encoder, ids.length);
+
+    let currVal = 0;
+    for (const range of ids) {
+      encoding.writeVarUint(encoder, range.clock - currVal);
+      currVal = range.clock;
+      encoding.writeVarUint(encoder, range.len - 1);
+      currVal += range.len;
+    }
+  }
+}
+
+function readIdSet(decoder: decoding.Decoder): IdSet {
+  const idSet = new IdSet();
+  const numClients = decoding.readVarUint(decoder);
+
+  for (let i = 0; i < numClients; i++) {
+    const client = decoding.readVarUint(decoder);
+    const numRanges = decoding.readVarUint(decoder);
+
+    if (numRanges > 0) {
+      const ranges: IdRange[] = [];
+      let currVal = 0;
+      for (let j = 0; j < numRanges; j++) {
+        currVal += decoding.readVarUint(decoder);
+        const clock = currVal;
+        const len = decoding.readVarUint(decoder) + 1;
+        currVal += len;
+        ranges.push(new IdRange(clock, len));
+      }
+      idSet.clients.set(client, new IdRanges(ranges));
+    }
+  }
+
+  return idSet;
+}
+
+export type EncodedContentIds = Uint8Array & { _tag: "content-ids" };
+
+const EMPTY_ENCODED_CONTENT_IDS = new Uint8Array([0, 0]) as EncodedContentIds;
+
+export function getEmptyEncodedContentIds(): EncodedContentIds {
+  return EMPTY_ENCODED_CONTENT_IDS;
+}
+
+export function encodeContentIds(contentIds: ContentIds): EncodedContentIds {
+  const encoder = encoding.createEncoder();
+  writeIdSet(encoder, contentIds.inserts);
+  writeIdSet(encoder, contentIds.deletes);
+  return encoding.toUint8Array(encoder) as EncodedContentIds;
+}
+
+export function decodeContentIds(buf: EncodedContentIds): ContentIds {
+  const decoder = decoding.createDecoder(buf);
+  return {
+    inserts: readIdSet(decoder),
+    deletes: readIdSet(decoder),
+  };
+}
+
+// --- IdMap / ContentMap encoding ---
+
+function writeIdMap(encoder: encoding.Encoder, idMap: IdMap) {
+  const visitedAttrNames: string[] = [];
+  const nameIndex = new Map<string, number>();
+  const visitedAttrs: ContentAttribute[] = [];
+  const attrIndex = new Map<string, number>();
+
+  const clients = [...idMap.clients.entries()].sort(([a], [b]) => a - b);
+  encoding.writeVarUint(encoder, clients.length);
+
+  for (const [client, ranges] of clients) {
+    encoding.writeVarUint(encoder, client);
+    const ids = ranges.getIds();
+    encoding.writeVarUint(encoder, ids.length);
+
+    let currVal = 0;
+    for (const range of ids) {
+      encoding.writeVarUint(encoder, range.clock - currVal);
+      currVal = range.clock;
+      encoding.writeVarUint(encoder, range.len - 1);
+      currVal += range.len;
+
+      encoding.writeVarUint(encoder, range.attrs.length);
+      for (const attr of range.attrs) {
+        const attrKey = `${attr.name}:${JSON.stringify(attr.val)}`;
+        let idx = attrIndex.get(attrKey);
+        if (idx === undefined) {
+          idx = visitedAttrs.length;
+          visitedAttrs.push(attr);
+          attrIndex.set(attrKey, idx);
+          encoding.writeVarUint(encoder, idx);
+
+          // Write attribute name (deduplicated)
+          let nIdx = nameIndex.get(attr.name);
+          if (nIdx === undefined) {
+            nIdx = visitedAttrNames.length;
+            visitedAttrNames.push(attr.name);
+            nameIndex.set(attr.name, nIdx);
+            encoding.writeVarUint(encoder, nIdx);
+            encoding.writeVarString(encoder, attr.name);
+          } else {
+            encoding.writeVarUint(encoder, nIdx);
+          }
+
+          encoding.writeAny(
+            encoder,
+            attr.val as encoding.AnyEncodable,
+          );
+        } else {
+          encoding.writeVarUint(encoder, idx);
+        }
+      }
+    }
+  }
+}
+
+function readIdMap(decoder: decoding.Decoder): IdMap {
+  const idMap = new IdMap();
+  const visitedAttrNames: string[] = [];
+  const visitedAttrs: ContentAttribute[] = [];
+
+  const numClients = decoding.readVarUint(decoder);
+
+  for (let i = 0; i < numClients; i++) {
+    const client = decoding.readVarUint(decoder);
+    const numRanges = decoding.readVarUint(decoder);
+    const ranges: AttrRange[] = [];
+
+    let currVal = 0;
+    for (let j = 0; j < numRanges; j++) {
+      currVal += decoding.readVarUint(decoder);
+      const clock = currVal;
+      const len = decoding.readVarUint(decoder) + 1;
+      currVal += len;
+
+      const numAttrs = decoding.readVarUint(decoder);
+      const attrs: ContentAttribute[] = [];
+      for (let k = 0; k < numAttrs; k++) {
+        const attrId = decoding.readVarUint(decoder);
+        if (attrId < visitedAttrs.length) {
+          attrs.push(visitedAttrs[attrId]);
+        } else {
+          const nameId = decoding.readVarUint(decoder);
+          let name: string;
+          if (nameId < visitedAttrNames.length) {
+            name = visitedAttrNames[nameId];
+          } else {
+            name = decoding.readVarString(decoder);
+            visitedAttrNames.push(name);
+          }
+          const val = decoding.readAny(decoder);
+          const attr = new ContentAttribute(name, val);
+          visitedAttrs.push(attr);
+          attrs.push(attr);
+        }
+      }
+
+      ranges.push(new AttrRange(clock, len, attrs));
+    }
+
+    if (ranges.length > 0) {
+      idMap.clients.set(client, new AttrRanges(ranges));
+    }
+  }
+
+  return idMap;
+}
+
+import type { EncodedContentMap } from "../../storage/types";
+
+export function encodeContentMap(contentMap: ContentMap): EncodedContentMap {
+  const encoder = encoding.createEncoder();
+  writeIdMap(encoder, contentMap.inserts);
+  writeIdMap(encoder, contentMap.deletes);
+  return encoding.toUint8Array(encoder) as EncodedContentMap;
+}
+
+export function decodeContentMap(buf: EncodedContentMap): ContentMap {
+  const decoder = decoding.createDecoder(buf);
+  return createContentMap(readIdMap(decoder), readIdMap(decoder));
+}

--- a/src/lib/attribution/extract.ts
+++ b/src/lib/attribution/extract.ts
@@ -1,0 +1,60 @@
+/**
+ * Extract ContentIds from Y.js v13 updates.
+ *
+ * Uses Y.decodeUpdateV2() to get the full struct and delete-set data,
+ * then builds ContentIds with the same granularity as v14's
+ * createContentIdsFromUpdate().
+ *
+ * When teleportal upgrades to v14, replace this with:
+ *   import { createContentIdsFromUpdate } from '@y/y'
+ */
+
+import * as Y from "yjs";
+import { type ContentIds, IdSet } from "./content-ids";
+
+/**
+ * Extract ContentIds (insert + delete ranges) from a Y.js v2-encoded update.
+ *
+ * Iterates the decoded structs to build insert ranges, accumulating
+ * consecutive operations from the same client into single ranges
+ * (same logic as v14's createContentIdsFromUpdateV2).
+ *
+ * GC and Skip structs are excluded — only Items count as inserts.
+ */
+export function createContentIdsFromUpdate(update: Uint8Array): ContentIds {
+  const { structs, ds } = Y.decodeUpdateV2(update);
+  const inserts = new IdSet();
+
+  let lastClient = -1;
+  let lastClock = 0;
+  let lastLen = 0;
+
+  for (const struct of structs) {
+    if (struct instanceof Y.GC || struct instanceof Y.Skip) continue;
+    const { client, clock } = struct.id;
+    if (client === lastClient && clock === lastClock + lastLen) {
+      lastLen += struct.length;
+    } else {
+      if (lastClient >= 0) {
+        inserts.add(lastClient, lastClock, lastLen);
+      }
+      lastClient = client;
+      lastClock = clock;
+      lastLen = struct.length;
+    }
+  }
+  if (lastClient >= 0) {
+    inserts.add(lastClient, lastClock, lastLen);
+  }
+
+  const deletes = new IdSet();
+  ds.clients.forEach(
+    (deleteItems: Array<{ clock: number; len: number }>, clientID: number) => {
+      for (const item of deleteItems) {
+        deletes.add(clientID, item.clock, item.len);
+      }
+    },
+  );
+
+  return { inserts, deletes };
+}

--- a/src/lib/attribution/index.ts
+++ b/src/lib/attribution/index.ts
@@ -46,3 +46,5 @@ export {
   getActivity,
   resolveItemAttribution,
 } from "./queries";
+
+export { milestoneContentMap, changesetContentMap } from "./milestone";

--- a/src/lib/attribution/index.ts
+++ b/src/lib/attribution/index.ts
@@ -1,0 +1,48 @@
+export {
+  IdRange,
+  IdRanges,
+  IdSet,
+  type MaybeIdRange,
+  type ContentIds,
+  createContentIds,
+  mergeContentIds,
+  excludeContentIds,
+  intersectContentIds,
+  mergeIdSets,
+  diffIdSet,
+  intersectIdSets,
+} from "./content-ids";
+
+export {
+  ContentAttribute,
+  createContentAttribute,
+  AttrRange,
+  type MaybeAttrRange,
+  AttrRanges,
+  IdMap,
+  type ContentMap,
+  createContentMap,
+  createContentMapFromContentIds,
+  mergeContentMaps,
+  filterContentMap,
+  excludeContentMap,
+  intersectContentMap,
+  createContentIdsFromContentMap,
+} from "./content-map";
+
+export {
+  type EncodedContentIds,
+  getEmptyEncodedContentIds,
+  encodeContentIds,
+  decodeContentIds,
+  encodeContentMap,
+  decodeContentMap,
+} from "./encoding";
+
+export { createContentIdsFromUpdate } from "./extract";
+
+export {
+  type ActivityEntry,
+  getActivity,
+  resolveItemAttribution,
+} from "./queries";

--- a/src/lib/attribution/milestone.test.ts
+++ b/src/lib/attribution/milestone.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import {
+  changesetContentMap,
+  createContentAttribute,
+  createContentIds,
+  createContentMapFromContentIds,
+  getActivity,
+  mergeContentMaps,
+  milestoneContentMap,
+  type ContentIds,
+  type ContentMap,
+} from "./index";
+
+/** A ContentMap attributing client `client`'s ops [0,len) to `user` at `t`. */
+function userMap(
+  client: number,
+  len: number,
+  user: string,
+  t: number,
+): ContentMap {
+  const ids = createContentIds();
+  ids.inserts.add(client, 0, len);
+  return createContentMapFromContentIds(ids, [
+    createContentAttribute("insert", user),
+    createContentAttribute("insertAt", t),
+  ]);
+}
+
+function ids(...ranges: [client: number, len: number][]): ContentIds {
+  const c = createContentIds();
+  for (const [client, len] of ranges) c.inserts.add(client, 0, len);
+  return c;
+}
+
+function users(map: ContentMap): string[] {
+  return [...new Set(getActivity(map).map((e) => e.userId))].sort() as string[];
+}
+
+describe("milestoneContentMap", () => {
+  const full = mergeContentMaps([
+    userMap(1, 6, "user-1", 1000),
+    userMap(2, 5, "user-2", 2000),
+  ]);
+
+  it("keeps only content present in the milestone", () => {
+    // Milestone with only client 1's content.
+    expect(users(milestoneContentMap(full, ids([1, 6])))).toEqual(["user-1"]);
+    // Milestone with both clients' content.
+    expect(users(milestoneContentMap(full, ids([1, 6], [2, 5])))).toEqual([
+      "user-1",
+      "user-2",
+    ]);
+  });
+
+  it("drops attribution for ops not in the milestone", () => {
+    const scoped = milestoneContentMap(full, ids([1, 6]));
+    expect(scoped.inserts.clients.has(2)).toBe(false);
+  });
+});
+
+describe("changesetContentMap", () => {
+  const full = mergeContentMaps([
+    userMap(1, 6, "user-1", 1000),
+    userMap(2, 5, "user-2", 2000),
+  ]);
+
+  it("keeps only the operations added between two milestones", () => {
+    const from = ids([1, 6]); // milestone A: user-1 only
+    const to = ids([1, 6], [2, 5]); // milestone B: both
+    expect(users(changesetContentMap(full, from, to))).toEqual(["user-2"]);
+  });
+
+  it("is empty when nothing changed between milestones", () => {
+    const same = ids([1, 6]);
+    expect(users(changesetContentMap(full, same, same))).toEqual([]);
+  });
+});

--- a/src/lib/attribution/milestone.ts
+++ b/src/lib/attribution/milestone.ts
@@ -1,0 +1,42 @@
+/**
+ * Milestone-scoped attribution.
+ *
+ * A milestone snapshot is a full Y.js update, so the operations *contained in*
+ * a milestone are `createContentIdsFromUpdate(snapshot)` (see ./extract). These
+ * helpers scope a document's full ContentMap to a milestone by intersecting it
+ * with those operation IDs, and compute changesets by diffing two milestones'
+ * IDs first.
+ *
+ * Pure composition over the set operations in ./content-ids and ./content-map —
+ * no Y.js dependency. The Y.js snapshot -> ContentIds step happens at the call
+ * site (the client), which is what keeps this E2EE-safe.
+ */
+
+import { type ContentIds, excludeContentIds } from "./content-ids";
+import { type ContentMap, intersectContentMap } from "./content-map";
+
+/**
+ * Restrict a document's full attribution ContentMap to the operations present
+ * in a milestone — i.e. who authored the content as of that milestone.
+ */
+export function milestoneContentMap(
+  fullMap: ContentMap,
+  milestoneIds: ContentIds,
+): ContentMap {
+  return intersectContentMap(fullMap, milestoneIds);
+}
+
+/**
+ * Restrict a document's full attribution ContentMap to the operations added
+ * between two milestones — i.e. who made the changes from `fromIds` to `toIds`.
+ *
+ * Covers both inserts and deletes introduced in the window, since
+ * `createContentIdsFromUpdate` populates both halves of {@link ContentIds}.
+ */
+export function changesetContentMap(
+  fullMap: ContentMap,
+  fromIds: ContentIds,
+  toIds: ContentIds,
+): ContentMap {
+  return intersectContentMap(fullMap, excludeContentIds(toIds, fromIds));
+}

--- a/src/lib/attribution/queries.ts
+++ b/src/lib/attribution/queries.ts
@@ -1,0 +1,124 @@
+/**
+ * Query utilities for ContentMap attribution data.
+ *
+ * These provide the same capabilities as yhub's activity/changeset endpoints
+ * but as pure functions over ContentMap.
+ */
+
+import { type ContentMap, filterContentMap } from "./content-map";
+
+export interface ActivityEntry {
+  from: number;
+  to: number;
+  userId: string | null;
+}
+
+/**
+ * Extract an activity timeline from a ContentMap.
+ * Returns a sorted list of time ranges with the user who made changes.
+ */
+export function getActivity(
+  contentMap: ContentMap,
+  options?: {
+    from?: number;
+    to?: number;
+    userId?: string;
+  },
+): ActivityEntry[] {
+  const filtered = filterContentMap(contentMap, (attrs) => {
+    if (options?.from !== undefined || options?.to !== undefined) {
+      const timeAttr = attrs.find(
+        (a) => a.name === "insertAt" || a.name === "deleteAt",
+      );
+      if (timeAttr) {
+        if (
+          options.from !== undefined &&
+          (timeAttr.val as number) < options.from
+        )
+          return false;
+        if (options.to !== undefined && (timeAttr.val as number) > options.to)
+          return false;
+      }
+    }
+    if (options?.userId !== undefined) {
+      const userAttr = attrs.find(
+        (a) => a.name === "insert" || a.name === "delete",
+      );
+      if (!userAttr || userAttr.val !== options.userId) return false;
+    }
+    return true;
+  });
+
+  const activity: ActivityEntry[] = [];
+
+  filtered.inserts.forEach((_client, _clock, _len, attrs) => {
+    const timeAttr = attrs.find((a) => a.name === "insertAt");
+    const userAttr = attrs.find((a) => a.name === "insert");
+    if (timeAttr) {
+      const t = timeAttr.val as number;
+      activity.push({
+        from: t,
+        to: t,
+        userId: userAttr ? (userAttr.val as string) : null,
+      });
+    }
+  });
+
+  filtered.deletes.forEach((_client, _clock, _len, attrs) => {
+    const timeAttr = attrs.find((a) => a.name === "deleteAt");
+    const userAttr = attrs.find((a) => a.name === "delete");
+    if (timeAttr) {
+      const t = timeAttr.val as number;
+      activity.push({
+        from: t,
+        to: t,
+        userId: userAttr ? (userAttr.val as string) : null,
+      });
+    }
+  });
+
+  activity.sort((a, b) => a.from - b.from);
+
+  // Group adjacent entries from the same user within 1 second
+  const grouped: ActivityEntry[] = [];
+  for (const entry of activity) {
+    const last = grouped.at(-1);
+    if (last && last.userId === entry.userId && entry.from - last.to < 1000) {
+      last.to = entry.to;
+    } else {
+      grouped.push({ ...entry });
+    }
+  }
+
+  return grouped;
+}
+
+/**
+ * Resolve who authored a specific Y.js item identified by (clientID, clock).
+ * Searches the ContentMap's insert ranges for a match.
+ */
+export function resolveItemAttribution(
+  contentMap: ContentMap,
+  clientID: number,
+  clock: number,
+): { userId: string; timestamp: number } | null {
+  const ranges = contentMap.inserts.clients.get(clientID);
+  if (!ranges) return null;
+
+  for (const range of ranges.getIds()) {
+    if (clock >= range.clock && clock < range.clock + range.len) {
+      let userId: string | undefined;
+      let timestamp: number | undefined;
+      for (const attr of range.attrs) {
+        if (attr.name === "insert") userId = attr.val as string;
+        if (attr.name === "insertAt") timestamp = attr.val as number;
+      }
+      if (userId !== undefined && timestamp !== undefined) {
+        return { userId, timestamp };
+      }
+      return null;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/protocol/encryption/encoding.ts
+++ b/src/lib/protocol/encryption/encoding.ts
@@ -5,6 +5,10 @@ import { digest } from "lib0/hash/sha256";
 
 import type { StateVector, SyncStep2Update, Update } from "teleportal";
 import { EncryptedBinary } from "teleportal/encryption-key";
+import {
+  type EncodedContentIds,
+  getEmptyEncodedContentIds,
+} from "teleportal/attribution";
 import type { ClientId, Counter, LamportClockValue } from "./lamport-clock";
 
 /**
@@ -95,6 +99,7 @@ export type DecodedEncryptedUpdatePayload = {
   id: EncryptedMessageId;
   timestamp: LamportClockValue;
   payload: EncryptedBinary;
+  contentIds: EncodedContentIds;
 };
 
 /**
@@ -124,6 +129,8 @@ export function encodeEncryptedUpdateMessages(
       encoding.writeVarUint(encoder, update.timestamp[1]);
       // payload
       encoding.writeVarUint8Array(encoder, update.payload);
+      // contentIds
+      encoding.writeVarUint8Array(encoder, update.contentIds);
     }
   }) as EncryptedUpdatePayload;
 }
@@ -134,9 +141,10 @@ export function encodeEncryptedUpdateMessages(
 export function encodeEncryptedUpdate(
   update: EncryptedBinary,
   timestamp: LamportClockValue,
+  contentIds: EncodedContentIds = getEmptyEncodedContentIds(),
 ): EncryptedUpdatePayload {
   return encodeEncryptedUpdateMessages([
-    { id: toBase64(digest(update)), timestamp, payload: update },
+    { id: toBase64(digest(update)), timestamp, payload: update, contentIds },
   ]);
 }
 
@@ -164,9 +172,13 @@ export function decodeEncryptedUpdate(
       const counter = decoding.readVarUint(decoder);
       // payload
       const payload = decoding.readVarUint8Array(decoder) as EncryptedBinary;
+      // contentIds
+      const contentIds = decoding.readVarUint8Array(
+        decoder,
+      ) as EncodedContentIds;
 
       // create message instance
-      messages.push({ id, timestamp: [clientId, counter], payload });
+      messages.push({ id, timestamp: [clientId, counter], payload, contentIds });
     }
     return messages;
   } catch (err) {
@@ -287,6 +299,7 @@ export function decodeFromSyncStep2(
         id,
         timestamp: [clientId, lamportClock],
         payload,
+        contentIds: getEmptyEncodedContentIds(),
       });
     }
     return { messages };

--- a/src/lib/protocol/encryption/encryption.test.ts
+++ b/src/lib/protocol/encryption/encryption.test.ts
@@ -21,6 +21,7 @@ import {
   getEmptyEncryptedSyncStep2,
 } from "./encoding";
 import type { ClientId, Counter, LamportClockValue } from "./lamport-clock";
+import { getEmptyEncodedContentIds } from "teleportal/attribution";
 
 describe("protocol encryption encoding", () => {
   describe("state vector encoding/decoding", () => {
@@ -78,6 +79,7 @@ describe("protocol encryption encoding", () => {
         id: "dGVzdC1tZXNzYWdlLWlk", // base64 encoded "test-message-id"
         timestamp,
         payload: testUpdate,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const encoded = encodeEncryptedUpdateMessages([message]);
@@ -95,11 +97,13 @@ describe("protocol encryption encoding", () => {
           id: "bXNnMQ==", // base64 encoded "msg1"
           timestamp: [1, 5],
           payload: new Uint8Array([1, 2, 3]) as EncryptedBinary,
+          contentIds: getEmptyEncodedContentIds(),
         },
         {
           id: "bXNnMg==", // base64 encoded "msg2"
           timestamp: [2, 10],
           payload: new Uint8Array([4, 5, 6]) as EncryptedBinary,
+          contentIds: getEmptyEncodedContentIds(),
         },
       ];
 
@@ -152,11 +156,13 @@ describe("protocol encryption encoding", () => {
           id: "msg1",
           timestamp: [1, 5],
           payload: new Uint8Array([1, 2, 3]) as EncryptedBinary,
+          contentIds: getEmptyEncodedContentIds(),
         },
         {
           id: "msg2",
           timestamp: [2, 10],
           payload: new Uint8Array([4, 5, 6]) as EncryptedBinary,
+          contentIds: getEmptyEncodedContentIds(),
         },
       ];
       const sync: DecodedEncryptedSyncStep2 = { messages };
@@ -175,11 +181,13 @@ describe("protocol encryption encoding", () => {
           id: "msg1",
           timestamp: [100, 5],
           payload: new Uint8Array([1, 2, 3]) as EncryptedBinary,
+          contentIds: getEmptyEncodedContentIds(),
         },
         {
           id: "msg2",
           timestamp: [100, 10], // Same client id
           payload: new Uint8Array([4, 5, 6]) as EncryptedBinary,
+          contentIds: getEmptyEncodedContentIds(),
         },
       ];
       const sync: DecodedEncryptedSyncStep2 = { messages };

--- a/src/lib/protocol/encryption/sync.ts
+++ b/src/lib/protocol/encryption/sync.ts
@@ -1,4 +1,5 @@
 import { EncryptedBinary } from "teleportal/encryption-key";
+import { getEmptyEncodedContentIds } from "teleportal/attribution";
 import type {
   DecodedEncryptedStateVector,
   DecodedEncryptedSyncStep2,
@@ -92,6 +93,7 @@ export async function getDecodedSyncStep2(
                 id: messageId,
                 timestamp,
                 payload,
+                contentIds: getEmptyEncodedContentIds(),
               }
             : null,
         ),

--- a/src/protocols/README.md
+++ b/src/protocols/README.md
@@ -7,6 +7,7 @@ This package contains the protocol implementations for Teleportal's Y.js Sync Se
 - [`teleportal/protocol`](../lib/protocol/README.md) - Core RPC messaging system (RPC types and message classes are exported from `teleportal/protocol`)
 - [`teleportal/protocols/milestone`](./milestone/README.md) - Milestone RPC methods
 - [`teleportal/protocols/file`](./file/README.md) - File RPC methods
+- [`teleportal/protocols/attribution`](./attribution/README.md) - Attribution (authorship) read methods
 
 ## Overview
 
@@ -83,3 +84,4 @@ RPC messages use a binary format with the following structure:
 - [RPC System](../lib/protocol/README.md) - Core RPC types, encoding, handlers, and serialization/deserialization (exported from `teleportal/protocol`)
 - [Milestone Methods](./milestone/README.md) - Milestone CRUD operations via RPC
 - [File Methods](./file/README.md) - File upload/download authorization via RPC
+- [Attribution Methods](./attribution/README.md) - Read document authorship via RPC

--- a/src/protocols/attribution/README.md
+++ b/src/protocols/attribution/README.md
@@ -1,0 +1,143 @@
+# Attribution RPC Methods
+
+Read-only RPC methods that surface document **attribution** (authorship) to clients.
+
+## Overview
+
+When attribution storage is enabled, the server records an encoded **ContentMap**
+per document — a mapping from CRDT operation ID ranges `(clientID, clock)` to
+`userId` + `timestamp`. See [`teleportal/attribution`](../../lib/attribution) and the
+`DocumentStorage.retrieveAttribution()` storage hook.
+
+This protocol exposes that latent data on demand (it is **not** synced continuously).
+It answers two questions:
+
+- **"What happened, and when?"** — an activity timeline, optionally filtered by user
+  or time range.
+- **"Who wrote this content?"** — the ContentMap, resolved client-side against the
+  local document to attribute a range of content.
+
+## Server Integration
+
+```typescript
+import { Server } from "teleportal/server";
+import { getAttributionRpcHandlers } from "teleportal/protocols/attribution";
+
+const server = new Server({
+  // ... other options (storage must implement retrieveAttribution)
+  rpcHandlers: {
+    ...getAttributionRpcHandlers(),
+  },
+});
+```
+
+RPC messages bypass the server's global permission check, so attribution-specific
+authorization is supplied here:
+
+```typescript
+getAttributionRpcHandlers({
+  checkPermission: (ctx) => canReadAttribution(ctx.userId, ctx.documentId),
+});
+```
+
+When `checkPermission` returns `false` (or throws), the call fails with a `403`.
+
+## Client Integration
+
+The `Provider` exposes the methods directly:
+
+```typescript
+import { Provider } from "teleportal/providers";
+
+const provider = await Provider.create({
+  url: "wss://...",
+  document: "my-doc",
+});
+
+// Activity timeline (optionally filtered).
+const activity = await provider.getActivity({ userId: "user-1" });
+
+// Who wrote characters 0..40 of a Y.Text?
+const text = provider.doc.getText("body");
+const segments = await provider.getAttributionForRange(text, 0, 40);
+// -> [{ from, to, userId, timestamp }, ...]
+
+// Point lookup by CRDT id, or the raw decoded ContentMap.
+const author = await provider.resolveAttribution(clientID, clock);
+const map = await provider.getAttributionMap();
+```
+
+`getAttributionMap()` fetches and caches the decoded ContentMap; the range/point
+helpers reuse that cache, fetching once on first use.
+
+## Methods
+
+### attributionActivity
+
+Activity timeline for the document.
+
+**Request:** `{ from?: number; to?: number; userId?: string }` (timestamps in ms)
+
+**Response:** `{ activity: Array<{ from: number; to: number; userId: string | null }> }`
+
+Works for **encrypted** documents — it is derived purely from authorship and
+timestamps and never needs the document content.
+
+### attributionGet
+
+The encoded ContentMap for client-side resolution.
+
+**Request:** `{ filter?: { from?: number; to?: number; userId?: string } }`
+
+**Response:** `{ contentMap: Uint8Array | null }` — `null` when the storage has no
+attribution for the document. When a filter is supplied, the map is narrowed
+server-side before encoding.
+
+## Milestones
+
+Attribution can be scoped to [milestones](../milestone/README.md). A milestone snapshot is
+a full Y.js update, so the operations it contains are `createContentIdsFromUpdate(snapshot)`;
+milestone attribution is then pure set composition over the document's ContentMap. This is
+done **entirely client-side** (the server stays out of it, which is required for E2EE), via
+`Provider`:
+
+```typescript
+// Who authored the content present in milestone M?
+const activity = await provider.getMilestoneActivity(milestoneId);
+const map = await provider.getMilestoneContentMap(milestoneId);
+
+// Who made the changes between two milestones?
+const changeset = await provider.getChangesetActivity(fromId, toId);
+
+// Who wrote chars i..j as of milestone M? (rebuilds M's doc locally)
+const segments = await provider.getMilestoneAttributionForRange(
+  milestoneId,
+  (doc) => doc.getText("body"),
+  0,
+  40,
+);
+```
+
+The underlying pure helpers live in `teleportal/attribution`:
+`milestoneContentMap(fullMap, milestoneIds)` and
+`changesetContentMap(fullMap, fromIds, toIds)`.
+
+> Note: for E2EE documents, milestone snapshots are encrypted on the client (see the
+> [milestone README](../milestone/README.md)); `Provider` decrypts them transparently before
+> deriving operation IDs. Server-generated _automatic_ milestones on E2EE documents use a
+> different snapshot format and are not consumed by these methods.
+
+## Encryption boundary
+
+For end-to-end-encrypted documents the server holds only ciphertext plus the
+plaintext ContentMap. It **can** answer `attributionActivity`, but it **cannot** map
+a content position to a CRDT id — only the client can, against its decrypted
+document. `getAttributionForRange` (and the `resolveRangeAttribution` /
+`collectRangeIds` utilities behind it) therefore run entirely client-side and work
+identically for encrypted and unencrypted documents.
+
+## See Also
+
+- [`teleportal/attribution`](../../lib/attribution) - ContentMap types and query helpers
+- [Protocols Overview](../README.md) - Package overview
+- [Milestone Methods](../milestone/README.md) - Milestone CRUD operations via RPC

--- a/src/protocols/attribution/attribution.test.ts
+++ b/src/protocols/attribution/attribution.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "bun:test";
+import * as Y from "yjs";
+import type { RpcServerContext } from "teleportal/protocol";
+import type { EncodedContentMap } from "teleportal/storage";
+import {
+  changesetContentMap,
+  createContentAttribute,
+  createContentIdsFromUpdate,
+  createContentMapFromContentIds,
+  decodeContentMap,
+  encodeContentIds,
+  encodeContentMap,
+  getActivity,
+  mergeContentMaps,
+  milestoneContentMap,
+} from "teleportal/attribution";
+import {
+  createEncryptionKey,
+  decryptUpdate,
+  encryptUpdate,
+} from "teleportal/encryption-key";
+import { getAttributionRpcHandlers } from "./index";
+import { collectRangeIds, resolveRangeAttribution } from "./resolve";
+
+/**
+ * Two-milestone scenario: snapshot s1 captures "Hello " (user-1 only); s2
+ * captures "Hello World" (user-1 + user-2). `full` is the merged ContentMap.
+ */
+function milestoneScenario() {
+  const doc1 = new Y.Doc();
+  let u1!: Uint8Array;
+  doc1.on("updateV2", (u) => (u1 = u));
+  doc1.getText("t").insert(0, "Hello ");
+  const s1 = Y.encodeStateAsUpdateV2(doc1);
+
+  const doc2 = new Y.Doc();
+  Y.applyUpdateV2(doc2, Y.encodeStateAsUpdateV2(doc1));
+  let u2!: Uint8Array;
+  doc2.on("updateV2", (u) => (u2 = u));
+  doc2.getText("t").insert(6, "World");
+  const s2 = Y.encodeStateAsUpdateV2(doc2);
+
+  const full = mergeContentMaps([
+    decodeContentMap(
+      encodeContentMap(
+        createContentMapFromContentIds(createContentIdsFromUpdate(u1), [
+          createContentAttribute("insert", "user-1"),
+          createContentAttribute("insertAt", 1000),
+        ]),
+      ),
+    ),
+    decodeContentMap(
+      encodeContentMap(
+        createContentMapFromContentIds(createContentIdsFromUpdate(u2), [
+          createContentAttribute("insert", "user-2"),
+          createContentAttribute("insertAt", 2000),
+        ]),
+      ),
+    ),
+  ]);
+
+  return { s1, s2, full };
+}
+
+function contributors(
+  map: Parameters<typeof getActivity>[0],
+): (string | null)[] {
+  return [...new Set(getActivity(map).map((e) => e.userId))].sort();
+}
+
+function docFromSnapshot(snapshot: Uint8Array): Y.Doc {
+  const doc = new Y.Doc();
+  Y.applyUpdateV2(doc, snapshot);
+  return doc;
+}
+
+/**
+ * Build an encoded ContentMap attributing every operation in `update` to
+ * `userId` at `timestamp` — mirrors what the server records on write.
+ */
+function attribute(
+  update: Uint8Array,
+  userId: string,
+  timestamp: number,
+): EncodedContentMap {
+  return encodeContentMap(
+    createContentMapFromContentIds(
+      createContentIdsFromUpdate(update),
+      [
+        createContentAttribute("insert", userId),
+        createContentAttribute("insertAt", timestamp),
+      ],
+      [
+        createContentAttribute("delete", userId),
+        createContentAttribute("deleteAt", timestamp),
+      ],
+    ),
+  );
+}
+
+function mockContext(
+  retrieveAttribution?: () => Promise<EncodedContentMap | null>,
+): RpcServerContext {
+  return {
+    documentId: "doc-1",
+    userId: "user-1",
+    server: {} as never,
+    session: {
+      storage: retrieveAttribution ? { retrieveAttribution } : {},
+    },
+  } as unknown as RpcServerContext;
+}
+
+/**
+ * Two users edit a shared Y.Text: user-1 writes "Hello ", user-2 appends
+ * "World". Returns the merged ContentMap plus the doc holding both edits.
+ */
+function twoUserDoc() {
+  const doc1 = new Y.Doc();
+  let u1!: Uint8Array;
+  doc1.on("updateV2", (u) => (u1 = u));
+  doc1.getText("t").insert(0, "Hello ");
+
+  const doc2 = new Y.Doc();
+  Y.applyUpdateV2(doc2, Y.encodeStateAsUpdateV2(doc1));
+  let u2!: Uint8Array;
+  doc2.on("updateV2", (u) => (u2 = u));
+  doc2.getText("t").insert(6, "World");
+
+  const map = mergeContentMaps([
+    decodeContentMap(attribute(u1, "user-1", 1000)),
+    decodeContentMap(attribute(u2, "user-2", 2000)),
+  ]);
+
+  return { doc: doc2, text: doc2.getText("t"), map };
+}
+
+describe("getAttributionRpcHandlers", () => {
+  it("registers both read methods", () => {
+    const handlers = getAttributionRpcHandlers();
+    expect("attributionActivity" in handlers).toBe(true);
+    expect("attributionGet" in handlers).toBe(true);
+  });
+
+  describe("attributionActivity", () => {
+    it("returns a timeline from stored attribution", async () => {
+      const { map } = twoUserDoc();
+      const encoded = encodeContentMap(map);
+      const handler = getAttributionRpcHandlers().attributionActivity;
+
+      const { response } = (await handler.handler(
+        {},
+        mockContext(async () => encoded),
+      )) as { response: { activity: { userId: string | null }[] } };
+
+      const users = response.activity.map((e) => e.userId).sort();
+      expect(users).toEqual(["user-1", "user-2"]);
+    });
+
+    it("applies the userId filter", async () => {
+      const { map } = twoUserDoc();
+      const encoded = encodeContentMap(map);
+      const handler = getAttributionRpcHandlers().attributionActivity;
+
+      const { response } = (await handler.handler(
+        { userId: "user-2" },
+        mockContext(async () => encoded),
+      )) as { response: { activity: { userId: string | null }[] } };
+
+      expect(response.activity.map((e) => e.userId)).toEqual(["user-2"]);
+    });
+
+    it("returns an empty timeline when the storage has no attribution", async () => {
+      const handler = getAttributionRpcHandlers().attributionActivity;
+      const { response } = (await handler.handler({}, mockContext())) as {
+        response: { activity: unknown[] };
+      };
+      expect(response.activity).toEqual([]);
+    });
+
+    it("denies when checkPermission rejects", async () => {
+      const { map } = twoUserDoc();
+      const encoded = encodeContentMap(map);
+      const handler = getAttributionRpcHandlers({
+        checkPermission: () => false,
+      }).attributionActivity;
+
+      const { response } = (await handler.handler(
+        {},
+        mockContext(async () => encoded),
+      )) as { response: { type?: string; statusCode?: number } };
+
+      expect(response.type).toBe("error");
+      expect(response.statusCode).toBe(403);
+    });
+  });
+
+  describe("attributionGet", () => {
+    it("returns the stored ContentMap unchanged when unfiltered", async () => {
+      const { map } = twoUserDoc();
+      const encoded = encodeContentMap(map);
+      const handler = getAttributionRpcHandlers().attributionGet;
+
+      const { response } = (await handler.handler(
+        {},
+        mockContext(async () => encoded),
+      )) as { response: { contentMap: EncodedContentMap | null } };
+
+      expect(response.contentMap).toBe(encoded);
+    });
+
+    it("narrows the ContentMap by filter", async () => {
+      const { map } = twoUserDoc();
+      const encoded = encodeContentMap(map);
+      const handler = getAttributionRpcHandlers().attributionGet;
+
+      const { response } = (await handler.handler(
+        { filter: { userId: "user-1" } },
+        mockContext(async () => encoded),
+      )) as { response: { contentMap: EncodedContentMap | null } };
+
+      const decoded = decodeContentMap(response.contentMap!);
+      // Only user-1's client should remain in the inserts.
+      const remaining = [...decoded.inserts.clients.values()].flatMap((r) =>
+        r
+          .getIds()
+          .flatMap((range) =>
+            range.attrs
+              .filter((a) => a.name === "insert")
+              .map((a) => a.val as string),
+          ),
+      );
+      expect([...new Set(remaining)]).toEqual(["user-1"]);
+    });
+
+    it("returns null when the storage has no attribution", async () => {
+      const handler = getAttributionRpcHandlers().attributionGet;
+      const { response } = (await handler.handler({}, mockContext())) as {
+        response: { contentMap: EncodedContentMap | null };
+      };
+      expect(response.contentMap).toBeNull();
+    });
+  });
+});
+
+describe("resolveRangeAttribution", () => {
+  it("attributes content ranges to the correct authors", () => {
+    const { text, map } = twoUserDoc();
+
+    const hello = resolveRangeAttribution(text, 0, 6, map);
+    expect(hello).toEqual([
+      { from: 0, to: 6, userId: "user-1", timestamp: 1000 },
+    ]);
+
+    const world = resolveRangeAttribution(text, 6, 5, map);
+    expect(world).toEqual([
+      { from: 6, to: 11, userId: "user-2", timestamp: 2000 },
+    ]);
+  });
+
+  it("splits a range spanning both authors", () => {
+    const { text, map } = twoUserDoc();
+    const all = resolveRangeAttribution(text, 0, 11, map);
+    expect(all).toEqual([
+      { from: 0, to: 6, userId: "user-1", timestamp: 1000 },
+      { from: 6, to: 11, userId: "user-2", timestamp: 2000 },
+    ]);
+  });
+
+  it("collectRangeIds skips deleted content", () => {
+    const doc = new Y.Doc();
+    const text = doc.getText("t");
+    text.insert(0, "abcdef");
+    text.delete(1, 2); // remove "bc" -> visible "adef"
+
+    const ids = collectRangeIds(text, 0, 4);
+    const total = ids.reduce((n, id) => n + id.len, 0);
+    expect(total).toBe(4);
+  });
+});
+
+describe("milestone-scoped attribution", () => {
+  it("attributes the content present in a milestone", () => {
+    const { s1, s2, full } = milestoneScenario();
+
+    const m1 = milestoneContentMap(full, createContentIdsFromUpdate(s1));
+    expect(contributors(m1)).toEqual(["user-1"]);
+
+    const m2 = milestoneContentMap(full, createContentIdsFromUpdate(s2));
+    expect(contributors(m2)).toEqual(["user-1", "user-2"]);
+  });
+
+  it("attributes the changeset between two milestones", () => {
+    const { s1, s2, full } = milestoneScenario();
+    const changeset = changesetContentMap(
+      full,
+      createContentIdsFromUpdate(s1),
+      createContentIdsFromUpdate(s2),
+    );
+    expect(contributors(changeset)).toEqual(["user-2"]);
+  });
+
+  it("resolves a content range as it existed in a milestone", () => {
+    const { s1, s2, full } = milestoneScenario();
+
+    // As of milestone 1 the text is just "Hello " — all user-1.
+    const m1Doc = docFromSnapshot(s1);
+    expect(resolveRangeAttribution(m1Doc.getText("t"), 0, 6, full)).toEqual([
+      { from: 0, to: 6, userId: "user-1", timestamp: 1000 },
+    ]);
+
+    // As of milestone 2, "World" is user-2.
+    const m2Doc = docFromSnapshot(s2);
+    expect(resolveRangeAttribution(m2Doc.getText("t"), 6, 5, full)).toEqual([
+      { from: 6, to: 11, userId: "user-2", timestamp: 2000 },
+    ]);
+  });
+
+  it("recovers milestone IDs after an encrypt/decrypt round-trip", async () => {
+    const { s2 } = milestoneScenario();
+    const key = await createEncryptionKey();
+
+    const encrypted = await encryptUpdate(key, s2);
+    const decrypted = await decryptUpdate(key, encrypted);
+
+    // The ciphertext must not equal the plaintext snapshot...
+    expect(encrypted).not.toEqual(s2);
+    // ...but the decrypted snapshot yields identical operation IDs.
+    expect(encodeContentIds(createContentIdsFromUpdate(decrypted))).toEqual(
+      encodeContentIds(createContentIdsFromUpdate(s2)),
+    );
+  });
+});

--- a/src/protocols/attribution/index.ts
+++ b/src/protocols/attribution/index.ts
@@ -1,0 +1,19 @@
+export {
+  getAttributionRpcHandlers,
+  type AttributionRpcOptions,
+} from "./server-handlers";
+
+export {
+  collectRangeIds,
+  resolveRangeAttribution,
+  type RangeId,
+} from "./resolve";
+
+export type {
+  AttributionFilter,
+  AttributionActivityRequest,
+  AttributionActivityResponse,
+  AttributionGetRequest,
+  AttributionGetResponse,
+  AttributedSegment,
+} from "./methods";

--- a/src/protocols/attribution/methods.ts
+++ b/src/protocols/attribution/methods.ts
@@ -1,0 +1,42 @@
+import type { ActivityEntry } from "teleportal/attribution";
+import type { EncodedContentMap } from "teleportal/storage";
+
+/**
+ * Filter applied to attribution data. All fields are optional and combine with
+ * AND semantics. `from`/`to` are millisecond timestamps (inclusive).
+ */
+export type AttributionFilter = {
+  userId?: string;
+  from?: number;
+  to?: number;
+};
+
+export type AttributionActivityRequest = AttributionFilter;
+
+export type AttributionActivityResponse = {
+  activity: ActivityEntry[];
+};
+
+export type AttributionGetRequest = {
+  filter?: AttributionFilter;
+};
+
+export type AttributionGetResponse = {
+  /**
+   * The encoded ContentMap for the document, or null when the storage has no
+   * attribution data (the storage does not support attribution, or none has
+   * been recorded yet).
+   */
+  contentMap: EncodedContentMap | null;
+};
+
+/**
+ * A resolved attribution segment over a content range, in the coordinate space
+ * of the queried Y type (e.g. character offsets in a Y.Text).
+ */
+export type AttributedSegment = {
+  from: number;
+  to: number;
+  userId: string | null;
+  timestamp: number | null;
+};

--- a/src/protocols/attribution/resolve.ts
+++ b/src/protocols/attribution/resolve.ts
@@ -1,0 +1,125 @@
+/**
+ * Client-side range -> attribution resolution.
+ *
+ * Attribution is keyed by CRDT operation IDs (clientID, clock), but clients
+ * think in terms of content positions (e.g. character offsets in a Y.Text).
+ * These helpers map a position range to operation IDs by walking the local Y
+ * type, then look those IDs up in a decoded ContentMap.
+ *
+ * This runs entirely against the local (decrypted) document, so it works
+ * identically for encrypted and unencrypted documents — the server never needs
+ * to resolve content positions.
+ */
+
+import type * as Y from "yjs";
+import type { ContentMap } from "teleportal/attribution";
+import type { AttributedSegment } from "./methods";
+
+/**
+ * A contiguous run of operation IDs from a single client, together with the
+ * content offset at which the run begins in the queried type.
+ */
+export interface RangeId {
+  client: number;
+  clock: number;
+  len: number;
+  /** Content offset (in the queried type) corresponding to `clock`. */
+  contentStart: number;
+}
+
+/**
+ * Collect the operation IDs backing the content range `[index, index + length)`
+ * of `type`. Deleted and non-countable items are skipped (they do not occupy a
+ * content position), matching how Y.js computes the visible length.
+ */
+export function collectRangeIds(
+  type: Y.AbstractType<any>,
+  index: number,
+  length: number,
+): RangeId[] {
+  const ids: RangeId[] = [];
+  const end = index + length;
+  let pos = 0;
+  let item = type._start;
+
+  while (item !== null && pos < end) {
+    if (!item.deleted && item.countable) {
+      const itemStart = pos;
+      const itemEnd = pos + item.length;
+      const overlapStart = Math.max(itemStart, index);
+      const overlapEnd = Math.min(itemEnd, end);
+      if (overlapStart < overlapEnd) {
+        ids.push({
+          client: item.id.client,
+          clock: item.id.clock + (overlapStart - itemStart),
+          len: overlapEnd - overlapStart,
+          contentStart: overlapStart,
+        });
+      }
+      pos = itemEnd;
+    }
+    item = item.right;
+  }
+
+  return ids;
+}
+
+/**
+ * Resolve attribution for the content range `[index, index + length)` of
+ * `type` against `contentMap`, returning attributed segments in the content
+ * coordinate space of `type`, sorted by `from` and merged across adjacent
+ * same-author runs.
+ *
+ * Content with no matching attribution (e.g. inserted before attribution was
+ * enabled) is omitted from the result.
+ */
+export function resolveRangeAttribution(
+  type: Y.AbstractType<any>,
+  index: number,
+  length: number,
+  contentMap: ContentMap,
+): AttributedSegment[] {
+  const segments: AttributedSegment[] = [];
+
+  for (const id of collectRangeIds(type, index, length)) {
+    const ranges = contentMap.inserts.clients.get(id.client);
+    if (!ranges) continue;
+
+    const idEnd = id.clock + id.len;
+    for (const range of ranges.getIds()) {
+      const overlapStart = Math.max(range.clock, id.clock);
+      const overlapEnd = Math.min(range.clock + range.len, idEnd);
+      if (overlapStart >= overlapEnd) continue;
+
+      const userAttr = range.attrs.find((a) => a.name === "insert");
+      const timeAttr = range.attrs.find((a) => a.name === "insertAt");
+      const from = id.contentStart + (overlapStart - id.clock);
+      segments.push({
+        from,
+        to: from + (overlapEnd - overlapStart),
+        userId: userAttr ? String(userAttr.val) : null,
+        timestamp: timeAttr ? Number(timeAttr.val) : null,
+      });
+    }
+  }
+
+  segments.sort((a, b) => a.from - b.from);
+
+  // Merge adjacent segments from the same author.
+  const merged: AttributedSegment[] = [];
+  for (const segment of segments) {
+    const last = merged.at(-1);
+    if (
+      last &&
+      last.to === segment.from &&
+      last.userId === segment.userId &&
+      last.timestamp === segment.timestamp
+    ) {
+      last.to = segment.to;
+    } else {
+      merged.push({ ...segment });
+    }
+  }
+
+  return merged;
+}

--- a/src/protocols/attribution/server-handlers.ts
+++ b/src/protocols/attribution/server-handlers.ts
@@ -1,0 +1,176 @@
+import {
+  type RpcError,
+  type RpcHandlerRegistry,
+  type RpcServerContext,
+  type RpcServerRequestHandler,
+} from "teleportal/protocol";
+import {
+  type ContentAttribute,
+  decodeContentMap,
+  encodeContentMap,
+  filterContentMap,
+  getActivity,
+} from "teleportal/attribution";
+import type { EncodedContentMap } from "teleportal/storage";
+import {
+  type AttributionActivityRequest,
+  type AttributionActivityResponse,
+  type AttributionFilter,
+  type AttributionGetRequest,
+  type AttributionGetResponse,
+} from "./methods";
+
+export interface AttributionRpcOptions {
+  /**
+   * Optional gate for attribution reads. RPC messages bypass the server's
+   * global permission check, so attribution-specific authorization lives here.
+   * Return false (or throw) to deny. When omitted, reads are allowed for any
+   * client with an open session for the document (milestone parity).
+   */
+  checkPermission?: (context: RpcServerContext) => boolean | Promise<boolean>;
+}
+
+const FORBIDDEN: RpcError = {
+  type: "error",
+  statusCode: 403,
+  details: "Attribution access denied",
+};
+
+async function loadContentMap(
+  context: RpcServerContext,
+): Promise<EncodedContentMap | null> {
+  const retrieve = context.session.storage.retrieveAttribution;
+  if (!retrieve) return null;
+  return retrieve.call(context.session.storage, context.documentId);
+}
+
+/**
+ * Build a ContentMap attribute predicate from an {@link AttributionFilter}.
+ * Insert ranges carry `insert`/`insertAt`, delete ranges `delete`/`deleteAt`.
+ */
+function matchesFilter(
+  filter: AttributionFilter,
+): (attrs: ContentAttribute[]) => boolean {
+  return (attrs) => {
+    if (filter.userId !== undefined) {
+      const userAttr = attrs.find(
+        (a) => a.name === "insert" || a.name === "delete",
+      );
+      if (!userAttr || userAttr.val !== filter.userId) return false;
+    }
+    if (filter.from !== undefined || filter.to !== undefined) {
+      const timeAttr = attrs.find(
+        (a) => a.name === "insertAt" || a.name === "deleteAt",
+      );
+      if (timeAttr) {
+        const t = timeAttr.val as number;
+        if (filter.from !== undefined && t < filter.from) return false;
+        if (filter.to !== undefined && t > filter.to) return false;
+      }
+    }
+    return true;
+  };
+}
+
+const activityHandler =
+  (options: AttributionRpcOptions) =>
+  async (
+    payload: AttributionActivityRequest,
+    context: RpcServerContext,
+  ): Promise<{ response: AttributionActivityResponse | RpcError }> => {
+    try {
+      if (
+        options.checkPermission &&
+        !(await options.checkPermission(context))
+      ) {
+        return { response: FORBIDDEN };
+      }
+      const encoded = await loadContentMap(context);
+      if (!encoded) return { response: { activity: [] } };
+
+      const activity = getActivity(decodeContentMap(encoded), {
+        from: payload.from,
+        to: payload.to,
+        userId: payload.userId,
+      });
+      return { response: { activity } };
+    } catch (error) {
+      return {
+        response: {
+          type: "error",
+          statusCode: 500,
+          details:
+            error instanceof Error
+              ? error.message
+              : "Failed to read attribution activity",
+        },
+      };
+    }
+  };
+
+const getHandler =
+  (options: AttributionRpcOptions) =>
+  async (
+    payload: AttributionGetRequest,
+    context: RpcServerContext,
+  ): Promise<{ response: AttributionGetResponse | RpcError }> => {
+    try {
+      if (
+        options.checkPermission &&
+        !(await options.checkPermission(context))
+      ) {
+        return { response: FORBIDDEN };
+      }
+      const encoded = await loadContentMap(context);
+      if (!encoded) return { response: { contentMap: null } };
+
+      const filter = payload.filter;
+      if (
+        filter &&
+        (filter.userId !== undefined ||
+          filter.from !== undefined ||
+          filter.to !== undefined)
+      ) {
+        const predicate = matchesFilter(filter);
+        const filtered = filterContentMap(decodeContentMap(encoded), predicate);
+        return { response: { contentMap: encodeContentMap(filtered) } };
+      }
+
+      return { response: { contentMap: encoded } };
+    } catch (error) {
+      return {
+        response: {
+          type: "error",
+          statusCode: 500,
+          details:
+            error instanceof Error
+              ? error.message
+              : "Failed to read attribution",
+        },
+      };
+    }
+  };
+
+/**
+ * Creates read-only RPC handlers that expose document attribution to clients.
+ *
+ * Register alongside other protocol handlers:
+ *
+ *   new Server({ rpcHandlers: { ...getAttributionRpcHandlers() } })
+ *
+ * Methods:
+ * - `attributionActivity` — activity timeline (works for encrypted documents).
+ * - `attributionGet` — the encoded ContentMap for client-side range resolution.
+ */
+export function getAttributionRpcHandlers(
+  options: AttributionRpcOptions = {},
+): RpcHandlerRegistry {
+  return {
+    ["attributionActivity"]: {
+      handler: activityHandler(options),
+    } as RpcServerRequestHandler<unknown, unknown, unknown, RpcServerContext>,
+    ["attributionGet"]: {
+      handler: getHandler(options),
+    } as RpcServerRequestHandler<unknown, unknown, unknown, RpcServerContext>,
+  };
+}

--- a/src/protocols/milestone/README.md
+++ b/src/protocols/milestone/README.md
@@ -45,7 +45,10 @@ The `Provider` automatically handles milestone RPC requests via its `RpcClient`.
 ```typescript
 import { Provider } from "teleportal/providers";
 
-const provider = await Provider.create({ url: "wss://...", document: "my-doc" });
+const provider = await Provider.create({
+  url: "wss://...",
+  document: "my-doc",
+});
 
 // List milestones
 const milestones = await provider.listMilestones();
@@ -56,6 +59,21 @@ const milestone = await provider.createMilestone("v1.0");
 // Get milestone snapshot
 const snapshot = await provider.getMilestoneSnapshot(milestone.id);
 ```
+
+## Encryption (E2EE)
+
+For end-to-end-encrypted documents (a `Provider` created with an `encryptionKey`),
+`createMilestone` encrypts the snapshot with that key before it leaves the client, so the
+server only ever stores ciphertext; `getMilestoneSnapshot` decrypts it transparently, so
+callers still receive a plaintext Y.js update. The server treats the snapshot as opaque
+bytes either way. This is what makes client-side
+[milestone attribution](../attribution/README.md) possible without exposing content to the
+server.
+
+> Known limitation: server-generated **automatic** milestones cannot encrypt this way (the
+> server has no plaintext) and currently store a different encrypted-message-container
+> format. They are not consumed by the attribution helpers; prefer client-created milestones
+> on E2EE documents.
 
 ## Methods
 
@@ -312,6 +330,7 @@ The `session.storage` property provides access to the `DocumentStorage` for the 
 ## Method Names
 
 The RPC methods use the following string names:
+
 - `"milestoneList"` - list milestones for a document
 - `"milestoneGet"` - get a milestone snapshot
 - `"milestoneCreate"` - create a new milestone

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -25,6 +25,29 @@ import {
   type MilestoneRestoreResponse,
   type MilestoneUpdateNameResponse,
 } from "../protocols/milestone";
+import {
+  resolveRangeAttribution,
+  type AttributedSegment,
+  type AttributionActivityResponse,
+  type AttributionFilter,
+  type AttributionGetResponse,
+} from "../protocols/attribution";
+import {
+  changesetContentMap,
+  createContentIdsFromUpdate,
+  decodeContentMap,
+  getActivity,
+  milestoneContentMap,
+  resolveItemAttribution,
+  type ActivityEntry,
+  type ContentIds,
+  type ContentMap,
+} from "teleportal/attribution";
+import {
+  decryptUpdate,
+  encryptUpdate,
+  type EncryptedBinary,
+} from "teleportal/encryption-key";
 import { Connection, ConnectionContext, ConnectionState } from "./connection";
 import { FallbackConnection } from "./fallback-connection";
 import { RpcClient, RpcOperationError } from "./rpc-client";
@@ -193,6 +216,8 @@ export class Provider<
   #getTransport: ProviderOptions["getTransport"];
   public subdocs: Map<string, Provider> = new Map();
   #rpcClient: RpcClient;
+  /** Cache of the decoded attribution ContentMap from the last fetch. */
+  #attributionMap: ContentMap | null | undefined;
   #rpcHandlers: ClientRpcHandlerRegistry;
   #handlerCleanups: Array<() => void> = [];
   public encryptionKey?: CryptoKey;
@@ -721,7 +746,13 @@ export class Provider<
         { milestoneId },
       );
 
-      return response.snapshot as unknown as MilestoneSnapshot;
+      const snapshot = response.snapshot as unknown as Uint8Array;
+      // For E2EE documents the snapshot is stored encrypted; decrypt it here so
+      // consumers always receive a plaintext Y.js update (see createMilestone).
+      const plaintext = this.encryptionKey
+        ? await decryptUpdate(this.encryptionKey, snapshot as EncryptedBinary)
+        : snapshot;
+      return plaintext as unknown as MilestoneSnapshot;
     } catch (error) {
       if (error instanceof RpcOperationError) {
         throw new MilestoneOperationError("get milestone snapshot", error);
@@ -737,9 +768,13 @@ export class Provider<
    * @throws Error if the operation is denied or if the connection fails
    */
   async createMilestone(name?: string): Promise<Milestone> {
-    const snapshot = Y.encodeStateAsUpdateV2(
-      this.doc,
-    ) as unknown as MilestoneSnapshot;
+    const plaintext = Y.encodeStateAsUpdateV2(this.doc);
+    // For E2EE documents, encrypt the snapshot before it leaves the client so
+    // milestone content is never stored in plaintext on the server. The server
+    // treats the snapshot as opaque bytes; getMilestoneSnapshot decrypts it.
+    const snapshot = (this.encryptionKey
+      ? await encryptUpdate(this.encryptionKey, plaintext)
+      : plaintext) as unknown as MilestoneSnapshot;
 
     try {
       const response =
@@ -829,6 +864,198 @@ export class Provider<
       }
       throw error;
     }
+  }
+
+  /**
+   * Fetch the attribution activity timeline for the current document.
+   *
+   * Works for encrypted documents — the server resolves this from authorship
+   * and timestamps without needing the document content.
+   *
+   * @param options - Optional time range (`from`/`to`, ms) and `userId` filter
+   * @returns A sorted list of activity entries
+   */
+  async getActivity(options?: AttributionFilter): Promise<ActivityEntry[]> {
+    const response =
+      await this.#rpcClient.sendRequest<AttributionActivityResponse>(
+        this.document,
+        "attributionActivity",
+        { ...options },
+      );
+    return response.activity;
+  }
+
+  /**
+   * Fetch and decode the attribution ContentMap for the current document, and
+   * cache it for subsequent local lookups. Returns null when the server has no
+   * attribution data for the document.
+   *
+   * @param filter - Optional server-side filter (`userId`, `from`/`to`)
+   */
+  async getAttributionMap(
+    filter?: AttributionFilter,
+  ): Promise<ContentMap | null> {
+    const response = await this.#rpcClient.sendRequest<AttributionGetResponse>(
+      this.document,
+      "attributionGet",
+      filter ? { filter } : {},
+    );
+    this.#attributionMap = response.contentMap
+      ? decodeContentMap(response.contentMap)
+      : null;
+    return this.#attributionMap;
+  }
+
+  /**
+   * Ensure the attribution ContentMap is loaded, fetching it once if needed.
+   */
+  async #ensureAttributionMap(): Promise<ContentMap | null> {
+    if (this.#attributionMap === undefined) {
+      await this.getAttributionMap();
+    }
+    return this.#attributionMap ?? null;
+  }
+
+  /**
+   * Resolve who authored a specific Y.js item identified by (clientID, clock).
+   * Uses the cached ContentMap, fetching it once if not yet loaded.
+   */
+  async resolveAttribution(
+    clientID: number,
+    clock: number,
+  ): Promise<{ userId: string; timestamp: number } | null> {
+    const map = await this.#ensureAttributionMap();
+    if (!map) return null;
+    return resolveItemAttribution(map, clientID, clock);
+  }
+
+  /**
+   * Resolve attribution for a content range of a Y type (e.g. a Y.Text), mapping
+   * the position range to CRDT operation IDs against the local document, then
+   * looking them up in the (cached) ContentMap. Runs entirely client-side, so it
+   * works for encrypted documents.
+   *
+   * @param type - The Y type the range refers to (Y.Text, Y.Array, Y.XmlText...)
+   * @param index - Start offset within `type`
+   * @param length - Number of positions to resolve
+   * @returns Attributed segments in the coordinate space of `type`
+   */
+  async getAttributionForRange(
+    type: Y.AbstractType<any>,
+    index: number,
+    length: number,
+  ): Promise<AttributedSegment[]> {
+    const map = await this.#ensureAttributionMap();
+    if (!map) return [];
+    return resolveRangeAttribution(type, index, length, map);
+  }
+
+  /**
+   * The operation IDs contained in a milestone, derived from its (decrypted)
+   * snapshot. These identify which CRDT operations existed as of the milestone.
+   */
+  async #milestoneContentIds(milestoneId: string): Promise<ContentIds> {
+    const snapshot = await this.getMilestoneSnapshot(milestoneId);
+    return createContentIdsFromUpdate(snapshot as unknown as Uint8Array);
+  }
+
+  /**
+   * Reconstruct the Y.Doc state captured by a milestone from its (decrypted)
+   * snapshot, for resolving content positions against that historical state.
+   */
+  async #milestoneDoc(milestoneId: string): Promise<Y.Doc> {
+    const snapshot = await this.getMilestoneSnapshot(milestoneId);
+    const doc = new Y.Doc();
+    Y.applyUpdateV2(doc, snapshot as unknown as Uint8Array);
+    return doc;
+  }
+
+  /**
+   * Attribution restricted to the content present in a milestone — i.e. who
+   * authored what the document contained as of that milestone. Computed
+   * client-side by intersecting the document's full ContentMap with the
+   * milestone's operation IDs. Returns null when no attribution data exists.
+   */
+  async getMilestoneContentMap(
+    milestoneId: string,
+  ): Promise<ContentMap | null> {
+    const [map, ids] = await Promise.all([
+      this.#ensureAttributionMap(),
+      this.#milestoneContentIds(milestoneId),
+    ]);
+    if (!map) return null;
+    return milestoneContentMap(map, ids);
+  }
+
+  /**
+   * Activity timeline for the content present in a milestone.
+   * @param options - Optional time range (`from`/`to`, ms) and `userId` filter
+   */
+  async getMilestoneActivity(
+    milestoneId: string,
+    options?: AttributionFilter,
+  ): Promise<ActivityEntry[]> {
+    const map = await this.getMilestoneContentMap(milestoneId);
+    if (!map) return [];
+    return getActivity(map, options);
+  }
+
+  /**
+   * Attribution for the changes made between two milestones — the operations
+   * added from `fromMilestoneId` to `toMilestoneId` (both new inserts and new
+   * deletes). Returns null when no attribution data exists.
+   */
+  async getChangesetContentMap(
+    fromMilestoneId: string,
+    toMilestoneId: string,
+  ): Promise<ContentMap | null> {
+    const [map, fromIds, toIds] = await Promise.all([
+      this.#ensureAttributionMap(),
+      this.#milestoneContentIds(fromMilestoneId),
+      this.#milestoneContentIds(toMilestoneId),
+    ]);
+    if (!map) return null;
+    return changesetContentMap(map, fromIds, toIds);
+  }
+
+  /**
+   * Activity timeline for the changes made between two milestones.
+   * @param options - Optional time range (`from`/`to`, ms) and `userId` filter
+   */
+  async getChangesetActivity(
+    fromMilestoneId: string,
+    toMilestoneId: string,
+    options?: AttributionFilter,
+  ): Promise<ActivityEntry[]> {
+    const map = await this.getChangesetContentMap(
+      fromMilestoneId,
+      toMilestoneId,
+    );
+    if (!map) return [];
+    return getActivity(map, options);
+  }
+
+  /**
+   * Resolve attribution for a content range as it existed in a milestone.
+   * Rebuilds the milestone's document from its (decrypted) snapshot, selects the
+   * target Y type via `select`, and resolves the range against the document's
+   * full ContentMap. Runs entirely client-side, so it works for E2EE documents.
+   *
+   * @param select - Picks the Y type from the rebuilt milestone Y.Doc
+   *   (e.g. `(doc) => doc.getText("body")`)
+   */
+  async getMilestoneAttributionForRange(
+    milestoneId: string,
+    select: (doc: Y.Doc) => Y.AbstractType<any>,
+    index: number,
+    length: number,
+  ): Promise<AttributedSegment[]> {
+    const [map, doc] = await Promise.all([
+      this.#ensureAttributionMap(),
+      this.#milestoneDoc(milestoneId),
+    ]);
+    if (!map) return [];
+    return resolveRangeAttribution(select(doc), index, length, map);
   }
 
   /**

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,4 +1,5 @@
 import type { Message, ServerContext } from "teleportal";
+import type { EncodedContentMap } from "teleportal/storage";
 import type { Session } from "./session";
 
 export type DocumentUnloadReason = "cleanup" | "delete" | "dispose";
@@ -109,6 +110,19 @@ export type SessionEvents<Context extends ServerContext = ServerContext> = {
     namespacedDocumentId: string;
     milestoneId: string;
     context: Context;
+  }) => void;
+
+  /**
+   * Emitted when attribution is recorded for a document update.
+   * Fires for both encrypted and unencrypted documents when attribution is computed.
+   */
+  "document-attribution": (data: {
+    documentId: string;
+    namespacedDocumentId: string;
+    sessionId: string;
+    userId: string;
+    timestamp: number;
+    contentMap: EncodedContentMap;
   }) => void;
 
   /**

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import * as Y from "yjs";
 
 import { Server } from "./server";
 import { checkPermissionWithTokenManager } from "./check-permission";
@@ -19,6 +20,12 @@ import type {
   DocumentStorage,
 } from "teleportal/storage";
 
+function createTestUpdate(content = "test"): Update {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, content);
+  return Y.encodeStateAsUpdateV2(doc) as Update;
+}
+
 // Mock DocumentStorage for testing
 class MockDocumentStorage implements DocumentStorage {
   readonly type = "document-storage" as const;
@@ -36,7 +43,7 @@ class MockDocumentStorage implements DocumentStorage {
       id: documentId,
       metadata: await this.getDocumentMetadata(documentId),
       content: {
-        update: new Uint8Array([1, 2, 3]) as unknown as Update,
+        update: createTestUpdate("sync"),
         stateVector: syncStep1,
       },
     };
@@ -49,7 +56,7 @@ class MockDocumentStorage implements DocumentStorage {
     return;
   }
 
-  async handleUpdate(_documentId: string, update: Update): Promise<void> {
+  async handleUpdate(_documentId: string, update: Update, _attribution?: import("teleportal/storage").EncodedContentMap): Promise<void> {
     this.mockHandleUpdate = true;
     this.storedUpdate = update;
   }
@@ -729,7 +736,7 @@ describe("Server", () => {
         "test-doc",
         {
           type: "sync-step-2",
-          update: new Uint8Array([1, 2, 3]) as SyncStep2Update,
+          update: createTestUpdate() as unknown as SyncStep2Update,
         },
         { clientId: "client-1", userId: "user-1", room: "room" },
         false,
@@ -1125,7 +1132,7 @@ describe("Server", () => {
       // Send update from client1
       const update = new DocMessage(
         "test-doc",
-        { type: "update", update: new Uint8Array([1, 2, 3]) as Update },
+        { type: "update", update: createTestUpdate() },
         { clientId: "client-1", userId: "user-1", room: "room" },
         false,
       );
@@ -1619,7 +1626,7 @@ describe("Server", () => {
 
       const message = new DocMessage(
         "test-doc",
-        { type: "update", update: new Uint8Array([1, 2, 3]) as Update },
+        { type: "update", update: createTestUpdate() },
         {
           clientId: "client-1",
           userId: payload.payload.userId,
@@ -1682,7 +1689,7 @@ describe("Server", () => {
 
       const message = new DocMessage(
         "test-doc",
-        { type: "update", update: new Uint8Array([1, 2, 3]) as Update },
+        { type: "update", update: createTestUpdate() },
         {
           clientId: "client-1",
           ...payload.payload,
@@ -1767,7 +1774,7 @@ describe("Server", () => {
         "test-doc",
         {
           type: "sync-step-2",
-          update: new Uint8Array([1, 2, 3]) as SyncStep2Update,
+          update: createTestUpdate() as unknown as SyncStep2Update,
         },
         {
           clientId: "client-1",
@@ -1859,7 +1866,7 @@ describe("Server", () => {
       // Test write operation
       const writeMessage = new DocMessage(
         "test-doc",
-        { type: "update", update: new Uint8Array([1, 2, 3]) as Update },
+        { type: "update", update: createTestUpdate() },
         {
           clientId: "client-1",
           userId: payload.payload.userId,

--- a/src/server/session-rpc.test.ts
+++ b/src/server/session-rpc.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as Y from "yjs";
 import type {
   Message,
   ServerContext,
@@ -16,6 +17,12 @@ import type {
 import { InMemoryPubSub } from "teleportal";
 import { Session } from "./session";
 import { Server } from "./server";
+
+function createTestUpdate(content = "test"): Update {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, content);
+  return Y.encodeStateAsUpdateV2(doc) as Update;
+}
 
 class MockClient<Context extends ServerContext> {
   public id: string;
@@ -48,7 +55,7 @@ class MockDocumentStorage implements DocumentStorage {
       id: documentId,
       metadata: await this.getDocumentMetadata(documentId),
       content: {
-        update: new Uint8Array([1, 2, 3]) as unknown as Update,
+        update: createTestUpdate("sync"),
         stateVector: syncStep1,
       },
     };
@@ -59,7 +66,7 @@ class MockDocumentStorage implements DocumentStorage {
     _syncStep2: SyncStep2Update,
   ): Promise<void> {}
 
-  async handleUpdate(_documentId: string, update: Update): Promise<void> {
+  async handleUpdate(_documentId: string, update: Update, _attribution?: import("teleportal/storage").EncodedContentMap): Promise<void> {
     this.storedUpdate = update;
   }
 

--- a/src/server/session.test.ts
+++ b/src/server/session.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { getLogger } from "@logtape/logtape";
+import * as Y from "yjs";
 import type {
   Message,
   ServerContext,
@@ -12,6 +13,7 @@ import type {
   Document,
   DocumentMetadata,
   DocumentStorage,
+  EncodedContentMap,
 } from "teleportal/storage";
 import { Session } from "./session";
 import { Server } from "./server";
@@ -59,7 +61,7 @@ class MockDocumentStorage implements DocumentStorage {
       id: documentId,
       metadata: await this.getDocumentMetadata(documentId),
       content: {
-        update: new Uint8Array([1, 2, 3]) as unknown as Update,
+        update: createTestUpdate("sync"),
         stateVector: syncStep1,
       },
     };
@@ -73,7 +75,7 @@ class MockDocumentStorage implements DocumentStorage {
     this.lastSyncStep2 = syncStep2;
   }
 
-  async handleUpdate(_documentId: string, update: Update): Promise<void> {
+  async handleUpdate(_documentId: string, update: Update, _attribution?: EncodedContentMap): Promise<void> {
     this.mockHandleUpdate = true;
     this.storedUpdate = update;
   }
@@ -153,6 +155,12 @@ function createMockServer(): Server<ServerContext> {
       throw new Error("Not implemented in mock");
     },
   });
+}
+
+function createTestUpdate(content = "test"): Update {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, content);
+  return Y.encodeStateAsUpdateV2(doc) as Update;
 }
 
 describe("Session", () => {
@@ -243,7 +251,7 @@ describe("Session", () => {
 
       const message = new DocMessage(
         "test-doc",
-        { type: "update", update: new Uint8Array([1, 2, 3]) as Update },
+        { type: "update", update: createTestUpdate() },
         { clientId: "other-client", userId: "user-1", room: "room" },
         false,
       );
@@ -268,7 +276,7 @@ describe("Session", () => {
 
       const message = new DocMessage(
         "test-doc",
-        { type: "update", update: new Uint8Array([1, 2, 3]) as Update },
+        { type: "update", update: createTestUpdate() },
         { clientId: "other-client", userId: "user-1", room: "room" },
         false,
       );
@@ -293,7 +301,7 @@ describe("Session", () => {
 
       const message = new DocMessage(
         "other-doc",
-        { type: "update", update: new Uint8Array([1, 2, 3]) as Update },
+        { type: "update", update: createTestUpdate() },
         { clientId: "other-client", userId: "user-1", room: "room" },
         false,
       );
@@ -486,7 +494,7 @@ describe("Session", () => {
 
   describe("write", () => {
     it("should write update to storage", async () => {
-      const update = new Uint8Array([1, 2, 3]) as Update;
+      const update = createTestUpdate();
       await session.write(update);
 
       expect(storage.mockHandleUpdate).toBe(true);
@@ -565,7 +573,7 @@ describe("Session", () => {
         session.addClient(client1 as any);
         session.addClient(client2 as any);
 
-        const update = new Uint8Array([1, 2, 3]) as Update;
+        const update = createTestUpdate();
         const message = new DocMessage(
           "test-doc",
           { type: "update", update },
@@ -587,7 +595,7 @@ describe("Session", () => {
         await session.load();
         session.addClient(client1 as any);
 
-        const update = new Uint8Array([1, 2, 3]) as Update;
+        const update = createTestUpdate();
         const message = new DocMessage(
           "test-doc",
           { type: "update", update },
@@ -625,7 +633,7 @@ describe("Session", () => {
         session.addClient(client1 as any);
         session.addClient(client2 as any);
 
-        const update = new Uint8Array([1, 2, 3]) as SyncStep2Update;
+        const update = createTestUpdate() as unknown as SyncStep2Update;
         const message = new DocMessage(
           "test-doc",
           { type: "sync-step-2", update },
@@ -645,7 +653,7 @@ describe("Session", () => {
       });
 
       it("should not send sync-done if no client provided", async () => {
-        const update = new Uint8Array([1, 2, 3]) as SyncStep2Update;
+        const update = createTestUpdate() as unknown as SyncStep2Update;
         const message = new DocMessage(
           "test-doc",
           { type: "sync-step-2", update },
@@ -864,7 +872,7 @@ describe("Session", () => {
         "test-doc",
         {
           type: "sync-step-2",
-          update: new Uint8Array([1, 2, 3]) as SyncStep2Update,
+          update: createTestUpdate() as unknown as SyncStep2Update,
         },
         { clientId: "client-1", userId: "user-1", room: "room" },
       );
@@ -889,7 +897,7 @@ describe("Session", () => {
         "test-doc",
         {
           type: "sync-step-2",
-          update: new Uint8Array([1, 2, 3]) as SyncStep2Update,
+          update: createTestUpdate() as unknown as SyncStep2Update,
         },
         { clientId: "client-1", userId: "user-1", room: "room" },
       );
@@ -918,7 +926,7 @@ describe("Session", () => {
         "test-doc",
         {
           type: "sync-step-2",
-          update: new Uint8Array([1, 2, 3]) as SyncStep2Update,
+          update: createTestUpdate() as unknown as SyncStep2Update,
         },
         { clientId: "client-1", userId: "user-1", room: "room" },
       );
@@ -945,7 +953,7 @@ describe("Session", () => {
         "test-doc",
         {
           type: "sync-step-2",
-          update: new Uint8Array([1, 2, 3]) as SyncStep2Update,
+          update: createTestUpdate() as unknown as SyncStep2Update,
         },
         { clientId: "client-1", userId: "user-1", room: "room" },
       );

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -16,7 +16,18 @@ import {
   type RpcServerContext,
   type RpcSuccess,
 } from "teleportal/protocol";
-import type { DocumentStorage } from "teleportal/storage";
+import type { DocumentStorage, EncodedContentMap } from "teleportal/storage";
+import type { EncryptedUpdatePayload } from "teleportal/protocol/encryption";
+import { decodeEncryptedUpdate } from "teleportal/protocol/encryption";
+import {
+  type ContentIds,
+  createContentAttribute,
+  createContentIdsFromUpdate,
+  createContentMapFromContentIds,
+  decodeContentIds,
+  encodeContentMap,
+  mergeContentIds,
+} from "teleportal/attribution";
 import { Observable } from "../lib/utils";
 import { Client } from "./client";
 import { TtlDedupe } from "./dedupe";
@@ -163,7 +174,7 @@ export class Session<Context extends ServerContext> extends Observable<
               sourceNodeId: sourceId,
               deduped: false,
             });
-          } catch (err) {
+          } catch (error_) {
             emitWideEvent("error", {
               event_type: "replication_apply_failed",
               timestamp: new Date().toISOString(),
@@ -172,8 +183,8 @@ export class Session<Context extends ServerContext> extends Observable<
               message_id: message.id,
               source_node_id: sourceId,
               error: {
-                type: err instanceof Error ? err.name : "Error",
-                message: err instanceof Error ? err.message : String(err),
+                type: error_ instanceof Error ? error_.name : "Error",
+                message: error_ instanceof Error ? error_.message : String(error_),
               },
             });
           }
@@ -266,9 +277,43 @@ export class Session<Context extends ServerContext> extends Observable<
   /**
    * Write an update to the storage.
    */
-  async write(update: Update, context?: Context) {
+  async write(
+    update: Update,
+    context?: Context,
+    source: DocumentMessageSource = "client",
+  ) {
     try {
-      await this.#storage.handleUpdate(this.namespacedDocumentId, update);
+      let attribution: EncodedContentMap | undefined;
+      if (source === "client" && context?.userId) {
+        try {
+          attribution = this.#computeAttribution(update, context);
+        } catch (error) {
+          emitWideEvent("error", {
+            event_type: "attribution_compute_failed",
+            timestamp: new Date().toISOString(),
+            document_id: this.documentId,
+            session_id: this.id,
+            error,
+          });
+        }
+      }
+
+      await this.#storage.handleUpdate(
+        this.namespacedDocumentId,
+        update,
+        attribution,
+      );
+
+      if (attribution) {
+        this.call("document-attribution", {
+          documentId: this.documentId,
+          namespacedDocumentId: this.namespacedDocumentId,
+          sessionId: this.id,
+          userId: context!.userId,
+          timestamp: Date.now(),
+          contentMap: attribution,
+        });
+      }
 
       this.call("document-write", {
         documentId: this.documentId,
@@ -334,6 +379,31 @@ export class Session<Context extends ServerContext> extends Observable<
       });
       throw error;
     }
+  }
+
+  #computeAttribution(update: Update, context: Context) {
+    let contentIds: ContentIds;
+    if (this.encrypted) {
+      const messages = decodeEncryptedUpdate(
+        update as unknown as EncryptedUpdatePayload,
+      );
+      const decoded = messages.map((m) => decodeContentIds(m.contentIds));
+      contentIds =
+        decoded.length === 1 ? decoded[0] : mergeContentIds(decoded);
+    } else {
+      contentIds = createContentIdsFromUpdate(update);
+    }
+    const now = Date.now();
+    const userId = context.userId;
+    return encodeContentMap(
+      createContentMapFromContentIds(contentIds, [
+        createContentAttribute("insert", userId),
+        createContentAttribute("insertAt", now),
+      ], [
+        createContentAttribute("delete", userId),
+        createContentAttribute("deleteAt", now),
+      ]),
+    );
   }
 
   #emitDocumentMessage(
@@ -424,7 +494,13 @@ export class Session<Context extends ServerContext> extends Observable<
               return;
             }
             case "update": {
-              await this.write(message.payload.update, message.context);
+              const messageSource: DocumentMessageSource =
+                replicationMeta?.sourceNodeId ? "replication" : "client";
+              await this.write(
+                message.payload.update,
+                message.context,
+                messageSource,
+              );
 
               await Promise.all([
                 this.broadcast(message, client?.id),
@@ -438,7 +514,7 @@ export class Session<Context extends ServerContext> extends Observable<
               this.#emitDocumentMessage(
                 message,
                 client,
-                replicationMeta?.sourceNodeId ? "replication" : "client",
+                messageSource,
                 replicationMeta?.sourceNodeId,
                 replicationMeta?.deduped,
               );
@@ -510,7 +586,8 @@ export class Session<Context extends ServerContext> extends Observable<
           const rpcMessage = message as RpcMessage<Context>;
           const { requestType, originalRequestId } = rpcMessage;
 
-          if (requestType === "request") {
+          switch (requestType) {
+          case "request": {
             const method = rpcMessage.rpcMethod;
 
             if (rpcMessage.payload.type !== "success") {
@@ -602,12 +679,10 @@ export class Session<Context extends ServerContext> extends Observable<
                       payload: result.response,
                     };
               const serializer = (ctx: any) => {
-                if (ctx.type === "rpc" && ctx.requestType === "response") {
-                  // Only serialize if it's a success response (not an error)
-                  if (ctx.message.payload.type === "success") {
+                if (ctx.type === "rpc" && ctx.requestType === "response" && // Only serialize if it's a success response (not an error)
+                  ctx.message.payload.type === "success") {
                     return handler.response?.encode?.(result.response);
                   }
-                }
                 return undefined;
               };
               const responseMessage = new RpcMessage(
@@ -650,7 +725,10 @@ export class Session<Context extends ServerContext> extends Observable<
               );
               await client.send(errorMessage);
             }
-          } else if (requestType === "stream") {
+          
+          break;
+          }
+          case "stream": {
             const method = rpcMessage.rpcMethod;
             const handler = this.#rpcHandlers[method];
 
@@ -710,7 +788,14 @@ export class Session<Context extends ServerContext> extends Observable<
                 }
               }
             }
-          } else if (requestType === "response") {
+          
+          break;
+          }
+          case "response": {
+          
+          break;
+          }
+          // No default
           }
 
           return;

--- a/src/storage/encrypted/document-storage.ts
+++ b/src/storage/encrypted/document-storage.ts
@@ -18,8 +18,10 @@ import {
   type DocumentMetadata as BaseDocumentMetadata,
   type DocumentStorage,
   type Document,
+  type EncodedContentMap,
 } from "../types";
 import { EncryptedBinary } from "teleportal/encryption-key";
+import { getEmptyEncodedContentIds } from "teleportal/attribution";
 
 export interface EncryptedDocumentMetadata extends BaseDocumentMetadata {
   seenMessages: SeenMessageMapping;
@@ -134,6 +136,7 @@ export abstract class EncryptedDocumentStorage implements DocumentStorage {
   async handleUpdate(
     key: string,
     update: EncryptedUpdatePayload,
+    _attribution?: EncodedContentMap,
   ): Promise<void> {
     await this.transaction(key, async () => {
       const { seenMessages, ...rest } = await this.getDocumentMetadata(key);
@@ -176,6 +179,7 @@ export abstract class EncryptedDocumentStorage implements DocumentStorage {
             id: messageId,
             payload: message,
             timestamp: [Number.parseInt(clientId), Number.parseInt(counter)],
+            contentIds: getEmptyEncodedContentIds(),
           });
         }
       }
@@ -210,4 +214,5 @@ export abstract class EncryptedDocumentStorage implements DocumentStorage {
   transaction<T>(key: string, cb: () => Promise<T>): Promise<T> {
     return cb();
   }
+
 }

--- a/src/storage/in-memory/encrypted.test.ts
+++ b/src/storage/in-memory/encrypted.test.ts
@@ -6,7 +6,7 @@ import type {
 import type { Update } from "teleportal";
 import { EncryptedBinary } from "teleportal/encryption-key";
 import { EncryptedMemoryStorage } from "./encrypted";
-import type { FileStorage } from "../types";
+import type { EncodedContentMap, FileStorage } from "../types";
 import {
   encodeEncryptedUpdateMessages,
   encodeToSyncStep2,
@@ -15,14 +15,23 @@ import {
 import type { DecodedEncryptedUpdatePayload } from "teleportal/protocol/encryption";
 import { digest } from "lib0/hash/sha256";
 import { toBase64 } from "lib0/buffer";
+import {
+  createContentAttribute,
+  createContentMapFromContentIds,
+  createContentIds,
+  decodeContentMap,
+  encodeContentMap,
+  getEmptyEncodedContentIds,
+  IdSet,
+} from "teleportal/attribution";
 
 describe("EncryptedMemoryStorage", () => {
   let storage: EncryptedMemoryStorage;
   let mockFileStorage: FileStorage;
 
   beforeEach(() => {
-    // Clear static map before each test
     EncryptedMemoryStorage.docs.clear();
+    EncryptedMemoryStorage.attributionMaps.clear();
     storage = new EncryptedMemoryStorage();
   });
 
@@ -304,6 +313,7 @@ describe("EncryptedMemoryStorage", () => {
         id: messageId,
         timestamp: [1, 5],
         payload,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const syncStep2 = encodeToSyncStep2({ messages: [message] });
@@ -328,11 +338,13 @@ describe("EncryptedMemoryStorage", () => {
         id: messageId1,
         timestamp: [1, 5],
         payload: payload1,
+        contentIds: getEmptyEncodedContentIds(),
       };
       const message2: DecodedEncryptedUpdatePayload = {
         id: messageId2,
         timestamp: [1, 6],
         payload: payload2,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const syncStep2 = encodeToSyncStep2({ messages: [message1, message2] });
@@ -354,6 +366,7 @@ describe("EncryptedMemoryStorage", () => {
         id: messageId,
         timestamp: [2, 10],
         payload,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const update = encodeEncryptedUpdateMessages([message]);
@@ -374,6 +387,7 @@ describe("EncryptedMemoryStorage", () => {
         id: "msg-1",
         timestamp: [3, 15],
         payload: new Uint8Array([1, 2, 3]) as EncryptedBinary,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const update = encodeEncryptedUpdateMessages([message]);
@@ -395,11 +409,13 @@ describe("EncryptedMemoryStorage", () => {
         id: "msg-1",
         timestamp: [1, 5],
         payload: new Uint8Array([1, 2, 3]) as EncryptedBinary,
+        contentIds: getEmptyEncodedContentIds(),
       };
       const message2: DecodedEncryptedUpdatePayload = {
         id: "msg-2",
         timestamp: [2, 10],
         payload: new Uint8Array([4, 5, 6]) as EncryptedBinary,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       await storage.storeEncryptedMessage(
@@ -463,6 +479,119 @@ describe("EncryptedMemoryStorage", () => {
       });
 
       expect(result).toBe("test-result");
+    });
+  });
+
+  describe("attribution", () => {
+    function makeAttribution(userId: string, clientId = 1, clock = 0, len = 1): EncodedContentMap {
+      const inserts = new IdSet();
+      inserts.add(clientId, clock, len);
+      const contentIds = createContentIds(inserts, new IdSet());
+      return encodeContentMap(
+        createContentMapFromContentIds(contentIds, [
+          createContentAttribute("insert", userId),
+          createContentAttribute("insertAt", Date.now()),
+        ], []),
+      );
+    }
+
+    it("should store and retrieve attribution via handleUpdate", async () => {
+      const key = "attr-doc-1";
+      const payload = new Uint8Array([10, 20, 30]) as EncryptedBinary;
+      const messageId = toBase64(digest(payload));
+      const message: DecodedEncryptedUpdatePayload = {
+        id: messageId,
+        timestamp: [1, 0],
+        payload,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+      const update = encodeEncryptedUpdateMessages([message]);
+      const attribution = makeAttribution("user-1");
+
+      await storage.handleUpdate(key, update, attribution);
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBeGreaterThan(0);
+    });
+
+    it("should return null when no attribution exists", async () => {
+      const result = await storage.retrieveAttribution("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("should not store attribution when param is undefined", async () => {
+      const key = "attr-doc-2";
+      const payload = new Uint8Array([1, 2, 3]) as EncryptedBinary;
+      const messageId = toBase64(digest(payload));
+      const message: DecodedEncryptedUpdatePayload = {
+        id: messageId,
+        timestamp: [1, 0],
+        payload,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+      const update = encodeEncryptedUpdateMessages([message]);
+
+      await storage.handleUpdate(key, update);
+
+      const result = await storage.retrieveAttribution(key);
+      expect(result).toBeNull();
+    });
+
+    it("should merge multiple attributions on retrieve", async () => {
+      const key = "attr-doc-3";
+      const payload1 = new Uint8Array([1, 2, 3]) as EncryptedBinary;
+      const payload2 = new Uint8Array([4, 5, 6]) as EncryptedBinary;
+      const msg1: DecodedEncryptedUpdatePayload = {
+        id: toBase64(digest(payload1)),
+        timestamp: [1, 0],
+        payload: payload1,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+      const msg2: DecodedEncryptedUpdatePayload = {
+        id: toBase64(digest(payload2)),
+        timestamp: [2, 0],
+        payload: payload2,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+
+      await storage.handleUpdate(
+        key,
+        encodeEncryptedUpdateMessages([msg1]),
+        makeAttribution("user-1", 1, 0, 5),
+      );
+      await storage.handleUpdate(
+        key,
+        encodeEncryptedUpdateMessages([msg2]),
+        makeAttribution("user-2", 2, 0, 3),
+      );
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBe(2);
+    });
+
+    it("should clean up attribution on deleteDocument", async () => {
+      const key = "attr-doc-4";
+      const payload = new Uint8Array([1, 2, 3]) as EncryptedBinary;
+      const msg: DecodedEncryptedUpdatePayload = {
+        id: toBase64(digest(payload)),
+        timestamp: [1, 0],
+        payload,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+
+      await storage.handleUpdate(
+        key,
+        encodeEncryptedUpdateMessages([msg]),
+        makeAttribution("user-1"),
+      );
+      expect(await storage.retrieveAttribution(key)).not.toBeNull();
+
+      await storage.deleteDocument(key);
+      expect(await storage.retrieveAttribution(key)).toBeNull();
     });
   });
 });

--- a/src/storage/in-memory/encrypted.ts
+++ b/src/storage/in-memory/encrypted.ts
@@ -3,11 +3,18 @@ import type {
   EncryptedUpdatePayload,
 } from "teleportal/protocol/encryption";
 import {
+  decodeContentMap,
+  encodeContentMap,
+  mergeContentMaps,
+} from "teleportal/attribution";
+import {
   EncryptedDocumentMetadata,
   EncryptedDocumentStorage,
 } from "../encrypted";
+import type { EncodedContentMap } from "../types";
 
 export class EncryptedMemoryStorage extends EncryptedDocumentStorage {
+  public static attributionMaps = new Map<string, EncodedContentMap[]>();
   constructor(
     private options: {
       write: (
@@ -111,7 +118,34 @@ export class EncryptedMemoryStorage extends EncryptedDocumentStorage {
     return update;
   }
 
+  override async handleUpdate(
+    key: string,
+    update: EncryptedUpdatePayload,
+    attribution?: EncodedContentMap,
+  ): Promise<void> {
+    await super.handleUpdate(key, update);
+    if (attribution) {
+      let list = EncryptedMemoryStorage.attributionMaps.get(key);
+      if (!list) {
+        list = [];
+        EncryptedMemoryStorage.attributionMaps.set(key, list);
+      }
+      list.push(attribution);
+    }
+  }
+
   async deleteDocument(key: string): Promise<void> {
     EncryptedMemoryStorage.docs.delete(key);
+    EncryptedMemoryStorage.attributionMaps.delete(key);
+  }
+
+  async retrieveAttribution(
+    documentId: string,
+  ): Promise<EncodedContentMap | null> {
+    const list = EncryptedMemoryStorage.attributionMaps.get(documentId);
+    if (!list || list.length === 0) return null;
+    if (list.length === 1) return list[0];
+    const merged = mergeContentMaps(list.map((m) => decodeContentMap(m)));
+    return encodeContentMap(merged) as EncodedContentMap;
   }
 }

--- a/src/storage/in-memory/ydoc.test.ts
+++ b/src/storage/in-memory/ydoc.test.ts
@@ -2,17 +2,25 @@ import { beforeEach, describe, expect, it } from "bun:test";
 import * as Y from "yjs";
 import type { StateVector, Update } from "teleportal";
 import { getEmptyStateVector, getEmptyUpdate } from "../../lib/protocol/utils";
+import {
+  createContentAttribute,
+  createContentIdsFromUpdate,
+  createContentMapFromContentIds,
+  decodeContentMap,
+  encodeContentMap,
+  resolveItemAttribution,
+} from "teleportal/attribution";
 import { YDocStorage } from "./ydoc";
-import type { FileStorage } from "../types";
+import type { EncodedContentMap, FileStorage } from "../types";
 
 describe("YDocStorage", () => {
   let storage: YDocStorage;
   let mockFileStorage: FileStorage;
 
   beforeEach(() => {
-    // Clear static maps before each test
     YDocStorage.docs.clear();
     YDocStorage.metadata.clear();
+    YDocStorage.attributionMaps.clear();
     storage = new YDocStorage();
   });
 
@@ -277,6 +285,86 @@ describe("YDocStorage", () => {
       });
 
       expect(result).toBe("test-result");
+    });
+  });
+
+  describe("attribution", () => {
+    function makeAttribution(update: Update, userId: string): EncodedContentMap {
+      const contentIds = createContentIdsFromUpdate(update);
+      return encodeContentMap(
+        createContentMapFromContentIds(contentIds, [
+          createContentAttribute("insert", userId),
+          createContentAttribute("insertAt", Date.now()),
+        ], [
+          createContentAttribute("delete", userId),
+          createContentAttribute("deleteAt", Date.now()),
+        ]),
+      );
+    }
+
+    it("should store and retrieve attribution via handleUpdate", async () => {
+      const key = "attr-doc-1";
+      const doc = new Y.Doc();
+      doc.getText("content").insert(0, "Hello");
+      const update = Y.encodeStateAsUpdateV2(doc) as Update;
+      const attribution = makeAttribution(update, "user-1");
+
+      await storage.handleUpdate(key, update, attribution);
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBeGreaterThan(0);
+    });
+
+    it("should return null when no attribution exists", async () => {
+      const result = await storage.retrieveAttribution("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("should not store attribution when param is undefined", async () => {
+      const key = "attr-doc-2";
+      const doc = new Y.Doc();
+      const update = Y.encodeStateAsUpdateV2(doc) as Update;
+
+      await storage.handleUpdate(key, update);
+
+      const result = await storage.retrieveAttribution(key);
+      expect(result).toBeNull();
+    });
+
+    it("should merge multiple attributions on retrieve", async () => {
+      const key = "attr-doc-3";
+      const doc1 = new Y.Doc();
+      doc1.getText("content").insert(0, "Hello");
+      const update1 = Y.encodeStateAsUpdateV2(doc1) as Update;
+
+      await storage.handleUpdate(key, update1, makeAttribution(update1, "user-1"));
+
+      const doc2 = new Y.Doc();
+      Y.applyUpdateV2(doc2, update1);
+      doc2.getText("content").insert(5, " World");
+      const update2 = Y.encodeStateAsUpdateV2(doc2) as Update;
+
+      await storage.handleUpdate(key, update2, makeAttribution(update2, "user-2"));
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBeGreaterThan(0);
+    });
+
+    it("should clean up attribution on deleteDocument", async () => {
+      const key = "attr-doc-4";
+      const doc = new Y.Doc();
+      doc.getText("content").insert(0, "Hello");
+      const update = Y.encodeStateAsUpdateV2(doc) as Update;
+
+      await storage.handleUpdate(key, update, makeAttribution(update, "user-1"));
+      expect(await storage.retrieveAttribution(key)).not.toBeNull();
+
+      await storage.deleteDocument(key);
+      expect(await storage.retrieveAttribution(key)).toBeNull();
     });
   });
 });

--- a/src/storage/in-memory/ydoc.ts
+++ b/src/storage/in-memory/ydoc.ts
@@ -5,28 +5,44 @@ import {
   getUpdateFromDoc,
   type Update,
 } from "teleportal";
+import {
+  decodeContentMap,
+  encodeContentMap,
+  mergeContentMaps,
+} from "teleportal/attribution";
 import { calculateDocumentSize } from "../utils";
 import { UnencryptedDocumentStorage } from "../unencrypted";
-import type { Document, DocumentMetadata } from "../types";
+import type { Document, DocumentMetadata, EncodedContentMap } from "../types";
 
 export class YDocStorage extends UnencryptedDocumentStorage {
   public static docs = new Map<string, Y.Doc>();
   public static metadata = new Map<string, DocumentMetadata>();
+  public static attributionMaps = new Map<string, EncodedContentMap[]>();
 
   constructor() {
     super();
   }
 
-  /**
-   * Persist a Y.js update to storage
-   */
-  async handleUpdate(key: string, update: Update): Promise<void> {
+  async handleUpdate(
+    key: string,
+    update: Update,
+    attribution?: EncodedContentMap,
+  ): Promise<void> {
     if (!YDocStorage.docs.has(key)) {
       YDocStorage.docs.set(key, new Y.Doc());
     }
     const doc = YDocStorage.docs.get(key)!;
 
     Y.applyUpdateV2(doc, update);
+
+    if (attribution) {
+      let list = YDocStorage.attributionMaps.get(key);
+      if (!list) {
+        list = [];
+        YDocStorage.attributionMaps.set(key, list);
+      }
+      list.push(attribution);
+    }
 
     await this.transaction(key, async () => {
       const meta = await this.getDocumentMetadata(key);
@@ -87,5 +103,16 @@ export class YDocStorage extends UnencryptedDocumentStorage {
   async deleteDocument(key: string): Promise<void> {
     YDocStorage.docs.delete(key);
     YDocStorage.metadata.delete(key);
+    YDocStorage.attributionMaps.delete(key);
+  }
+
+  async retrieveAttribution(
+    documentId: string,
+  ): Promise<EncodedContentMap | null> {
+    const list = YDocStorage.attributionMaps.get(documentId);
+    if (!list || list.length === 0) return null;
+    if (list.length === 1) return list[0];
+    const merged = mergeContentMaps(list.map((m) => decodeContentMap(m)));
+    return encodeContentMap(merged) as EncodedContentMap;
   }
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -428,8 +428,15 @@ export interface DocumentStorage {
 
   /**
    * Handles an update for a document.
+   * @param attribution - Optional encoded ContentMap with attribution metadata (userId, timestamp per operation range).
+   *   Passed by the server when attribution is available (client-sourced updates with a userId).
+   *   Implementations that support attribution should persist this alongside the update.
    */
-  handleUpdate(documentId: Document["id"], update: Update): Promise<void>;
+  handleUpdate(
+    documentId: Document["id"],
+    update: Update,
+    attribution?: EncodedContentMap,
+  ): Promise<void>;
 
   /**
    * Fetches the update and computes a state vector for a document.
@@ -461,7 +468,22 @@ export interface DocumentStorage {
    * @returns The result of the transaction
    */
   transaction<T>(documentId: Document["id"], cb: () => Promise<T>): Promise<T>;
+
+  /**
+   * Get the merged attribution data (ContentMap) for a document.
+   * Returns null if no attribution data exists.
+   * Implementations that support attribution override this method.
+   */
+  retrieveAttribution?(
+    documentId: Document["id"],
+  ): Promise<EncodedContentMap | null>;
 }
+
+/**
+ * An encoded ContentMap blob. Contains attribution metadata (userId, timestamp)
+ * for CRDT operation ranges. Format matches Y.js v14's encodeContentMap.
+ */
+export type EncodedContentMap = Uint8Array & { _tag: "content-map" };
 
 /**
  * State of a rate limit for a specific key

--- a/src/storage/unencrypted/document-storage.ts
+++ b/src/storage/unencrypted/document-storage.ts
@@ -12,6 +12,7 @@ import type {
   Document,
   DocumentMetadata,
   DocumentStorage,
+  EncodedContentMap,
 } from "../types";
 
 function defaultMetadata(now: number, encrypted: boolean): DocumentMetadata {
@@ -34,6 +35,7 @@ export abstract class UnencryptedDocumentStorage implements DocumentStorage {
   abstract handleUpdate(
     documentId: Document["id"],
     update: Update,
+    attribution?: EncodedContentMap,
   ): Promise<void>;
   abstract getDocument(documentId: Document["id"]): Promise<Document | null>;
   abstract writeDocumentMetadata(
@@ -80,4 +82,5 @@ export abstract class UnencryptedDocumentStorage implements DocumentStorage {
     // when unencrypted, there is no difference between the sync step 2 and the update message type
     await this.handleUpdate(documentId, syncStep2 as unknown as Update);
   }
+
 }

--- a/src/storage/unstorage/encrypted.test.ts
+++ b/src/storage/unstorage/encrypted.test.ts
@@ -13,9 +13,18 @@ import {
 import type { DecodedEncryptedUpdatePayload } from "teleportal/protocol/encryption";
 import { digest } from "lib0/hash/sha256";
 import { toBase64 } from "lib0/buffer";
+import {
+  createContentAttribute,
+  createContentIds,
+  createContentMapFromContentIds,
+  decodeContentMap,
+  encodeContentMap,
+  getEmptyEncodedContentIds,
+  IdSet,
+} from "teleportal/attribution";
 import { UnstorageEncryptedDocumentStorage } from "./encrypted";
 import { UnstorageMilestoneStorage } from "./milestone-storage";
-import type { FileStorage, MilestoneStorage } from "../types";
+import type { EncodedContentMap, FileStorage, MilestoneStorage } from "../types";
 import type { MilestoneSnapshot } from "teleportal";
 
 describe("UnstorageEncryptedDocumentStorage", () => {
@@ -267,6 +276,7 @@ describe("UnstorageEncryptedDocumentStorage", () => {
         id: messageId,
         timestamp: [1, 5],
         payload,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const syncStep2 = encodeToSyncStep2({ messages: [message] });
@@ -292,11 +302,13 @@ describe("UnstorageEncryptedDocumentStorage", () => {
         id: messageId1,
         timestamp: [1, 5],
         payload: payload1,
+        contentIds: getEmptyEncodedContentIds(),
       };
       const message2: DecodedEncryptedUpdatePayload = {
         id: messageId2,
         timestamp: [1, 6],
         payload: payload2,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const syncStep2 = encodeToSyncStep2({ messages: [message1, message2] });
@@ -318,6 +330,7 @@ describe("UnstorageEncryptedDocumentStorage", () => {
         id: messageId,
         timestamp: [2, 10],
         payload,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const update = encodeEncryptedUpdateMessages([message]);
@@ -341,6 +354,7 @@ describe("UnstorageEncryptedDocumentStorage", () => {
         id: messageId,
         timestamp: [3, 15],
         payload,
+        contentIds: getEmptyEncodedContentIds(),
       };
 
       const update = encodeEncryptedUpdateMessages([message]);
@@ -445,6 +459,119 @@ describe("UnstorageEncryptedDocumentStorage", () => {
       expect(executionOrder).toContain("end-1");
       expect(executionOrder).toContain("start-2");
       expect(executionOrder).toContain("end-2");
+    });
+  });
+
+  describe("attribution", () => {
+    function makeAttribution(userId: string, clientId = 1, clock = 0, len = 1): EncodedContentMap {
+      const inserts = new IdSet();
+      inserts.add(clientId, clock, len);
+      const contentIds = createContentIds(inserts, new IdSet());
+      return encodeContentMap(
+        createContentMapFromContentIds(contentIds, [
+          createContentAttribute("insert", userId),
+          createContentAttribute("insertAt", Date.now()),
+        ], []),
+      );
+    }
+
+    it("should store and retrieve attribution via handleUpdate", async () => {
+      const key = "attr-doc-1";
+      const payload = new Uint8Array([10, 20, 30]) as EncryptedBinary;
+      const messageId = toBase64(digest(payload));
+      const message: DecodedEncryptedUpdatePayload = {
+        id: messageId,
+        timestamp: [1, 0],
+        payload,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+      const update = encodeEncryptedUpdateMessages([message]);
+      const attribution = makeAttribution("user-1");
+
+      await storage.handleUpdate(key, update, attribution);
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBeGreaterThan(0);
+    });
+
+    it("should return null when no attribution exists", async () => {
+      const result = await storage.retrieveAttribution("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("should not store attribution when param is undefined", async () => {
+      const key = "attr-doc-2";
+      const payload = new Uint8Array([1, 2, 3]) as EncryptedBinary;
+      const messageId = toBase64(digest(payload));
+      const message: DecodedEncryptedUpdatePayload = {
+        id: messageId,
+        timestamp: [1, 0],
+        payload,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+      const update = encodeEncryptedUpdateMessages([message]);
+
+      await storage.handleUpdate(key, update);
+
+      const result = await storage.retrieveAttribution(key);
+      expect(result).toBeNull();
+    });
+
+    it("should merge multiple attributions on retrieve", async () => {
+      const key = "attr-doc-3";
+      const payload1 = new Uint8Array([1, 2, 3]) as EncryptedBinary;
+      const payload2 = new Uint8Array([4, 5, 6]) as EncryptedBinary;
+      const msg1: DecodedEncryptedUpdatePayload = {
+        id: toBase64(digest(payload1)),
+        timestamp: [1, 0],
+        payload: payload1,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+      const msg2: DecodedEncryptedUpdatePayload = {
+        id: toBase64(digest(payload2)),
+        timestamp: [2, 0],
+        payload: payload2,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+
+      await storage.handleUpdate(
+        key,
+        encodeEncryptedUpdateMessages([msg1]),
+        makeAttribution("user-1", 1, 0, 5),
+      );
+      await storage.handleUpdate(
+        key,
+        encodeEncryptedUpdateMessages([msg2]),
+        makeAttribution("user-2", 2, 0, 3),
+      );
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBe(2);
+    });
+
+    it("should clean up attribution on deleteDocument", async () => {
+      const key = "attr-doc-4";
+      const payload = new Uint8Array([1, 2, 3]) as EncryptedBinary;
+      const msg: DecodedEncryptedUpdatePayload = {
+        id: toBase64(digest(payload)),
+        timestamp: [1, 0],
+        payload,
+        contentIds: getEmptyEncodedContentIds(),
+      };
+
+      await storage.handleUpdate(
+        key,
+        encodeEncryptedUpdateMessages([msg]),
+        makeAttribution("user-1"),
+      );
+      expect(await storage.retrieveAttribution(key)).not.toBeNull();
+
+      await storage.deleteDocument(key);
+      expect(await storage.retrieveAttribution(key)).toBeNull();
     });
   });
 });

--- a/src/storage/unstorage/encrypted.ts
+++ b/src/storage/unstorage/encrypted.ts
@@ -1,11 +1,21 @@
+import { uuidv4 } from "lib0/random";
 import type { Storage } from "unstorage";
 
 import { EncryptedBinary } from "teleportal/encryption-key";
-import type { EncryptedMessageId } from "teleportal/protocol/encryption";
+import type {
+  EncryptedMessageId,
+  EncryptedUpdatePayload,
+} from "teleportal/protocol/encryption";
+import {
+  decodeContentMap,
+  encodeContentMap,
+  mergeContentMaps,
+} from "teleportal/attribution";
 import {
   EncryptedDocumentMetadata,
   EncryptedDocumentStorage,
 } from "../encrypted";
+import type { EncodedContentMap } from "../types";
 import { withTransaction } from "./transaction";
 
 export class UnstorageEncryptedDocumentStorage extends EncryptedDocumentStorage {
@@ -33,6 +43,14 @@ export class UnstorageEncryptedDocumentStorage extends EncryptedDocumentStorage 
 
   #getMessageKey(key: string, messageId: string): string {
     return this.#getKey(key) + ":" + messageId;
+  }
+
+  #getAttributionKeyPrefix(key: string): string {
+    return this.#getKey(key) + ":attribution";
+  }
+
+  #getAttributionKey(key: string): string {
+    return this.#getAttributionKeyPrefix(key) + ":" + uuidv4();
   }
 
   /**
@@ -96,9 +114,40 @@ export class UnstorageEncryptedDocumentStorage extends EncryptedDocumentStorage 
     return payload;
   }
 
+  override async handleUpdate(
+    key: string,
+    update: EncryptedUpdatePayload,
+    attribution?: EncodedContentMap,
+  ): Promise<void> {
+    await super.handleUpdate(key, update);
+    if (attribution) {
+      await this.storage.setItemRaw(this.#getAttributionKey(key), attribution);
+    }
+  }
+
+  async retrieveAttribution(
+    key: string,
+  ): Promise<EncodedContentMap | null> {
+    const attrKeys = await this.storage.getKeys(
+      this.#getAttributionKeyPrefix(key),
+    );
+    if (attrKeys.length === 0) return null;
+    if (attrKeys.length === 1) {
+      return await this.storage.getItemRaw(attrKeys[0]);
+    }
+    const maps = (
+      await Promise.all(
+        attrKeys.map((k) => this.storage.getItemRaw<EncodedContentMap>(k)),
+      )
+    ).filter(Boolean) as EncodedContentMap[];
+    if (maps.length === 0) return null;
+    if (maps.length === 1) return maps[0];
+    const merged = mergeContentMaps(maps.map((m) => decodeContentMap(m)));
+    return encodeContentMap(merged) as EncodedContentMap;
+  }
+
   async deleteDocument(key: string): Promise<void> {
     const metadata = await this.getDocumentMetadata(key);
-    const prefixedKey = this.#getKey(key);
 
     // Delete all messages
     const promises = [];
@@ -111,6 +160,14 @@ export class UnstorageEncryptedDocumentStorage extends EncryptedDocumentStorage 
       }
     }
     await Promise.all(promises);
+
+    // Delete attribution data
+    const attrKeys = await this.storage.getKeys(
+      this.#getAttributionKeyPrefix(key),
+    );
+    if (attrKeys.length > 0) {
+      await Promise.all(attrKeys.map((k) => this.storage.removeItem(k)));
+    }
 
     // Delete metadata
     await this.storage.removeItem(this.#getMetadataKey(key));

--- a/src/storage/unstorage/unencrypted.test.ts
+++ b/src/storage/unstorage/unencrypted.test.ts
@@ -3,9 +3,16 @@ import { createStorage } from "unstorage";
 import * as Y from "yjs";
 import type { MilestoneSnapshot, StateVector, Update } from "teleportal";
 import { getEmptyStateVector } from "../../lib/protocol/utils";
+import {
+  createContentAttribute,
+  createContentIdsFromUpdate,
+  createContentMapFromContentIds,
+  decodeContentMap,
+  encodeContentMap,
+} from "teleportal/attribution";
 import { UnstorageDocumentStorage } from "./unencrypted";
 import { UnstorageMilestoneStorage } from "./milestone-storage";
-import type { FileStorage, MilestoneStorage } from "../types";
+import type { EncodedContentMap, FileStorage, MilestoneStorage } from "../types";
 
 describe("UnstorageDocumentStorage", () => {
   let storage: UnstorageDocumentStorage;
@@ -385,6 +392,86 @@ describe("UnstorageDocumentStorage", () => {
       const newDoc = new Y.Doc();
       Y.applyUpdateV2(newDoc, retrieved!.content.update);
       expect(newDoc.getText("content").toString()).toBe("First Second");
+    });
+  });
+
+  describe("attribution", () => {
+    function makeAttribution(update: Update, userId: string): EncodedContentMap {
+      const contentIds = createContentIdsFromUpdate(update);
+      return encodeContentMap(
+        createContentMapFromContentIds(contentIds, [
+          createContentAttribute("insert", userId),
+          createContentAttribute("insertAt", Date.now()),
+        ], [
+          createContentAttribute("delete", userId),
+          createContentAttribute("deleteAt", Date.now()),
+        ]),
+      );
+    }
+
+    it("should store and retrieve attribution via handleUpdate", async () => {
+      const key = "attr-doc-1";
+      const doc = new Y.Doc();
+      doc.getText("content").insert(0, "Hello");
+      const update = Y.encodeStateAsUpdateV2(doc) as Update;
+      const attribution = makeAttribution(update, "user-1");
+
+      await storage.handleUpdate(key, update, attribution);
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBeGreaterThan(0);
+    });
+
+    it("should return null when no attribution exists", async () => {
+      const result = await storage.retrieveAttribution("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("should not store attribution when param is undefined", async () => {
+      const key = "attr-doc-2";
+      const doc = new Y.Doc();
+      const update = Y.encodeStateAsUpdateV2(doc) as Update;
+
+      await storage.handleUpdate(key, update);
+
+      const result = await storage.retrieveAttribution(key);
+      expect(result).toBeNull();
+    });
+
+    it("should merge multiple attributions on retrieve", async () => {
+      const key = "attr-doc-3";
+      const doc1 = new Y.Doc();
+      doc1.getText("content").insert(0, "Hello");
+      const update1 = Y.encodeStateAsUpdateV2(doc1) as Update;
+
+      await storage.handleUpdate(key, update1, makeAttribution(update1, "user-1"));
+
+      const doc2 = new Y.Doc();
+      Y.applyUpdateV2(doc2, update1);
+      doc2.getText("content").insert(5, " World");
+      const update2 = Y.encodeStateAsUpdateV2(doc2) as Update;
+
+      await storage.handleUpdate(key, update2, makeAttribution(update2, "user-2"));
+
+      const retrieved = await storage.retrieveAttribution(key);
+      expect(retrieved).not.toBeNull();
+      const map = decodeContentMap(retrieved!);
+      expect(map.inserts.clients.size).toBeGreaterThan(0);
+    });
+
+    it("should clean up attribution on deleteDocument", async () => {
+      const key = "attr-doc-4";
+      const doc = new Y.Doc();
+      doc.getText("content").insert(0, "Hello");
+      const update = Y.encodeStateAsUpdateV2(doc) as Update;
+
+      await storage.handleUpdate(key, update, makeAttribution(update, "user-1"));
+      expect(await storage.retrieveAttribution(key)).not.toBeNull();
+
+      await storage.deleteDocument(key);
+      expect(await storage.retrieveAttribution(key)).toBeNull();
     });
   });
 });

--- a/src/storage/unstorage/unencrypted.ts
+++ b/src/storage/unstorage/unencrypted.ts
@@ -6,7 +6,12 @@ import {
   mergeUpdates,
   type Update,
 } from "teleportal";
-import type { Document, DocumentMetadata } from "../types";
+import {
+  decodeContentMap,
+  encodeContentMap,
+  mergeContentMaps,
+} from "teleportal/attribution";
+import type { Document, DocumentMetadata, EncodedContentMap } from "../types";
 import { UnencryptedDocumentStorage } from "../unencrypted";
 import { calculateDocumentSize } from "../utils";
 import { withTransaction } from "./transaction";
@@ -55,6 +60,14 @@ export class UnstorageDocumentStorage extends UnencryptedDocumentStorage {
     return this.#getKey(key) + ":meta";
   }
 
+  #getAttributionKeyPrefix(key: string): string {
+    return this.#getKey(key) + ":attribution";
+  }
+
+  #getAttributionKey(key: string): string {
+    return this.#getAttributionKeyPrefix(key) + ":" + uuidv4();
+  }
+
   /**
    * Lock a key for 5 seconds
    * @param key - The key to lock
@@ -74,11 +87,16 @@ export class UnstorageDocumentStorage extends UnencryptedDocumentStorage {
   async handleUpdate(
     key: string,
     update: Update,
+    attribution?: EncodedContentMap,
     overwriteKeys?: boolean,
   ): Promise<void> {
     const prefixedKey = this.#getKey(key);
     const updateKey = this.#getUpdateKeyPrefix(key) + uuidv4();
     await this.storage.setItemRaw(updateKey, update);
+
+    if (attribution) {
+      await this.storage.setItemRaw(this.#getAttributionKey(key), attribution);
+    }
     if (this.options.scanKeys) {
       return;
     }
@@ -153,7 +171,7 @@ export class UnstorageDocumentStorage extends UnencryptedDocumentStorage {
     ) as Update;
 
     // asynchronously store the update and delete the keys
-    const promise = this.handleUpdate(key, update, true).then(() => {
+    const promise = this.handleUpdate(key, update, undefined, true).then(() => {
       return Promise.all([...keys].map((key) => this.storage.removeItem(key)));
     });
 
@@ -200,6 +218,27 @@ export class UnstorageDocumentStorage extends UnencryptedDocumentStorage {
     };
   }
 
+  async retrieveAttribution(
+    key: string,
+  ): Promise<EncodedContentMap | null> {
+    const attrKeys = await this.storage.getKeys(
+      this.#getAttributionKeyPrefix(key),
+    );
+    if (attrKeys.length === 0) return null;
+    if (attrKeys.length === 1) {
+      return await this.storage.getItemRaw(attrKeys[0]);
+    }
+    const maps = (
+      await Promise.all(
+        attrKeys.map((k) => this.storage.getItemRaw<EncodedContentMap>(k)),
+      )
+    ).filter(Boolean) as EncodedContentMap[];
+    if (maps.length === 0) return null;
+    if (maps.length === 1) return maps[0];
+    const merged = mergeContentMaps(maps.map((m) => decodeContentMap(m)));
+    return encodeContentMap(merged) as EncodedContentMap;
+  }
+
   async deleteDocument(key: string): Promise<void> {
     const prefixedKey = this.#getKey(key);
     // Delete metadata
@@ -213,6 +252,14 @@ export class UnstorageDocumentStorage extends UnencryptedDocumentStorage {
 
     if (keys.size > 0) {
       await Promise.all([...keys].map((k) => this.storage.removeItem(k)));
+    }
+
+    // Delete attribution data
+    const attrKeys = await this.storage.getKeys(
+      this.#getAttributionKeyPrefix(key),
+    );
+    if (attrKeys.length > 0) {
+      await Promise.all(attrKeys.map((k) => this.storage.removeItem(k)));
     }
 
     await this.storage.removeItem(prefixedKey);

--- a/src/storage/virtual-storage.ts
+++ b/src/storage/virtual-storage.ts
@@ -3,6 +3,7 @@ import type {
   DocumentStorage,
   DocumentMetadata,
   Document,
+  EncodedContentMap,
 } from "teleportal/storage";
 import type { StateVector, SyncStep2Update, Update } from "teleportal";
 
@@ -16,6 +17,11 @@ const defaultOptions: VirtualStorageOptions = {
   batchWaitMs: 2000,
 };
 
+interface BufferedUpdate {
+  update: Update;
+  attribution?: EncodedContentMap;
+}
+
 /**
  * VirtualStorage is an in-memory abstraction layer over DocumentStorage that batches writes
  * to improve performance by reducing DB operations. Writes are buffered in memory and
@@ -25,14 +31,18 @@ export class VirtualStorage implements DocumentStorage {
   readonly type = "document-storage" as const;
   readonly storageType: "encrypted" | "unencrypted";
 
+  retrieveAttribution?: (
+    documentId: string,
+  ) => Promise<EncodedContentMap | null>;
+
   #storage: DocumentStorage;
   #buffer = new Map<
     string,
-    { updates: Update[]; metadata?: DocumentMetadata }
+    { updates: BufferedUpdate[]; metadata?: DocumentMetadata }
   >();
   #batchProcessor: (item: {
     key: string;
-    updates: Update[];
+    updates: BufferedUpdate[];
     metadata?: DocumentMetadata;
   }) => void;
 
@@ -43,21 +53,24 @@ export class VirtualStorage implements DocumentStorage {
     this.#storage = storage;
     this.storageType = storage.storageType;
 
+    if (storage.retrieveAttribution) {
+      this.retrieveAttribution = (documentId: string) =>
+        this.#storage.retrieveAttribution!(documentId);
+    }
+
     // Set up batch processor
     this.#batchProcessor = batch(
       async (
         batches: Array<{
           key: string;
-          updates: Update[];
+          updates: BufferedUpdate[];
           metadata?: DocumentMetadata;
         }>,
       ) => {
         for (const { key, updates, metadata } of batches) {
-          // Flush updates
-          for (const update of updates) {
-            await this.#storage.handleUpdate(key, update);
+          for (const { update, attribution } of updates) {
+            await this.#storage.handleUpdate(key, update, attribution);
           }
-          // Flush metadata if present
           if (metadata) {
             await this.#storage.writeDocumentMetadata(key, metadata);
           }
@@ -70,16 +83,14 @@ export class VirtualStorage implements DocumentStorage {
     );
   }
 
-  /**
-   * Buffer an update for later batch processing.
-   */
-  async handleUpdate(documentId: string, update: Update): Promise<void> {
-    this.#addToBuffer(documentId, { updates: [update] });
+  async handleUpdate(
+    documentId: string,
+    update: Update,
+    attribution?: EncodedContentMap,
+  ): Promise<void> {
+    this.#addToBuffer(documentId, { updates: [{ update, attribution }] });
   }
 
-  /**
-   * Buffer metadata for later batch processing.
-   */
   async writeDocumentMetadata(
     documentId: string,
     metadata: DocumentMetadata,
@@ -87,12 +98,9 @@ export class VirtualStorage implements DocumentStorage {
     this.#addToBuffer(documentId, { metadata });
   }
 
-  /**
-   * Add item to buffer and trigger batch processing.
-   */
   #addToBuffer(
     documentId: string,
-    item: { updates?: Update[]; metadata?: DocumentMetadata },
+    item: { updates?: BufferedUpdate[]; metadata?: DocumentMetadata },
   ) {
     const existing = this.#buffer.get(documentId) ?? { updates: [] };
     const merged = {
@@ -101,37 +109,24 @@ export class VirtualStorage implements DocumentStorage {
     };
     this.#buffer.set(documentId, merged);
 
-    // Trigger batch processing
     this.#batchProcessor({ key: documentId, ...merged });
   }
 
-  /**
-   * Flush any pending writes for a document, then read.
-   */
   async getDocument(documentId: string): Promise<Document | null> {
     await this.#flushPending(documentId);
     return this.#storage.getDocument(documentId);
   }
 
-  /**
-   * Flush any pending writes for a document, then read metadata.
-   */
   async getDocumentMetadata(documentId: string): Promise<DocumentMetadata> {
     await this.#flushPending(documentId);
     return this.#storage.getDocumentMetadata(documentId);
   }
 
-  /**
-   * Flush pending writes before deleting.
-   */
   async deleteDocument(documentId: string): Promise<void> {
     await this.#flushPending(documentId);
     return this.#storage.deleteDocument(documentId);
   }
 
-  /**
-   * Forward sync step 1 (read operation).
-   */
   async handleSyncStep1(
     documentId: string,
     syncStep1: StateVector,
@@ -140,35 +135,23 @@ export class VirtualStorage implements DocumentStorage {
     return this.#storage.handleSyncStep1(documentId, syncStep1);
   }
 
-  /**
-   * Forward sync step 2 (write operation), but buffer it.
-   */
   async handleSyncStep2(
     documentId: string,
     syncStep2: SyncStep2Update,
   ): Promise<void> {
-    // Assume sync step 2 involves updates, buffer it
-    // For now, forward directly since it might call handleUpdate internally
     return this.#storage.handleSyncStep2(documentId, syncStep2);
   }
 
-  /**
-   * Forward transaction.
-   */
   async transaction<T>(documentId: string, cb: () => Promise<T>): Promise<T> {
     return this.#storage.transaction(documentId, cb);
   }
 
-  /**
-   * Flush pending writes for a specific document immediately.
-   */
   async #flushPending(documentId: string): Promise<void> {
     const pending = this.#buffer.get(documentId);
     if (pending) {
       this.#buffer.delete(documentId);
-      // Process immediately
-      for (const update of pending.updates) {
-        await this.#storage.handleUpdate(documentId, update);
+      for (const { update, attribution } of pending.updates) {
+        await this.#storage.handleUpdate(documentId, update, attribution);
       }
       if (pending.metadata) {
         await this.#storage.writeDocumentMetadata(documentId, pending.metadata);

--- a/src/transports/encrypted/client.ts
+++ b/src/transports/encrypted/client.ts
@@ -39,6 +39,11 @@ import {
   LamportClock,
 } from "teleportal/protocol/encryption";
 import {
+  createContentIdsFromUpdate,
+  encodeContentIds,
+  getEmptyEncodedContentIds,
+} from "teleportal/attribution";
+import {
   applyAwarenessUpdate,
   Awareness,
   encodeAwarenessUpdate,
@@ -296,11 +301,12 @@ export class EncryptionClient
    * This tracks the update in the {@link seenMessages}
    */
   private async trackUpdate(payload: Update): Promise<EncryptedUpdatePayload> {
+    const contentIds = encodeContentIds(createContentIdsFromUpdate(payload));
     const encryptedUpdate = await this.encryptUpdate(payload);
     const messageId = toBase64(digest(encryptedUpdate));
     const decodedUpdate = this.createMessageNode(messageId, encryptedUpdate);
 
-    return encodeEncryptedUpdateMessages([decodedUpdate]);
+    return encodeEncryptedUpdateMessages([{ ...decodedUpdate, contentIds }]);
   }
 
   /**
@@ -372,7 +378,12 @@ export class EncryptionClient
     }
 
     this.markMessageAsSeen(timestamp, messageId);
-    const node = { id: messageId, timestamp, payload };
+    const node: DecodedEncryptedUpdatePayload = {
+      id: messageId,
+      timestamp,
+      payload,
+      contentIds: getEmptyEncodedContentIds(),
+    };
 
     this.call("seen-update", node);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
       "teleportal/merkle-tree": ["./src/merkle-tree/index.ts"],
       "teleportal/devtools": ["./src/devtools/index.ts"],
       "teleportal/agent": ["./src/agent/index.ts"],
+      "teleportal/attribution": ["./src/lib/attribution/index.ts"],
       "teleportal": ["./src/lib/index.ts"]
     },
     "jsx": "react-jsx"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,9 @@
       "teleportal/protocol": ["./src/lib/protocol/index.ts"],
       "teleportal/protocols/milestone": ["./src/protocols/milestone/index.ts"],
       "teleportal/protocols/file": ["./src/protocols/file/index.ts"],
+      "teleportal/protocols/attribution": [
+        "./src/protocols/attribution/index.ts"
+      ],
       "teleportal/providers": ["./src/providers/index.ts"],
       "teleportal/websocket-server": ["./src/websocket-server/index.ts"],
       "teleportal/monitoring": ["./src/monitoring/index.ts"],


### PR DESCRIPTION
Adds an end-to-end attribution layer: storage records a per-document ContentMap (CRDT operation-ID ranges → userId/timestamp) via a new optional `retrieveAttribution` hook implemented across the in-memory and unstorage backends. It exposes that data read-only through a new `teleportal/protocols/attribution` RPC package (`attributionActivity` + `attributionGet`) plus client-side range resolution and `Provider` helpers (`getActivity`, `getAttributionMap`, `getAttributionForRange`, `resolveAttribution`). On top of that it adds milestone-scoped attribution — who authored a milestone, the changeset between two milestones, and range-within-a-milestone — computed fully client-side so it works for end-to-end-encrypted documents. It also fixes an E2EE leak where client-created milestone snapshots were stored in plaintext, by encrypting them on `createMilestone` and decrypting transparently on read. Finally it ships a multi-author Authorship panel in the playground demo (live document composition by author, activity timeline, and milestone/changeset contributors), devtools rendering of attribution payloads, tests, and docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)