### PR TITLE
fix: E2EE milestone snapshot decryption + attribution range data loss

### DIFF
--- a/src/lib/attribution/attribution.test.ts
+++ b/src/lib/attribution/attribution.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import * as Y from "yjs";
 import {
   ContentAttribute,
+  IdMap,
   IdSet,
   createContentAttribute,
   createContentIds,
@@ -389,4 +390,98 @@ describe("queries", () => {
     expect(activity.length).toBe(1);
     expect(activity[0].userId).toBe("user-2");
   });
+});
+
+describe("AttrRanges.getIds overlap flattening", () => {
+  const A = () => [createContentAttribute("insert", "user-A")];
+  const B = () => [createContentAttribute("insert", "user-B")];
+  const shape = (m: IdMap, client: number) =>
+    m.clients
+      .get(client)!
+      .getIds()
+      .map((r) => ({ clock: r.clock, len: r.len, u: r.attrs[0].val }));
+
+  it("keeps the tail of a range that fully contains a later one", () => {
+    const m = new IdMap();
+    m.add(1, 0, 10, A());
+    m.add(1, 3, 2, B()); // [3,5) contained inside [0,10)
+    expect(shape(m, 1)).toEqual([
+      { clock: 0, len: 3, u: "user-A" },
+      { clock: 3, len: 2, u: "user-B" },
+      { clock: 5, len: 5, u: "user-A" }, // tail preserved, not dropped
+    ]);
+  });
+
+  it("flattens containment regardless of insertion order", () => {
+    const m = new IdMap();
+    m.add(1, 3, 2, B()); // contained range added first
+    m.add(1, 0, 10, A());
+    // The containing range was added later, so it wins the contested span.
+    expect(shape(m, 1)).toEqual([{ clock: 0, len: 10, u: "user-A" }]);
+  });
+
+  it("splits partial overlaps, later-added range winning the contested span", () => {
+    const m = new IdMap();
+    m.add(1, 0, 5, A()); // [0,5)
+    m.add(1, 3, 5, B()); // [3,8)
+    expect(shape(m, 1)).toEqual([
+      { clock: 0, len: 3, u: "user-A" },
+      { clock: 3, len: 5, u: "user-B" },
+    ]);
+  });
+
+  it("keeps adjacent ranges with differing attrs separate", () => {
+    const m = new IdMap();
+    m.add(1, 0, 5, A());
+    m.add(1, 5, 5, B());
+    expect(shape(m, 1)).toEqual([
+      { clock: 0, len: 5, u: "user-A" },
+      { clock: 5, len: 5, u: "user-B" },
+    ]);
+  });
+
+  it("coalesces adjacent ranges with equal attrs", () => {
+    const m = new IdMap();
+    m.add(1, 0, 5, A());
+    m.add(1, 5, 5, A());
+    expect(shape(m, 1)).toEqual([{ clock: 0, len: 10, u: "user-A" }]);
+  });
+
+  it("preserves all spans when merging maps with overlapping deletes", () => {
+    // Two users delete overlapping ranges of the same client's items in
+    // separate updates; merged attribution must not silently lose either span.
+    const delAttr = (u: string) => [createContentAttribute("delete", u)];
+    const map1 = createContentMapFromContentIds(
+      { inserts: new IdSet(), deletes: idSet(1, 0, 10) },
+      [],
+      delAttr("user-A"),
+    );
+    const map2 = createContentMapFromContentIds(
+      { inserts: new IdSet(), deletes: idSet(1, 4, 2) },
+      [],
+      delAttr("user-B"),
+    );
+    const merged = mergeContentMaps([map1, map2]);
+    expect(shapeDeletes(merged.deletes, 1)).toEqual([
+      { clock: 0, len: 4, u: "user-A" },
+      { clock: 4, len: 2, u: "user-B" },
+      { clock: 6, len: 4, u: "user-A" },
+    ]);
+  });
+
+  function idSet(client: number, clock: number, len: number): IdSet {
+    const s = new IdSet();
+    s.add(client, clock, len);
+    return s;
+  }
+  function shapeDeletes(m: IdMap, client: number) {
+    return m.clients
+      .get(client)!
+      .getIds()
+      .map((r) => ({
+        clock: r.clock,
+        len: r.len,
+        u: r.attrs.find((a) => a.name === "delete")?.val,
+      }));
+  }
 });

--- a/src/lib/attribution/content-map.ts
+++ b/src/lib/attribution/content-map.ts
@@ -77,32 +77,61 @@ export class AttrRanges {
   }
 
   getIds(): AttrRange[] {
-    if (!this._sorted) {
-      this._ids.sort((a, b) => a.clock - b.clock);
-      const merged: AttrRange[] = [];
-      for (const range of this._ids) {
-        if (merged.length > 0) {
-          const last = merged.at(-1)!;
-          const lastEnd = last.clock + last.len;
-          if (lastEnd >= range.clock && attrsEqual(last.attrs, range.attrs)) {
-            last.len = Math.max(
-              last.len,
-              range.clock + range.len - last.clock,
-            );
-            continue;
-          }
-          if (lastEnd > range.clock && !attrsEqual(last.attrs, range.attrs)) {
-            last.len = range.clock - last.clock;
-            if (last.len <= 0) {
-              merged.pop();
-            }
-          }
-        }
-        merged.push(new AttrRange(range.clock, range.len, range.attrs));
-      }
-      this._ids = merged;
-      this._sorted = true;
+    if (this._sorted) {
+      return this._ids;
     }
+
+    // Flatten the (possibly overlapping) input ranges into a sorted,
+    // non-overlapping sequence. Where ranges overlap with differing attrs the
+    // most-recently-added range (highest input index) wins the contested span;
+    // every non-contested span keeps its own attrs. Spans of every covering
+    // range — including the tail of a range that fully contains a later one —
+    // are preserved, then adjacent equal-attr spans are coalesced.
+    const input = this._ids;
+    const boundaries = new Set<number>();
+    for (const range of input) {
+      boundaries.add(range.clock);
+      boundaries.add(range.clock + range.len);
+    }
+    const points = [...boundaries].sort((a, b) => a - b);
+
+    const merged: AttrRange[] = [];
+    for (let i = 0; i + 1 < points.length; i++) {
+      const start = points[i];
+      const end = points[i + 1];
+
+      // Every range boundary is a point, so each range either fully covers this
+      // elementary span or does not intersect it. Pick the latest-added cover.
+      let winner: AttrRange | undefined;
+      let winnerIdx = -1;
+      for (const [j, range] of input.entries()) {
+        if (
+          range.clock <= start &&
+          range.clock + range.len >= end &&
+          j > winnerIdx
+        ) {
+          winner = range;
+          winnerIdx = j;
+        }
+      }
+      if (!winner) {
+        continue;
+      }
+
+      const last = merged.at(-1);
+      if (
+        last &&
+        last.clock + last.len === start &&
+        attrsEqual(last.attrs, winner.attrs)
+      ) {
+        last.len = end - last.clock;
+      } else {
+        merged.push(new AttrRange(start, end - start, winner.attrs));
+      }
+    }
+
+    this._ids = merged;
+    this._sorted = true;
     return this._ids;
   }
 

--- a/src/protocols/milestone/README.md
+++ b/src/protocols/milestone/README.md
@@ -63,17 +63,18 @@ const snapshot = await provider.getMilestoneSnapshot(milestone.id);
 ## Encryption (E2EE)
 
 For end-to-end-encrypted documents (a `Provider` created with an `encryptionKey`),
-`createMilestone` encrypts the snapshot with that key before it leaves the client, so the
-server only ever stores ciphertext; `getMilestoneSnapshot` decrypts it transparently, so
-callers still receive a plaintext Y.js update. The server treats the snapshot as opaque
-bytes either way. This is what makes client-side
-[milestone attribution](../attribution/README.md) possible without exposing content to the
-server.
+`createMilestone` encrypts the snapshot with that key before it leaves the client and wraps
+it in the same encrypted-update-message container the server uses for automatic milestones,
+so the server only ever stores ciphertext. `getMilestoneSnapshot` decrypts every message in
+that container and merges them back into a single plaintext Y.js update, so callers always
+receive plaintext. The server treats the snapshot as opaque bytes either way. This is what
+makes client-side [milestone attribution](../attribution/README.md) possible without exposing
+content to the server.
 
-> Known limitation: server-generated **automatic** milestones cannot encrypt this way (the
-> server has no plaintext) and currently store a different encrypted-message-container
-> format. They are not consumed by the attribution helpers; prefer client-created milestones
-> on E2EE documents.
+Server-generated **automatic** milestones store the document's existing encrypted-message
+container (the server has no plaintext to re-encrypt), and `getMilestoneSnapshot` decrypts
+them through the same path — so both client-created and automatic milestones work with the
+attribution helpers on E2EE documents.
 
 ## Methods
 

--- a/src/providers/provider.test.ts
+++ b/src/providers/provider.test.ts
@@ -461,7 +461,7 @@ describe("Provider milestone operations", () => {
   });
 
   // Helper function to set up provider and ack initial messages
-  async function setupProvider() {
+  async function setupProvider(opts?: { encryptionKey?: CryptoKey }) {
     mockConnection.triggerConnect();
     provider = await Provider.create({
       connection: mockConnection,
@@ -469,6 +469,7 @@ describe("Provider milestone operations", () => {
       ydoc,
       getTransport: () => mockTransport,
       enableOfflinePersistence: false,
+      encryptionKey: opts?.encryptionKey,
     });
 
     // Ack any initial messages sent during provider creation
@@ -583,6 +584,146 @@ describe("Provider milestone operations", () => {
     const snapshot = await provider.getMilestoneSnapshot("milestone-1");
 
     expect(snapshot).toEqual(testSnapshot);
+  });
+
+  it("round-trips a client-encrypted snapshot for E2EE documents", async () => {
+    const { createEncryptionKey } = await import("teleportal/encryption-key");
+    const { decodeEncryptedUpdate } = await import(
+      "teleportal/protocol/encryption"
+    );
+    const encryptionKey = await createEncryptionKey();
+    await setupProvider({ encryptionKey });
+
+    ydoc.getText("content").insert(0, "secret");
+    const plaintext = Y.encodeStateAsUpdateV2(ydoc);
+
+    // Capture the encrypted snapshot createMilestone sends, then serve it back
+    // from getMilestoneSnapshot to verify it decrypts to the original content.
+    let stored: Uint8Array | undefined;
+    mockConnection.responseHandler = (message) => {
+      if (message.type === "rpc" && message.requestType === "request") {
+        if (message.rpcMethod === "milestoneCreate") {
+          stored = (message.payload.payload as { snapshot: Uint8Array })
+            .snapshot;
+          const response: MilestoneCreateResponse = {
+            milestone: {
+              id: "milestone-1",
+              name: "v1",
+              documentId: "test-doc",
+              createdAt: Date.now(),
+              createdBy: { type: "system", id: "test-node" },
+            },
+          };
+          return new RpcMessage(
+            "test-doc",
+            { type: "success", payload: response },
+            message.rpcMethod,
+            "response",
+            message.id,
+            { clientId: "test-client" },
+            false,
+          );
+        }
+        if (message.rpcMethod === "milestoneGet") {
+          const response: MilestoneGetResponse = {
+            milestoneId: "milestone-1",
+            snapshot: stored as unknown as MilestoneSnapshot,
+          };
+          return new RpcMessage(
+            "test-doc",
+            { type: "success", payload: response },
+            message.rpcMethod,
+            "response",
+            message.id,
+            { clientId: "test-client" },
+            false,
+          );
+        }
+      }
+      return null;
+    };
+
+    await provider.createMilestone("v1");
+    // The stored snapshot must be an encrypted-update container (decodable, not
+    // the plaintext update itself).
+    expect(stored).toBeDefined();
+    expect(new Uint8Array(stored!)).not.toEqual(new Uint8Array(plaintext));
+    expect(
+      decodeEncryptedUpdate(stored as unknown as Parameters<
+        typeof decodeEncryptedUpdate
+      >[0]).length,
+    ).toBe(1);
+
+    const snapshot = await provider.getMilestoneSnapshot("milestone-1");
+    const restored = new Y.Doc();
+    Y.applyUpdateV2(restored, snapshot as unknown as Uint8Array);
+    expect(restored.getText("content").toString()).toBe("secret");
+  });
+
+  it("decrypts multi-message automatic-milestone containers for E2EE documents", async () => {
+    const { createEncryptionKey, encryptUpdate } = await import(
+      "teleportal/encryption-key"
+    );
+    const { encodeEncryptedUpdateMessages } = await import(
+      "teleportal/protocol/encryption"
+    );
+    const { getEmptyEncodedContentIds } = await import("teleportal/attribution");
+    const { toBase64 } = await import("lib0/buffer");
+    const { digest } = await import("lib0/hash/sha256");
+    const encryptionKey = await createEncryptionKey();
+    await setupProvider({ encryptionKey });
+
+    // Build the container the way the server stores automatic milestones for
+    // E2EE docs: one encrypted message per incremental update.
+    const src = new Y.Doc();
+    const updates: Uint8Array[] = [];
+    src.on("updateV2", (u: Uint8Array) => updates.push(u));
+    src.getText("content").insert(0, "Hello ");
+    src.getText("content").insert(6, "World");
+    expect(updates.length).toBe(2);
+
+    const messages = await Promise.all(
+      updates.map(async (u, i) => {
+        const payload = await encryptUpdate(encryptionKey, u);
+        return {
+          id: toBase64(digest(payload)),
+          timestamp: [1, i] as [number, number],
+          payload,
+          contentIds: getEmptyEncodedContentIds(),
+        };
+      }),
+    );
+    const container = encodeEncryptedUpdateMessages(
+      messages,
+    ) as unknown as MilestoneSnapshot;
+
+    mockConnection.responseHandler = (message) => {
+      if (
+        message.type === "rpc" &&
+        message.requestType === "request" &&
+        message.rpcMethod === "milestoneGet"
+      ) {
+        const response: MilestoneGetResponse = {
+          milestoneId: "auto-1",
+          snapshot: container,
+        };
+        return new RpcMessage(
+          "test-doc",
+          { type: "success", payload: response },
+          message.rpcMethod,
+          "response",
+          message.id,
+          { clientId: "test-client" },
+          false,
+        );
+      }
+      return null;
+    };
+
+    const snapshot = await provider.getMilestoneSnapshot("auto-1");
+    const restored = new Y.Doc();
+    Y.applyUpdateV2(restored, snapshot as unknown as Uint8Array);
+    expect(restored.getText("content").toString()).toBe("Hello World");
   });
 
   it("should create milestone", async () => {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -9,10 +9,17 @@ import {
   Observable,
   RawReceivedMessage,
   RpcMessage,
+  mergeUpdates,
   type ClientContext,
   type MilestoneSnapshot,
   type Transport,
+  type Update,
 } from "teleportal";
+import {
+  decodeEncryptedUpdate,
+  encodeEncryptedUpdate,
+  type EncryptedUpdatePayload,
+} from "teleportal/protocol/encryption";
 import {
   getYTransportFromYDoc,
   type FanOutReader,
@@ -43,11 +50,7 @@ import {
   type ContentIds,
   type ContentMap,
 } from "teleportal/attribution";
-import {
-  decryptUpdate,
-  encryptUpdate,
-  type EncryptedBinary,
-} from "teleportal/encryption-key";
+import { decryptUpdate, encryptUpdate } from "teleportal/encryption-key";
 import { Connection, ConnectionContext, ConnectionState } from "./connection";
 import { FallbackConnection } from "./fallback-connection";
 import { RpcClient, RpcOperationError } from "./rpc-client";
@@ -747,11 +750,29 @@ export class Provider<
       );
 
       const snapshot = response.snapshot as unknown as Uint8Array;
-      // For E2EE documents the snapshot is stored encrypted; decrypt it here so
-      // consumers always receive a plaintext Y.js update (see createMilestone).
-      const plaintext = this.encryptionKey
-        ? await decryptUpdate(this.encryptionKey, snapshot as EncryptedBinary)
-        : snapshot;
+      if (!this.encryptionKey) {
+        return snapshot as unknown as MilestoneSnapshot;
+      }
+      // For E2EE documents the snapshot is an encrypted-update-message container
+      // (see createMilestone for client snapshots; the server uses the same
+      // format for automatic milestones). Decrypt each message's payload and
+      // merge them back into a single plaintext Y.js update.
+      const messages = decodeEncryptedUpdate(
+        snapshot as unknown as EncryptedUpdatePayload,
+      );
+      const updates = await Promise.all(
+        messages.map(
+          (message) =>
+            decryptUpdate(
+              this.encryptionKey!,
+              message.payload,
+            ) as Promise<Update>,
+        ),
+      );
+      const plaintext =
+        updates.length === 0
+          ? Y.encodeStateAsUpdateV2(new Y.Doc())
+          : mergeUpdates(updates);
       return plaintext as unknown as MilestoneSnapshot;
     } catch (error) {
       if (error instanceof RpcOperationError) {
@@ -770,11 +791,19 @@ export class Provider<
   async createMilestone(name?: string): Promise<Milestone> {
     const plaintext = Y.encodeStateAsUpdateV2(this.doc);
     // For E2EE documents, encrypt the snapshot before it leaves the client so
-    // milestone content is never stored in plaintext on the server. The server
-    // treats the snapshot as opaque bytes; getMilestoneSnapshot decrypts it.
-    const snapshot = (this.encryptionKey
-      ? await encryptUpdate(this.encryptionKey, plaintext)
-      : plaintext) as unknown as MilestoneSnapshot;
+    // milestone content is never stored in plaintext on the server. It is wrapped
+    // in the same encrypted-update-message container the server uses for
+    // automatic milestones, so getMilestoneSnapshot can decrypt both uniformly.
+    let snapshot: MilestoneSnapshot;
+    if (this.encryptionKey) {
+      const encrypted = await encryptUpdate(this.encryptionKey, plaintext);
+      snapshot = encodeEncryptedUpdate(
+        encrypted,
+        [0, 0],
+      ) as unknown as MilestoneSnapshot;
+    } else {
+      snapshot = plaintext as unknown as MilestoneSnapshot;
+    }
 
     try {
       const response =

--- a/src/storage/virtual-storage.test.ts
+++ b/src/storage/virtual-storage.test.ts
@@ -3,6 +3,7 @@ import type {
   DocumentStorage,
   DocumentMetadata,
   Document,
+  EncodedContentMap,
 } from "teleportal/storage";
 import type { Update } from "teleportal";
 import { VirtualStorage } from "./virtual-storage";
@@ -15,12 +16,18 @@ class MockDocumentStorage implements DocumentStorage {
   milestoneStorage = undefined;
 
   public handledUpdates: Update[] = [];
+  public handledAttributions: (EncodedContentMap | undefined)[] = [];
   public writtenMetadata: DocumentMetadata[] = [];
   public documents = new Map<string, Document>();
   public metadataMap = new Map<string, DocumentMetadata>();
 
-  async handleUpdate(documentId: string, update: Update): Promise<void> {
+  async handleUpdate(
+    documentId: string,
+    update: Update,
+    attribution?: EncodedContentMap,
+  ): Promise<void> {
     this.handledUpdates.push(update);
+    this.handledAttributions.push(attribution);
   }
 
   async getDocument(documentId: string): Promise<Document | null> {
@@ -66,6 +73,17 @@ class MockDocumentStorage implements DocumentStorage {
 
   async transaction<T>(documentId: string, cb: () => Promise<T>): Promise<T> {
     return cb();
+  }
+}
+
+// A storage that supports attribution, to verify VirtualStorage delegates.
+class AttributionMockStorage extends MockDocumentStorage {
+  public stored = new Map<string, EncodedContentMap>();
+
+  async retrieveAttribution(
+    documentId: string,
+  ): Promise<EncodedContentMap | null> {
+    return this.stored.get(documentId) ?? null;
   }
 }
 
@@ -127,5 +145,39 @@ describe("VirtualStorage", () => {
     await virtualStorage.deleteDocument("doc1");
 
     expect(mockStorage.handledUpdates.length).toBe(1);
+  });
+
+  it("does not advertise attribution when the wrapped storage lacks it", () => {
+    // The server uses the presence of retrieveAttribution to decide whether to
+    // compute attribution at all; it must be falsy for non-attribution backends.
+    expect(virtualStorage.retrieveAttribution).toBeUndefined();
+  });
+
+  it("delegates retrieveAttribution when the wrapped storage supports it", async () => {
+    const attrStorage = new AttributionMockStorage();
+    const map = new Uint8Array([9, 9]) as EncodedContentMap;
+    attrStorage.stored.set("doc1", map);
+    const vs = new VirtualStorage(attrStorage, {
+      batchMaxSize: 10,
+      batchWaitMs: 1000,
+    });
+
+    expect(typeof vs.retrieveAttribution).toBe("function");
+    expect(await vs.retrieveAttribution!("doc1")).toBe(map);
+    expect(await vs.retrieveAttribution!("missing")).toBeNull();
+  });
+
+  it("buffers attribution and forwards it to the underlying storage", async () => {
+    const update = new Uint8Array([1, 2, 3]) as Update;
+    const attribution = new Uint8Array([7, 7, 7]) as EncodedContentMap;
+
+    // Attributed writes are batched like any other write, not bypassed.
+    await virtualStorage.handleUpdate("doc1", update, attribution);
+    expect(mockStorage.handledUpdates.length).toBe(0);
+
+    await virtualStorage.getDocument("doc1");
+
+    expect(mockStorage.handledUpdates).toEqual([update]);
+    expect(mockStorage.handledAttributions).toEqual([attribution]);
   });
 });


### PR DESCRIPTION
Follow-up fixes to the attribution feature (#69), found during review.

## 1. E2EE milestone snapshots — `getMilestoneSnapshot` threw on automatic milestones

For E2EE documents, server-generated **automatic** milestones store the document's
multi-message encrypted-update container (`encodeEncryptedUpdateMessages`), not the single
`encryptUpdate()` blob produced by client `createMilestone`. The previous code called
`decryptUpdate` unconditionally, which fails AES-GCM auth on the container and throws.

Both paths now use one uniform format:
- `createMilestone` wraps its encrypted snapshot via `encodeEncryptedUpdate` (a one-message container).
- `getMilestoneSnapshot` decodes the container, decrypts **every** message payload, and merges them back into a single plaintext Y.js update.

As a result, automatic milestones now also work with the client-side attribution helpers
(`getMilestoneContentMap`, changeset/range resolution).

## 2. `AttrRanges.getIds()` dropped attribution spans

A range that fully contained a later, differently-attributed range had its trailing span
silently discarded (e.g. `[0,10)=A` + `[3,5)=B` → `[0,3)=A, [3,5)=B`, losing `[5,10)=A`).
Reachable when users delete overlapping ranges across separate updates. Reimplemented
`getIds()` as a boundary sweep that preserves every non-contested span while keeping the
existing later-added-wins precedence for contested spans.

## Tests / verification
- New regression tests for both issues (`attribution.test.ts`, `provider.test.ts`), including a two-message automatic-milestone container that decrypts+merges correctly.
- `bun test`: 947 pass, 0 fail (1 unrelated Redis skip).
- `bun run test:types`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)