### PR TITLE
feat: client flow control non-fatal rate limiting, ACK timeout, update batching

### DIFF
--- a/src/providers/connection.test.ts
+++ b/src/providers/connection.test.ts
@@ -47,7 +47,7 @@ class MockConnection extends Connection<{
     isOnline?: boolean;
     eventTarget?: EventTarget;
   }) {
-    super({ connect: false, ...options });
+    super({ connect: false, batchIntervalMs: 0, ...options });
     // Initialize state to disconnected
     this.setState({
       type: "disconnected",

--- a/src/providers/connection.test.ts
+++ b/src/providers/connection.test.ts
@@ -6,7 +6,9 @@ import {
   Message,
   type ClientContext,
   type StateVector,
+  type Update,
 } from "teleportal";
+import * as Y from "yjs";
 import { RpcMessage } from "teleportal/protocol";
 import { Connection, type ConnectionState } from "./connection";
 import { Timer } from "./utils";
@@ -46,6 +48,8 @@ class MockConnection extends Connection<{
     timer?: Timer;
     isOnline?: boolean;
     eventTarget?: EventTarget;
+    batchIntervalMs?: number;
+    maxBatchIntervalMs?: number;
   }) {
     super({ connect: false, batchIntervalMs: 0, ...options });
     // Initialize state to disconnected
@@ -347,6 +351,80 @@ describe("Connection", () => {
       await connection.send(message);
       // Message should not be sent or buffered when manually disconnected
       expect(connection.sentMessages.length).toBe(0);
+    });
+  });
+
+  describe("Update Batching", () => {
+    // Build a real Y.js V2 update so mergeUpdates can merge it.
+    const makeUpdate = (doc: string, mutate: (d: Y.Doc) => void): DocMessage<any> => {
+      const d = new Y.Doc();
+      mutate(d);
+      return new DocMessage(doc, { type: "update", update: Y.encodeStateAsUpdateV2(d) as Update }, {
+        clientId: "test-client",
+      } as ClientContext);
+    };
+
+    it("merges multiple updates for the same doc into one valid DocMessage", async () => {
+      const batched = new MockConnection({ connect: false, batchIntervalMs: 30 });
+      await batched.connect();
+
+      await batched.send(makeUpdate("doc-a", (d) => d.getMap("m").set("a", 1)));
+      await batched.send(makeUpdate("doc-a", (d) => d.getMap("m").set("b", 2)));
+
+      // Nothing sent yet (still within the batch interval)
+      expect(batched.sentMessages.length).toBe(0);
+
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      // The two updates collapse into a single message
+      expect(batched.sentMessages.length).toBe(1);
+      const sent = batched.sentMessages[0]!;
+      // The flushed message must remain a real DocMessage instance: the transport
+      // relies on the `id`/`encoded` prototype getters, which a plain-object spread
+      // would have dropped.
+      expect(sent).toBeInstanceOf(DocMessage);
+      expect(typeof sent.id).toBe("string");
+      expect(sent.encoded).toBeInstanceOf(Uint8Array);
+      expect((sent.payload as { type: string }).type).toBe("update");
+
+      await batched.destroy();
+    });
+
+    it("sends a single update as-is, preserving message identity", async () => {
+      const batched = new MockConnection({ connect: false, batchIntervalMs: 30 });
+      await batched.connect();
+
+      const message = makeUpdate("doc-b", (d) => d.getMap("m").set("a", 1));
+      await batched.send(message);
+
+      await new Promise((resolve) => setTimeout(resolve, 60));
+
+      expect(batched.sentMessages.length).toBe(1);
+      expect(batched.sentMessages[0]).toBe(message);
+
+      await batched.destroy();
+    });
+
+    it("keeps batching enabled after repeated ACKs (AIMD floor)", async () => {
+      const batched = new MockConnection({ connect: false, batchIntervalMs: 30 });
+      // Echo an ACK for every sent message to drive the AIMD speed-up.
+      batched.responseHandler = (message) =>
+        new AckMessage({ type: "ack", messageId: message.id }, undefined);
+      await batched.connect();
+
+      // Flush many batches; each ACK decrements the interval by 10.
+      for (let i = 0; i < 20; i++) {
+        await batched.send(makeUpdate("doc-c", (d) => d.getMap("m").set(`k${i}`, i)));
+        await new Promise((resolve) => setTimeout(resolve, 40));
+      }
+
+      // Batching must still be active: a fresh update is held, not flushed
+      // immediately (which is what a 0 interval would do).
+      const before = batched.sentMessages.length;
+      await batched.send(makeUpdate("doc-c", (d) => d.getMap("m").set("final", 1)));
+      expect(batched.sentMessages.length).toBe(before);
+
+      await batched.destroy();
     });
   });
 

--- a/src/providers/connection.ts
+++ b/src/providers/connection.ts
@@ -1,5 +1,11 @@
-import { AckMessage, Message, Observable, RawReceivedMessage } from "teleportal";
+import {
+  AckMessage,
+  Message,
+  Observable,
+  RawReceivedMessage,
+} from "teleportal";
 import { createFanOutWriter, FanOutReader } from "teleportal/transports";
+import { mergeUpdatesV2 } from "yjs";
 import { ExponentialBackoff, TimerManager, type Timer } from "./utils";
 
 /**
@@ -130,11 +136,37 @@ export type ConnectionOptions = {
    */
   reconnectBackoffFactor?: number;
   /**
+   * Per-message ACK timeout in milliseconds (0 to disable).
+   * If a message is not ACKed within this time, it is evicted from in-flight
+   * tracking. This prevents the `synced` promise from blocking forever when
+   * the server drops a message (e.g. due to rate limiting or permission denial).
+   *
+   * @default 30000
+   */
+  inFlightMessageTimeout?: number;
+  /**
    * Timer implementation for dependency injection (testing)
    *
    * @default defaultTimer
    */
   timer?: Timer;
+
+  /**
+   * Batch outbound doc-update messages over this interval (ms) and merge them
+   * into a single message before sending. Reduces message rate and avoids
+   * tripping server-side rate limits. 0 = no batching.
+   *
+   * @default 100
+   */
+  batchIntervalMs?: number;
+
+  /**
+   * Maximum batch interval in milliseconds. The interval grows toward this
+   * value when ACKs are slow or missing (multiplicative increase).
+   *
+   * @default 5000
+   */
+  maxBatchIntervalMs?: number;
 };
 
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 10;
@@ -145,6 +177,7 @@ const DEFAULT_MIN_UPTIME = 0;
 const DEFAULT_RECONNECT_DELAY_JITTER = 0;
 const DEFAULT_MAX_BUFFERED_MESSAGES = Number.POSITIVE_INFINITY;
 const DEFAULT_RECONNECT_BACKOFF_FACTOR = 1.3;
+const DEFAULT_IN_FLIGHT_MESSAGE_TIMEOUT = 30_000;
 
 export abstract class Connection<Context extends ConnectionContext = any> extends Observable<{
   update: (state: ConnectionState<Context>) => void;
@@ -184,7 +217,17 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
   #messageBuffer: Message[] = [];
 
   // In-flight message tracking (messages sent but not yet acked, excluding awareness)
-  #inFlightMessages = new Map<string, Message>();
+  #inFlightMessages = new Map<
+    string,
+    { message: Message; timer: ReturnType<typeof setTimeout> | null }
+  >();
+  #inFlightMessageTimeoutMs: number;
+
+  // Update batching (AIMD congestion control)
+  #batchIntervalMs: number;
+  #maxBatchIntervalMs: number;
+  #pendingUpdates = new Map<string, { updates: Uint8Array[]; message: Message }>();
+  #batchFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Heartbeat and connection check state
   #heartbeatInterval: ReturnType<typeof setInterval> | null = null;
@@ -219,7 +262,10 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
     reconnectDelayJitter = DEFAULT_RECONNECT_DELAY_JITTER,
     maxBufferedMessages = DEFAULT_MAX_BUFFERED_MESSAGES,
     reconnectBackoffFactor = DEFAULT_RECONNECT_BACKOFF_FACTOR,
+    inFlightMessageTimeout = DEFAULT_IN_FLIGHT_MESSAGE_TIMEOUT,
     timer,
+    batchIntervalMs = 100,
+    maxBatchIntervalMs = 5000,
   }: ConnectionOptions = {}) {
     super();
 
@@ -242,6 +288,9 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
     this.#heartbeatIntervalMs = heartbeatInterval;
     this.#messageReconnectTimeoutMs = messageReconnectTimeout;
     this.#minUptimeMs = minUptime;
+    this.#inFlightMessageTimeoutMs = inFlightMessageTimeout;
+    this.#batchIntervalMs = batchIntervalMs;
+    this.#maxBatchIntervalMs = maxBatchIntervalMs;
 
     // Set up event target and online state
     if (globalThis.window === undefined) {
@@ -288,10 +337,15 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
     this.on("received-message", (message) => {
       if (message.type === "ack") {
         const messageId = message.payload.messageId;
-        if (this.#inFlightMessages.has(messageId)) {
+        const entry = this.#inFlightMessages.get(messageId);
+        if (entry) {
+          if (entry.timer) this.timerManager.clearTimeout(entry.timer);
           this.#inFlightMessages.delete(messageId);
-          // Emit event with current in-flight status
           this.call("messages-in-flight", this.#inFlightMessages.size > 0);
+          // AIMD: speed up on successful ACK
+          if (this.#batchIntervalMs > 0) {
+            this.#batchIntervalMs = Math.max(0, this.#batchIntervalMs - 10);
+          }
         }
       } else {
         // Send ACK for all non-ACK messages received from the server
@@ -313,12 +367,6 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
         });
       }
     });
-  }
-
-  private getPayloadType(message: Message): string | undefined {
-    if (message.type !== "doc") return undefined;
-    const payload = message.payload as { type?: string } | undefined;
-    return payload?.type;
   }
 
   /**
@@ -395,8 +443,18 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
         if (previousState.type !== "disconnected") {
           this.call("disconnected");
         }
+        // Flush any pending batched updates before clearing state
+        if (this.#batchFlushTimer) {
+          this.timerManager.clearTimeout(this.#batchFlushTimer);
+          this.#batchFlushTimer = null;
+        }
+        this.#flushBatch();
+
         // Clear in-flight messages when disconnected (they'll need to be re-sent)
         const hadInFlightMessages = this.#inFlightMessages.size > 0;
+        for (const { timer } of this.#inFlightMessages.values()) {
+          if (timer) this.timerManager.clearTimeout(timer);
+        }
         this.#inFlightMessages.clear();
         if (hadInFlightMessages) {
           this.call("messages-in-flight", false);
@@ -574,6 +632,47 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
     this.scheduleReconnect();
   }
 
+  private isDocUpdate(message: Message): boolean {
+    return (
+      message.type === "doc" &&
+      (message.payload as { type?: string })?.type === "update" &&
+      message.document != null
+    );
+  }
+
+  #scheduleBatchFlush(): void {
+    if (this.#batchFlushTimer || this.#pendingUpdates.size === 0) return;
+
+    const interval = this.#batchIntervalMs;
+    if (interval <= 0) {
+      this.#flushBatch();
+      return;
+    }
+
+    this.#batchFlushTimer = this.timerManager.setTimeout(() => {
+      this.#batchFlushTimer = null;
+      this.#flushBatch();
+    }, interval);
+  }
+
+  #flushing = false;
+
+  #flushBatch(): void {
+    if (this.#pendingUpdates.size === 0) return;
+
+    this.#flushing = true;
+    for (const [, { updates, message }] of this.#pendingUpdates) {
+      const merged = updates.length === 1 ? updates[0]! : mergeUpdatesV2(updates);
+      const batched = {
+        ...message,
+        payload: { type: "update" as const, update: merged },
+      } as Message;
+      this.sendOrBuffer(batched);
+    }
+    this.#pendingUpdates.clear();
+    this.#flushing = false;
+  }
+
   /**
    * Send a buffered message if connected, otherwise buffer it
    */
@@ -586,13 +685,44 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
       return; // Don't send if manually disconnected
     }
 
+    // Batch doc update messages when batching is enabled
+    if (this.#batchIntervalMs > 0 && !this.#flushing && this.isDocUpdate(message)) {
+      const doc = message.document!;
+      const update = (message.payload as { update: Uint8Array }).update;
+      const existing = this.#pendingUpdates.get(doc);
+      if (existing) {
+        existing.updates.push(update);
+      } else {
+        this.#pendingUpdates.set(doc, { updates: [update], message });
+      }
+      this.#scheduleBatchFlush();
+      return;
+    }
+
     if (this.state.type === "connected") {
-      // Track in-flight messages that expect an ack. Ack, awareness and presence
+      // Track in-flight messages that expect an ack. Ack, awareness, and presence
       // messages are fire-and-forget and are never acked.
-      if (message.type !== "ack" && message.type !== "awareness" && message.type !== "presence") {
+      if (
+        message.type !== "ack" &&
+        message.type !== "awareness" &&
+        message.type !== "presence"
+      ) {
         const wasEmpty = this.#inFlightMessages.size === 0;
-        this.#inFlightMessages.set(message.id, message);
-        // Emit event when messages become in-flight
+        const timer =
+          this.#inFlightMessageTimeoutMs > 0
+            ? this.timerManager.setTimeout(() => {
+                if (this.#inFlightMessages.has(message.id)) {
+                  this.#inFlightMessages.delete(message.id);
+                  this.call("messages-in-flight", this.#inFlightMessages.size > 0);
+                  // AIMD: slow down when a message goes unACKed
+                  this.#batchIntervalMs = Math.min(
+                    this.#maxBatchIntervalMs,
+                    Math.max(50, this.#batchIntervalMs * 2),
+                  );
+                }
+              }, this.#inFlightMessageTimeoutMs)
+            : null;
+        this.#inFlightMessages.set(message.id, { message, timer });
         if (wasEmpty) {
           this.call("messages-in-flight", true);
         }
@@ -600,9 +730,14 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
 
       this.sendMessage(message).catch(async (err) => {
         // Remove from in-flight if send fails
-        if (message.type !== "ack" && message.type !== "awareness" && message.type !== "presence") {
+        if (
+          message.type !== "ack" &&
+          message.type !== "awareness" &&
+          message.type !== "presence"
+        ) {
+          const entry = this.#inFlightMessages.get(message.id);
+          if (entry?.timer) this.timerManager.clearTimeout(entry.timer);
           this.#inFlightMessages.delete(message.id);
-          // Emit event with current in-flight status
           this.call("messages-in-flight", this.#inFlightMessages.size > 0);
         }
 
@@ -827,7 +962,15 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
     // Clear message buffer
     this.#messageBuffer = [];
 
-    // Clear in-flight messages
+    // Flush pending batch and clear in-flight messages
+    if (this.#batchFlushTimer) {
+      this.timerManager.clearTimeout(this.#batchFlushTimer);
+      this.#batchFlushTimer = null;
+    }
+    this.#pendingUpdates.clear();
+    for (const { timer } of this.#inFlightMessages.values()) {
+      if (timer) this.timerManager.clearTimeout(timer);
+    }
     this.#inFlightMessages.clear();
 
     // Clear connected promise

--- a/src/providers/connection.ts
+++ b/src/providers/connection.ts
@@ -1,11 +1,13 @@
 import {
   AckMessage,
+  DocMessage,
+  type Update,
   Message,
+  mergeUpdates,
   Observable,
   RawReceivedMessage,
 } from "teleportal";
 import { createFanOutWriter, FanOutReader } from "teleportal/transports";
-import { mergeUpdatesV2 } from "yjs";
 import { ExponentialBackoff, TimerManager, type Timer } from "./utils";
 
 /**
@@ -178,6 +180,11 @@ const DEFAULT_RECONNECT_DELAY_JITTER = 0;
 const DEFAULT_MAX_BUFFERED_MESSAGES = Number.POSITIVE_INFINITY;
 const DEFAULT_RECONNECT_BACKOFF_FACTOR = 1.3;
 const DEFAULT_IN_FLIGHT_MESSAGE_TIMEOUT = 30_000;
+// Floor for the AIMD batch interval while batching is enabled. The interval is
+// only ever 0 when batching is explicitly disabled (batchIntervalMs: 0); the
+// speed-up step must not drive an enabled interval down to 0, which would
+// silently disable batching for the rest of the connection's life.
+const MIN_BATCH_INTERVAL_MS = 10;
 
 export abstract class Connection<Context extends ConnectionContext = any> extends Observable<{
   update: (state: ConnectionState<Context>) => void;
@@ -226,7 +233,7 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
   // Update batching (AIMD congestion control)
   #batchIntervalMs: number;
   #maxBatchIntervalMs: number;
-  #pendingUpdates = new Map<string, { updates: Uint8Array[]; message: Message }>();
+  #pendingUpdates = new Map<string, { updates: Update[]; message: DocMessage<any> }>();
   #batchFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Heartbeat and connection check state
@@ -342,9 +349,10 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
           if (entry.timer) this.timerManager.clearTimeout(entry.timer);
           this.#inFlightMessages.delete(messageId);
           this.call("messages-in-flight", this.#inFlightMessages.size > 0);
-          // AIMD: speed up on successful ACK
+          // AIMD: speed up on successful ACK (never below the floor, so batching
+          // stays enabled once turned on)
           if (this.#batchIntervalMs > 0) {
-            this.#batchIntervalMs = Math.max(0, this.#batchIntervalMs - 10);
+            this.#batchIntervalMs = Math.max(MIN_BATCH_INTERVAL_MS, this.#batchIntervalMs - 10);
           }
         }
       } else {
@@ -662,11 +670,19 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
 
     this.#flushing = true;
     for (const [, { updates, message }] of this.#pendingUpdates) {
-      const merged = updates.length === 1 ? updates[0]! : mergeUpdatesV2(updates);
-      const batched = {
-        ...message,
-        payload: { type: "update" as const, update: merged },
-      } as Message;
+      // Single update: the original message is unchanged, so send it as-is to
+      // preserve its identity (id/encoded cache). Multiple updates: build a new
+      // DocMessage instance — spreading the message would yield a plain object
+      // that loses the prototype getters (id/encoded) the transport relies on.
+      const batched =
+        updates.length === 1
+          ? message
+          : new DocMessage(
+              message.document,
+              { type: "update", update: mergeUpdates(updates) },
+              message.context,
+              message.encrypted,
+            );
       this.sendOrBuffer(batched);
     }
     this.#pendingUpdates.clear();
@@ -687,13 +703,14 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
 
     // Batch doc update messages when batching is enabled
     if (this.#batchIntervalMs > 0 && !this.#flushing && this.isDocUpdate(message)) {
-      const doc = message.document!;
-      const update = (message.payload as { update: Uint8Array }).update;
+      const docMessage = message as DocMessage<any>;
+      const doc = docMessage.document;
+      const update = (docMessage.payload as { update: Update }).update;
       const existing = this.#pendingUpdates.get(doc);
       if (existing) {
         existing.updates.push(update);
       } else {
-        this.#pendingUpdates.set(doc, { updates: [update], message });
+        this.#pendingUpdates.set(doc, { updates: [update], message: docMessage });
       }
       this.#scheduleBatchFlush();
       return;
@@ -702,11 +719,7 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
     if (this.state.type === "connected") {
       // Track in-flight messages that expect an ack. Ack, awareness, and presence
       // messages are fire-and-forget and are never acked.
-      if (
-        message.type !== "ack" &&
-        message.type !== "awareness" &&
-        message.type !== "presence"
-      ) {
+      if (message.type !== "ack" && message.type !== "awareness" && message.type !== "presence") {
         const wasEmpty = this.#inFlightMessages.size === 0;
         const timer =
           this.#inFlightMessageTimeoutMs > 0
@@ -730,11 +743,7 @@ export abstract class Connection<Context extends ConnectionContext = any> extend
 
       this.sendMessage(message).catch(async (err) => {
         // Remove from in-flight if send fails
-        if (
-          message.type !== "ack" &&
-          message.type !== "awareness" &&
-          message.type !== "presence"
-        ) {
+        if (message.type !== "ack" && message.type !== "awareness" && message.type !== "presence") {
           const entry = this.#inFlightMessages.get(message.id);
           if (entry?.timer) this.timerManager.clearTimeout(entry.timer);
           this.#inFlightMessages.delete(message.id);

--- a/src/transports/encrypted/e2e.test.ts
+++ b/src/transports/encrypted/e2e.test.ts
@@ -479,6 +479,7 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       url: baseUrl,
       connect: opts?.connect ?? true,
       maxReconnectAttempts: 0,
+      batchIntervalMs: 0,
     });
     cleanups.push(() => conn.destroy());
     return conn;
@@ -664,6 +665,7 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       maxReconnectAttempts: 5,
       initialReconnectDelay: 100,
       maxBackoffTime: 500,
+      batchIntervalMs: 0,
     });
     cleanups.push(() => conn2.destroy());
     await conn2.connected;
@@ -860,6 +862,7 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       url: baseUrl,
       connect: false,
       maxReconnectAttempts: 0,
+      batchIntervalMs: 0,
     });
     cleanups.push(() => conn.destroy());
 

--- a/src/transports/rate-limiter/analytics.test.ts
+++ b/src/transports/rate-limiter/analytics.test.ts
@@ -125,15 +125,8 @@ describe("Rate Limit Analytics", () => {
 
     const writer2 = rateLimitedTransport.writable.getWriter();
 
-    // First message consumed the token, so second should be rate limited
-    try {
-      await writer2.write(message2);
-      // If we get here without error, something is wrong
-      expect(false).toBe(true);
-    } catch (error: any) {
-      // Expected: rate limit exceeded
-      expect(error.message).toBe("Rate limit exceeded");
-    }
+    // First message consumed the token, so second should be silently dropped
+    await writer2.write(message2);
 
     writer2.releaseLock();
 

--- a/src/transports/rate-limiter/dynamic-limits.test.ts
+++ b/src/transports/rate-limiter/dynamic-limits.test.ts
@@ -52,6 +52,7 @@ describe("RateLimitedTransport - Dynamic Limits", () => {
   });
 
   it("should support dynamic maxMessages based on user", async () => {
+    const onRateLimitExceeded = mock();
     const rateLimited = new RateLimitedTransport<any, any>(transport as any, {
       rules: [
         {
@@ -64,6 +65,7 @@ describe("RateLimitedTransport - Dynamic Limits", () => {
         },
       ],
       rateLimitStorage: mockStorage,
+      onRateLimitExceeded,
     });
 
     const writer = rateLimited.writable.getWriter();
@@ -91,18 +93,12 @@ describe("RateLimitedTransport - Dynamic Limits", () => {
     // Due to token bucket refill, tokens might be slightly > 0, but should be < 1
     expect(stateNormal?.tokens).toBeLessThan(1); // 2 - 2 = 0 (with possible tiny refill)
 
-    // Now send 3rd message for Normal - should fail
-    let errorNormal;
-    try {
-      await writer.write({
-        type: "ping",
-        context: { userId: "normal" },
-      } as any);
-    } catch (e: any) {
-      errorNormal = e;
-    }
-    expect(errorNormal).toBeDefined();
-    expect(errorNormal.message).toBe("Rate limit exceeded");
+    // Now send 3rd message for Normal - should be silently dropped
+    await writer.write({
+      type: "ping",
+      context: { userId: "normal" },
+    } as any);
+    expect(onRateLimitExceeded).toHaveBeenCalled();
   });
 
   it("should support dynamic windowMs", async () => {

--- a/src/transports/rate-limiter/index.test.ts
+++ b/src/transports/rate-limiter/index.test.ts
@@ -328,14 +328,13 @@ describe("RateLimitedTransport", () => {
     sourceController.ctrl.enqueue({ type: "ping" } as any);
     sourceController.ctrl.enqueue({ type: "ping" } as any);
 
-    // Wait a tick for processing
-    await new Promise((r) => setTimeout(r, 50));
+    // Close the source and wait for the read loop to drain deterministically
+    // (avoids a flaky fixed-delay wait on slower CI).
+    sourceController.ctrl.close();
+    await readLoop;
 
     // Only the first should have passed through
     expect(received.length).toBe(1);
     expect(onRateLimitExceeded).toHaveBeenCalledTimes(2);
-
-    sourceController.ctrl.close();
-    await readLoop;
   });
 });

--- a/src/transports/rate-limiter/index.test.ts
+++ b/src/transports/rate-limiter/index.test.ts
@@ -52,6 +52,7 @@ describe("RateLimitedTransport", () => {
   });
 
   it("should enforce rate limits with transport tracking", async () => {
+    const onRateLimitExceeded = mock();
     const rateLimited = new RateLimitedTransport(transport as any, {
       rules: [
         {
@@ -61,6 +62,7 @@ describe("RateLimitedTransport", () => {
           trackBy: "transport",
         },
       ],
+      onRateLimitExceeded,
     });
 
     const writer = rateLimited.writable.getWriter();
@@ -69,16 +71,10 @@ describe("RateLimitedTransport", () => {
     await writer.write({ type: "ping" } as any);
     await writer.write({ type: "ping" } as any);
 
-    // 3rd message should fail
-    let error;
-    try {
-      await writer.write({ type: "ping" } as any);
-    } catch (e: any) {
-      error = e;
-    }
+    // 3rd message should be silently dropped (not thrown)
+    await writer.write({ type: "ping" } as any);
 
-    expect(error).toBeDefined();
-    expect(error.message).toBe("Rate limit exceeded");
+    expect(onRateLimitExceeded).toHaveBeenCalled();
   });
 
   it("should use storage when provided", async () => {
@@ -171,6 +167,7 @@ describe("RateLimitedTransport", () => {
   });
 
   it("should apply rate limit if permission granted", async () => {
+    const onRateLimitExceeded = mock();
     const rateLimited = new RateLimitedTransport(transport as any, {
       rules: [
         {
@@ -181,23 +178,20 @@ describe("RateLimitedTransport", () => {
         },
       ],
       checkPermission: () => true, // Permission granted
+      onRateLimitExceeded,
     });
 
     const writer = rateLimited.writable.getWriter();
 
     await writer.write({ type: "ping" } as any);
 
-    // Second should fail
-    let error;
-    try {
-      await writer.write({ type: "ping" } as any);
-    } catch (e) {
-      error = e;
-    }
-    expect(error).toBeDefined();
+    // Second should be silently dropped
+    await writer.write({ type: "ping" } as any);
+    expect(onRateLimitExceeded).toHaveBeenCalled();
   });
 
   it("should skip rate limit if shouldSkipRateLimit returns true", async () => {
+    const onRateLimitExceeded = mock();
     const rateLimited = new RateLimitedTransport(transport as any, {
       rules: [
         {
@@ -208,7 +202,9 @@ describe("RateLimitedTransport", () => {
           getUserId: (msg) => (msg.context as any)?.userId,
         },
       ],
+      rateLimitStorage: mockStorage,
       shouldSkipRateLimit: (msg) => (msg.context as any)?.userId === "admin",
+      onRateLimitExceeded,
     });
 
     const writer = rateLimited.writable.getWriter();
@@ -217,14 +213,12 @@ describe("RateLimitedTransport", () => {
     await writer.write({ type: "ping", context: { userId: "admin" } } as any);
     await writer.write({ type: "ping", context: { userId: "admin" } } as any);
     await writer.write({ type: "ping", context: { userId: "admin" } } as any);
+    expect(onRateLimitExceeded).not.toHaveBeenCalled();
 
-    // Regular user should be limited
+    // Regular user should be limited (silently dropped)
     await writer.write({ type: "ping", context: { userId: "user" } } as any);
-    try {
-      await writer.write({ type: "ping", context: { userId: "user" } } as any);
-    } catch (e: any) {
-      expect(e.message).toBe("Rate limit exceeded");
-    }
+    await writer.write({ type: "ping", context: { userId: "user" } } as any);
+    expect(onRateLimitExceeded).toHaveBeenCalled();
   });
 
   it("should enforce multiple rules simultaneously", async () => {
@@ -265,5 +259,83 @@ describe("RateLimitedTransport", () => {
     expect(docState).not.toBeNull();
     expect(userState?.tokens).toBe(99); // 100 - 1
     expect(docState?.tokens).toBe(199); // 200 - 1
+  });
+
+  it("should silently drop rate-limited messages (stream survives)", async () => {
+    const onRateLimitExceeded = mock();
+    const rateLimited = new RateLimitedTransport(transport as any, {
+      rules: [
+        {
+          id: "transport-limit",
+          maxMessages: 1,
+          windowMs: 1000,
+          trackBy: "transport",
+        },
+      ],
+      onRateLimitExceeded,
+    });
+
+    const writer = rateLimited.writable.getWriter();
+
+    // First message passes
+    await writer.write({ type: "ping" } as any);
+
+    // Second message is dropped silently
+    await writer.write({ type: "ping" } as any);
+    expect(onRateLimitExceeded).toHaveBeenCalledTimes(1);
+
+    // Stream is still alive — third message is also dropped (not thrown)
+    await writer.write({ type: "ping" } as any);
+    expect(onRateLimitExceeded).toHaveBeenCalledTimes(2);
+  });
+
+  it("should drop rate-limited messages on readable stream too", async () => {
+    const onRateLimitExceeded = mock();
+    const sourceController: any = {};
+    const readable = new ReadableStream<Message<ClientContext>>({
+      start(controller) {
+        sourceController.ctrl = controller;
+      },
+    });
+    const writable = new WritableStream<Message<ClientContext>>({ write: mock() });
+
+    const rateLimited = new RateLimitedTransport({ readable, writable } as any, {
+      rules: [
+        {
+          id: "transport-limit",
+          maxMessages: 1,
+          windowMs: 1000,
+          trackBy: "transport",
+        },
+      ],
+      onRateLimitExceeded,
+    });
+
+    const received: any[] = [];
+    const reader = rateLimited.readable.getReader();
+
+    // Start reading in background
+    const readLoop = (async () => {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        received.push(value);
+      }
+    })();
+
+    // Enqueue 3 messages into source
+    sourceController.ctrl.enqueue({ type: "ping" } as any);
+    sourceController.ctrl.enqueue({ type: "ping" } as any);
+    sourceController.ctrl.enqueue({ type: "ping" } as any);
+
+    // Wait a tick for processing
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Only the first should have passed through
+    expect(received.length).toBe(1);
+    expect(onRateLimitExceeded).toHaveBeenCalledTimes(2);
+
+    sourceController.ctrl.close();
+    await readLoop;
   });
 });

--- a/src/transports/rate-limiter/index.ts
+++ b/src/transports/rate-limiter/index.ts
@@ -309,16 +309,17 @@ export class RateLimitedTransport<
   }
 
   /**
-   * Check a single rate limit rule
+   * Check a single rate limit rule.
+   * Returns null if the rule passes, or the exceeded data if violated.
    */
   private async checkRule(
     rule: RateLimitRule<Context>,
     message: Message<Context>,
-  ): Promise<boolean> {
+  ): Promise<RateLimitExceededData<Context> | null> {
     // Skip this rule if shouldSkipRule returns true
     if (rule.shouldSkipRule) {
       if (await rule.shouldSkipRule(message)) {
-        return true;
+        return null;
       }
     }
 
@@ -371,7 +372,7 @@ export class RateLimitedTransport<
             exceededData.trackBy,
           );
           this.eventEmitter?.call("rate-limit-exceeded", exceededData);
-          return false;
+          return exceededData;
         }
 
         // Consume token
@@ -386,7 +387,7 @@ export class RateLimitedTransport<
           trackBy: rule.trackBy,
         });
 
-        return true;
+        return null;
       });
     }
 
@@ -408,38 +409,41 @@ export class RateLimitedTransport<
         this.onRateLimitExceeded?.(exceededData);
         this.metricsCollector?.recordRateLimitExceeded("unknown", undefined, "transport");
         this.eventEmitter?.call("rate-limit-exceeded", exceededData);
-        return false;
+        return exceededData;
       }
 
       bucket.tokens--;
-      return true;
+      return null;
     }
 
     // If we don't have storage and it's not transport-level, we can't track it
     // This shouldn't happen in practice, but fail open for safety
-    return true;
+    return null;
   }
 
   /**
    * Check if a message can be sent based on all rate limit rules
-   * All rules must pass for the message to be allowed
+   * All rules must pass for the message to be allowed.
+   * Returns null if allowed, or the exceeded data if rejected.
    */
-  private async checkRateLimit(message: Message<Context>): Promise<boolean> {
+  private async checkRateLimit(
+    message: Message<Context>,
+  ): Promise<RateLimitExceededData<Context> | null> {
     // 1. Check global permissions first
     if (!(await this.shouldRateLimit(message))) {
-      return true;
+      return null;
     }
 
     // 2. Check all rules sequentially
     // If any rule fails, reject immediately
     for (const rule of this.rules) {
-      const passed = await this.checkRule(rule, message);
-      if (!passed) {
-        return false;
+      const exceeded = await this.checkRule(rule, message);
+      if (exceeded) {
+        return exceeded;
       }
     }
 
-    return true;
+    return null;
   }
 
   /**
@@ -459,7 +463,8 @@ export class RateLimitedTransport<
   }
 
   /**
-   * Create a rate-limited writable stream
+   * Create a rate-limited writable stream.
+   * Rate-limited messages are silently dropped (never thrown) to keep the stream alive.
    */
   private createRateLimitedWritable(
     writable: WritableStream<Message<Context>>,
@@ -472,8 +477,9 @@ export class RateLimitedTransport<
           throw new Error("Message size limit exceeded");
         }
 
-        if (!(await this.checkRateLimit(chunk))) {
-          throw new Error("Rate limit exceeded");
+        const exceeded = await this.checkRateLimit(chunk);
+        if (exceeded) {
+          return;
         }
 
         return writer.write(chunk);
@@ -484,7 +490,8 @@ export class RateLimitedTransport<
   }
 
   /**
-   * Create a rate-limited readable stream
+   * Create a rate-limited readable stream.
+   * Rate-limited messages are silently dropped (never thrown) to keep the stream alive.
    */
   private createRateLimitedReadable(
     readable: ReadableStream<Message<Context>>,
@@ -496,8 +503,9 @@ export class RateLimitedTransport<
             throw new Error("Message size limit exceeded");
           }
 
-          if (!(await this.checkRateLimit(chunk))) {
-            throw new Error("Rate limit exceeded");
+          const exceeded = await this.checkRateLimit(chunk);
+          if (exceeded) {
+            return;
           }
 
           controller.enqueue(chunk);

--- a/src/transports/rate-limiter/index.ts
+++ b/src/transports/rate-limiter/index.ts
@@ -365,13 +365,18 @@ export class RateLimitedTransport<
             resetAt: currentState.lastRefill + currentState.windowMs,
             message,
           };
-          this.onRateLimitExceeded?.(exceededData);
-          this.metricsCollector?.recordRateLimitExceeded(
-            exceededData.userId ?? "unknown",
-            exceededData.documentId,
-            exceededData.trackBy,
-          );
-          this.eventEmitter?.call("rate-limit-exceeded", exceededData);
+          try {
+            this.onRateLimitExceeded?.(exceededData);
+            this.metricsCollector?.recordRateLimitExceeded(
+              exceededData.userId ?? "unknown",
+              exceededData.documentId,
+              exceededData.trackBy,
+            );
+            this.eventEmitter?.call("rate-limit-exceeded", exceededData);
+          } catch (err) {
+            // Observability hooks must not break the non-fatal drop guarantee.
+            console.warn("Rate limit observability hook threw:", err);
+          }
           return exceededData;
         }
 
@@ -406,9 +411,14 @@ export class RateLimitedTransport<
           resetAt: bucket.lastRefill + currentWindowMs,
           message,
         };
-        this.onRateLimitExceeded?.(exceededData);
-        this.metricsCollector?.recordRateLimitExceeded("unknown", undefined, "transport");
-        this.eventEmitter?.call("rate-limit-exceeded", exceededData);
+        try {
+          this.onRateLimitExceeded?.(exceededData);
+          this.metricsCollector?.recordRateLimitExceeded("unknown", undefined, "transport");
+          this.eventEmitter?.call("rate-limit-exceeded", exceededData);
+        } catch (err) {
+          // Observability hooks must not break the non-fatal drop guarantee.
+          console.warn("Rate limit observability hook threw:", err);
+        }
         return exceededData;
       }
 


### PR DESCRIPTION
Adds client-side flow control to keep connections healthy under load. Rate-limited messages are now silently dropped instead of throwing (which previously tore down the stream), so `checkRule`/`checkRateLimit` return the exceeded data rather than a boolean. A per-message ACK timeout evicts unacked in-flight messages so the `synced` promise can't block forever when the server drops a message (e.g. rate limiting or permission denial). Outbound doc updates are batched and merged over an AIMD-controlled interval to reduce message rate and avoid tripping server-side limits.

This also fixes two batching bugs found in review: the batch flush rebuilt messages with an object spread that dropped the `DocMessage` prototype getters (`id`/`encoded`) the transport relies on — now it reuses the original instance for a single update and constructs a real `DocMessage` for merged updates — and the AIMD speed-up is floored so repeated ACKs can no longer drive an enabled batch interval to 0 and silently disable batching. Adds batching tests (the mock previously disabled batching entirely).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic batching of document updates to efficiently merge multiple updates into single messages with configurable intervals
  * Added new connection configuration options for per-message ACK timeout and batch interval control to enable fine-tuned performance settings
  * Improved rate-limiting behavior by silently dropping rate-limited messages instead of throwing errors to provide more graceful degradation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->