### PR TITLE
feat: custom attribution metadata, encrypted-doc attribution, and unified RPC permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,4 @@ There are several sub-packages built with documentation:
 - Type checking: `bun run test:types` (oxlint + tsgo via `vp check`)
 - A goal of this project is to have the minimum number of dependencies and to be as small as possible, so avoid adding dependencies unless otherwise specified
 - When fixing a bug, add a corresponding test case to prevent regression if reasonable to do so
+- Prefer a red-green-refactor cycle: before implementing a fix, write a test that captures the expected behavior and confirm it fails (red). Only then implement the fix to make the test pass (green). This forces you to articulate your expectations upfront rather than acting on a hunch. It doesn't need to slow you down — treat it as a thinking tool that clarifies what "correct" means before you start changing code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ There are several sub-packages built with documentation:
 - [`teleportal/http`](./src/http/README.md) - HTTP handlers
 - [`teleportal/protocol`](./src/lib/protocol/README.md) - Protocol encoding/decoding
 - [`teleportal/protocol/encryption`](./src/lib/protocol/encryption/README.md) - Encryption protocol
+- [`teleportal/attribution`](./src/lib/attribution/README.md) - Attribution data model, set operations, and encoding
 - [`teleportal/protocols/attribution`](./src/protocols/attribution/README.md) - Attribution (authorship) read RPC methods
 - [`teleportal/providers`](./src/providers/README.md) - Provider and connection architecture
 - [`teleportal/transports`](./src/transports/README.md) - Transport middleware

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -115,6 +115,7 @@ export default defineConfig({
             { label: "Server", slug: "core-concepts/server" },
             { label: "Transport", slug: "core-concepts/transport" },
             { label: "Provider", slug: "core-concepts/provider" },
+            { label: "Attribution", slug: "core-concepts/attribution" },
             { label: "Milestones", slug: "core-concepts/milestones" },
             { label: "Authentication", slug: "core-concepts/authentication" },
           ],

--- a/docs/src/content/docs/core-concepts/attribution.mdx
+++ b/docs/src/content/docs/core-concepts/attribution.mdx
@@ -82,7 +82,7 @@ You can attach arbitrary metadata by providing an `attributionConfig` when creat
 import { Server } from "teleportal/server";
 
 const server = new Server({
-  getStorage: async (ctx) => storage,
+  storage: async (ctx) => storage,
   attributionConfig: {
     getAttributes: ({ context }) => ({
       source: context.source ?? "human",
@@ -220,7 +220,7 @@ import { Server } from "teleportal/server";
 import { getAttributionRpcHandlers } from "teleportal/protocols/attribution";
 
 const server = new Server({
-  getStorage: async (ctx) => storage,
+  storage: async (ctx) => storage,
   rpcHandlers: {
     ...getAttributionRpcHandlers(),
   },
@@ -233,7 +233,7 @@ Attribution RPC methods (`attributionActivity`, `attributionGet`) are covered by
 
 ```typescript
 const server = new Server({
-  getStorage: async (ctx) => storage,
+  storage: async (ctx) => storage,
   checkPermission: async ({ context, documentId, rpcMethod }) => {
     if (rpcMethod === "attributionActivity" || rpcMethod === "attributionGet") {
       return canReadAttribution(context.userId, documentId);

--- a/docs/src/content/docs/core-concepts/attribution.mdx
+++ b/docs/src/content/docs/core-concepts/attribution.mdx
@@ -229,17 +229,24 @@ const server = new Server({
 
 ### Permission Control
 
-RPC messages bypass the server's global `checkPermission` hook. To gate attribution access, provide a `checkPermission` callback to the RPC handlers:
+Attribution RPC methods (`attributionActivity`, `attributionGet`) are covered by the server's global `checkPermission` hook. Use the `rpcMethod` field to apply method-level authorization:
 
 ```typescript
-getAttributionRpcHandlers({
-  checkPermission: async (ctx) => {
-    return await canReadAttribution(ctx.userId, ctx.documentId);
+const server = new Server({
+  getStorage: async (ctx) => storage,
+  checkPermission: async ({ context, documentId, rpcMethod }) => {
+    if (rpcMethod === "attributionActivity" || rpcMethod === "attributionGet") {
+      return canReadAttribution(context.userId, documentId);
+    }
+    // ... other permission logic
+  },
+  rpcHandlers: {
+    ...getAttributionRpcHandlers(),
   },
 });
 ```
 
-When `checkPermission` returns `false` (or throws), the call fails with a `403`.
+When `checkPermission` returns `false` (or throws), the RPC call fails with a `403`.
 
 ## Encryption Boundary
 

--- a/docs/src/content/docs/core-concepts/attribution.mdx
+++ b/docs/src/content/docs/core-concepts/attribution.mdx
@@ -1,0 +1,288 @@
+---
+title: Attribution
+description: Track who wrote or deleted every piece of content in a collaborative document
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Attribution tracks **who** inserted or deleted each piece of content in a Y.js document, and **when**. It answers questions like "who wrote this paragraph?" and "what changed between yesterday and today?" — the foundation for features like author highlighting, activity feeds, and audit trails.
+
+## Overview
+
+Every Y.js CRDT operation has a unique ID: `(clientID, clock)`. The attribution system maps these operation IDs to authorship metadata — userId, timestamp, and optional custom attributes — in a compact binary structure called a **ContentMap**.
+
+```mermaid
+flowchart LR
+    Client[Client sends update] --> Server[Server extracts operation IDs]
+    Server --> Tag[Tag with userId + timestamp]
+    Tag --> Store[Store ContentMap alongside update]
+    Store --> Query[Clients query attribution on demand]
+```
+
+The server computes and stores attribution automatically. Clients query it on demand via RPC — attribution data is **not** synced continuously, only fetched when requested.
+
+## How It Works
+
+### Server-Side: Computing Attribution
+
+When a client sends a Y.js update, the server:
+
+1. **Extracts operation IDs** from the update — which operations were inserted and which were deleted
+2. **Tags** each operation range with the authenticated userId and current timestamp
+3. **Encodes** the result as a binary ContentMap
+4. **Stores** it alongside the update in storage
+
+```typescript
+// This happens automatically inside the server — no configuration needed
+// beyond enabling attribution in your storage implementation.
+```
+
+The server emits a `document-attribution` event on every attributed update, which you can use for real-time integrations:
+
+```typescript
+server.on(
+  "document-attribution",
+  ({ documentId, namespacedDocumentId, sessionId, userId, timestamp, contentMap }) => {
+    // React to attribution changes in real-time
+  },
+);
+```
+
+### Client-Side: Querying Attribution
+
+The `Provider` exposes attribution methods that query the server and resolve content ranges locally:
+
+```typescript
+const provider = await Provider.create({
+  url: "wss://example.com",
+  document: "my-document",
+});
+
+// Activity timeline — who edited, and when?
+const activity = await provider.getActivity();
+
+// Who wrote characters 0..100 of a Y.Text?
+const text = provider.doc.getText("body");
+const segments = await provider.getAttributionForRange(text, 0, 100);
+// → [{ from: 0, to: 45, userId: "alice", timestamp: 1700000000 },
+//    { from: 45, to: 100, userId: "bob", timestamp: 1700000500 }]
+
+// Point lookup by CRDT ID
+const author = await provider.resolveAttribution(clientID, clock);
+// → { userId: "alice", timestamp: 1700000000 }
+```
+
+`getAttributionForRange` works with any Y.js sequence type — `Y.Text`, `Y.Array`, `Y.XmlText`, `Y.XmlFragment`, etc. For key-value types like `Y.Map`, use `resolveAttribution` with the CRDT ID of the item you're interested in.
+
+## Custom Attributes
+
+You can attach arbitrary metadata by providing an `attributionConfig` when creating the server. The returned attributes are stored as-is on both the insert and delete sides of the ContentMap:
+
+```typescript
+import { Server } from "teleportal/server";
+
+const server = new Server({
+  getStorage: async (ctx) => storage,
+  attributionConfig: {
+    getAttributes: ({ context }) => ({
+      source: context.source ?? "human",
+      model: context.model ?? "unknown",
+    }),
+  },
+});
+```
+
+Custom attributes are encoded, stored, and transmitted alongside standard attributes. Use cases include AI agent tagging, change source tracking, or any domain-specific metadata.
+
+## Provider API
+
+Each `Provider` instance represents a single document. Attribution methods operate on that document's data — subdocuments have their own `Provider` instances with independent attribution.
+
+### Activity Timeline
+
+`getActivity` is the single entrypoint for "who did what, when?" — all filters compose with AND:
+
+```typescript
+// All activity
+await provider.getActivity();
+
+// Filter by user
+await provider.getActivity({ userId: "alice" });
+
+// Time range
+await provider.getActivity({ from: hourAgo, to: now });
+
+// Scoped to a milestone
+await provider.getActivity({ milestone: milestoneId });
+
+// Changes between two milestones
+await provider.getActivity({ changeset: [fromId, toId] });
+
+// Custom attribute filter
+await provider.getActivity({ attributes: { source: "ai" } });
+
+// Combine any filters
+await provider.getActivity({ milestone: milestoneId, userId: "alice" });
+```
+
+Each entry includes an `attributes` record containing all attributes (standard and custom):
+
+```typescript
+// → [{ from: 1700000000, to: 1700000500, userId: "alice",
+//       attributes: { insert: "alice", insertAt: 1700000000, "source": "human" } }, ...]
+```
+
+Adjacent entries from the same user within 1 second are grouped, but only when their attributes match — entries from the same user but different custom attributes (e.g. human vs AI) stay separate.
+
+<Aside type="tip">
+  Activity works for **encrypted documents** — it is derived from authorship metadata and
+  timestamps, never from document content. Milestone/changeset scoping is also E2EE-safe.
+</Aside>
+
+### Range Attribution
+
+Resolve who authored a range of content in a Y type:
+
+```typescript
+const text = provider.doc.getText("body");
+const segments = await provider.getAttributionForRange(text, 0, 100);
+// → [{ from: 0, to: 45, userId: "alice", timestamp: 1700000000,
+//       attributes: { insert: "alice", insertAt: 1700000000, "source": "human" } },
+//    { from: 45, to: 100, userId: "bob", timestamp: 1700000500,
+//       attributes: { insert: "bob", insertAt: 1700000500, "source": "ai" } }]
+```
+
+Segments with different custom attributes are not merged, even if they have the same userId and timestamp. Runs **entirely client-side**, so it works identically for encrypted and unencrypted documents.
+
+### Lower-Level Methods
+
+For advanced use cases, the raw ContentMap and point-lookup APIs are available:
+
+```typescript
+// Raw ContentMap (fetched once, cached for subsequent calls)
+const map = await provider.getAttributionMap();
+const filtered = await provider.getAttributionMap({ userId: "alice" });
+provider.invalidateAttributionCache(); // force re-fetch on next use
+
+// Point lookup by CRDT ID
+const author = await provider.resolveAttribution(clientID, clock);
+// → { userId: "alice", timestamp: 1700000000, attributes: { ... } } | null
+
+// Milestone-scoped ContentMaps (for direct set operations)
+const milestoneMap = await provider.getMilestoneContentMap(milestoneId);
+const changesetMap = await provider.getChangesetContentMap(fromId, toId);
+```
+
+```mermaid
+flowchart LR
+    Full[Full ContentMap] --> Intersect["Intersect with milestone IDs"]
+    Milestone[Milestone Snapshot] --> Extract["Extract operation IDs"]
+    Extract --> Intersect
+    Intersect --> Scoped[Scoped ContentMap]
+```
+
+## Server Configuration
+
+### Enabling Attribution
+
+Attribution requires a storage implementation that supports it. Your storage must:
+
+1. Accept the optional `attribution` parameter in `handleUpdate`
+2. Implement the optional `retrieveAttribution` method
+
+```typescript
+import { type DocumentStorage, type EncodedContentMap } from "teleportal/storage";
+
+class MyStorage implements DocumentStorage {
+  async handleUpdate(documentId: string, update: VersionedUpdate, attribution?: EncodedContentMap) {
+    // Persist the update
+    await this.saveUpdate(documentId, update);
+
+    // Persist attribution alongside the update (merge with existing)
+    if (attribution) {
+      await this.mergeAttribution(documentId, attribution);
+    }
+  }
+
+  async retrieveAttribution(documentId: string): Promise<EncodedContentMap | null> {
+    // Return the merged ContentMap for the document
+    return this.loadAttribution(documentId);
+  }
+}
+```
+
+### Attribution RPC Handlers
+
+Register the attribution RPC handlers on the server to expose the query API to clients:
+
+```typescript
+import { Server } from "teleportal/server";
+import { getAttributionRpcHandlers } from "teleportal/protocols/attribution";
+
+const server = new Server({
+  getStorage: async (ctx) => storage,
+  rpcHandlers: {
+    ...getAttributionRpcHandlers(),
+  },
+});
+```
+
+### Permission Control
+
+RPC messages bypass the server's global `checkPermission` hook. To gate attribution access, provide a `checkPermission` callback to the RPC handlers:
+
+```typescript
+getAttributionRpcHandlers({
+  checkPermission: async (ctx) => {
+    return await canReadAttribution(ctx.userId, ctx.documentId);
+  },
+});
+```
+
+When `checkPermission` returns `false` (or throws), the call fails with a `403`.
+
+## Encryption Boundary
+
+For end-to-end-encrypted documents:
+
+- The server holds only ciphertext plus the plaintext ContentMap (operation IDs + userId/timestamp — no document content)
+- **`getActivity`** works — it is derived purely from authorship metadata
+- **`getAttributionForRange`** works — it resolves content positions against the local decrypted document, entirely client-side
+- **Milestone attribution** works — the client decrypts the milestone snapshot locally before extracting operation IDs
+
+The server never sees document content in any of these flows.
+
+## Set Operations
+
+The attribution library provides a full set algebra over ContentMaps and ContentIds, useful for advanced use cases:
+
+```typescript
+import {
+  mergeContentMaps,
+  filterContentMap,
+  intersectContentMap,
+  excludeContentMap,
+} from "teleportal/attribution";
+
+// Merge multiple ContentMaps
+const merged = mergeContentMaps([mapA, mapB, mapC]);
+
+// Filter by attribute predicate
+const byAlice = filterContentMap(contentMap, (attrs) => {
+  const user = attrs.find((a) => a.name === "insert");
+  return user?.val === "alice";
+});
+
+// Intersect: keep only ranges present in both
+const scoped = intersectContentMap(fullMap, milestoneIds);
+
+// Exclude: remove already-attributed ranges
+const newOnly = excludeContentMap(fullMap, alreadyAttributedIds);
+```
+
+## Next Steps
+
+- [Milestones](/core-concepts/milestones/) — Scope attribution to document snapshots
+- [Provider](/core-concepts/provider/) — Client-side API reference
+- [Server](/core-concepts/server/) — Server configuration and events
+- [Authentication](/core-concepts/authentication/) — How userId flows into attribution

--- a/docs/src/content/docs/core-concepts/attribution.mdx
+++ b/docs/src/content/docs/core-concepts/attribution.mdx
@@ -250,7 +250,9 @@ When `checkPermission` returns `false` (or throws), the RPC call fails with a `4
 
 ## Encryption Boundary
 
-For end-to-end-encrypted documents:
+Attribution works for end-to-end-encrypted documents without the server ever seeing content.
+
+Every Y.js operation has a structural ID — `(clientID, clock)` — that is separate from the content it represents. The encrypted client extracts these IDs from the plaintext update **before** encrypting, and sends them alongside the ciphertext in the wire protocol. The server tags them with the authenticated userId and timestamp, exactly as it does for unencrypted documents. The content IDs reveal the shape of the CRDT (which client wrote how many operations), but never the text or data itself.
 
 - The server holds only ciphertext plus the plaintext ContentMap (operation IDs + userId/timestamp — no document content)
 - **`getActivity`** works — it is derived purely from authorship metadata

--- a/playground/src/components/attributionPanel.tsx
+++ b/playground/src/components/attributionPanel.tsx
@@ -183,7 +183,7 @@ export function AttributionPanel({
       return;
     }
     try {
-      const here = await provider.getMilestoneActivity(selectedMilestone.id);
+      const here = await provider.getActivity({ milestone: selectedMilestone.id });
       setMilestoneContributors(toContributions(here));
 
       // Compare against the milestone created immediately before this one.
@@ -191,7 +191,7 @@ export function AttributionPanel({
       const idx = all.findIndex((m) => m.id === selectedMilestone.id);
       const prev = idx > 0 ? all[idx - 1] : null;
       if (prev) {
-        const delta = await provider.getChangesetActivity(prev.id, selectedMilestone.id);
+        const delta = await provider.getActivity({ changeset: [prev.id, selectedMilestone.id] });
         setChangeset(toContributions(delta));
       } else {
         setChangeset(null);

--- a/src/lib/attribution/README.md
+++ b/src/lib/attribution/README.md
@@ -1,0 +1,313 @@
+# Attribution
+
+Content attribution (authorship tracking) for Y.js documents. Tracks who inserted
+or deleted each operation, and when, as a compact binary-encoded ContentMap.
+
+This is the core data layer — pure functions over ID sets and attributed maps, with
+no network or Y.js document dependency (except `createContentIdsFromUpdate` which
+decodes Y.js updates). The protocol layer ([`teleportal/protocols/attribution`](../../protocols/attribution/README.md))
+and provider API ([`teleportal/providers`](../../providers/README.md)) build on top of this.
+
+## Background
+
+The data model is based on [Y.js v14](https://github.com/yjs/yjs)'s ContentMap format,
+originally implemented in [yhub](https://github.com/yjs/yhub). Teleportal reimplements
+these structures in TypeScript against Y.js v13's `decodeUpdate` API, but maintains
+format and semantic compatibility with the v14 design. When teleportal upgrades to v14,
+`createContentIdsFromUpdate` can be replaced with v14's native implementation and the
+set operations / encoding can be swapped for `@y/y` exports.
+
+## Data Model
+
+### Operation IDs
+
+Every Y.js CRDT operation has a unique ID: `(clientID, clock)`. Consecutive operations
+from the same client form contiguous ranges `(clientID, clock, length)`. The attribution
+system works entirely in this ID space — it never touches document content directly.
+
+### ContentIds
+
+A pair of `IdSet`s representing which operations exist in a Y.js update:
+
+```typescript
+interface ContentIds {
+  inserts: IdSet; // operations that insert content
+  deletes: IdSet; // operations that delete content
+}
+```
+
+Created from a Y.js update:
+
+```typescript
+import { createContentIdsFromUpdate } from "teleportal/attribution";
+
+const ids = createContentIdsFromUpdate(update);
+// ids.inserts: IdSet — all insert operations in the update
+// ids.deletes: IdSet — all delete operations in the update
+```
+
+### ContentMap
+
+Extends ContentIds by attaching `ContentAttribute[]` metadata to each operation range:
+
+```typescript
+interface ContentMap {
+  inserts: IdMap; // insert ranges with attribution attributes
+  deletes: IdMap; // delete ranges with attribution attributes
+}
+```
+
+Each range in an `IdMap` carries an array of `ContentAttribute` name/value pairs.
+
+### Standard Attributes
+
+These attribute names follow the Y.js v14 / yhub convention and are a compatibility
+contract with that ecosystem:
+
+| Attribute  | Applied to | Value                   | Meaning                      |
+| ---------- | ---------- | ----------------------- | ---------------------------- |
+| `insert`   | inserts    | `string` (userId)       | Who created the content      |
+| `insertAt` | inserts    | `number` (ms timestamp) | When the content was created |
+| `delete`   | deletes    | `string` (userId)       | Who deleted the content      |
+| `deleteAt` | deletes    | `number` (ms timestamp) | When the content was deleted |
+
+These are always applied as pairs: `insert` + `insertAt` on inserts, `delete` + `deleteAt`
+on deletes.
+
+### Custom Attributes
+
+Custom attributes are stored flat alongside the standard attributes. The same
+custom attributes are attached to both the insert and delete sides:
+
+```typescript
+import { createContentAttribute, createContentMapFromContentIds } from "teleportal/attribution";
+
+const contentMap = createContentMapFromContentIds(
+  contentIds,
+  [
+    createContentAttribute("insert", userId),
+    createContentAttribute("insertAt", Date.now()),
+    createContentAttribute("source", "ai"),
+    createContentAttribute("model", "claude-4"),
+  ],
+  [
+    createContentAttribute("delete", userId),
+    createContentAttribute("deleteAt", Date.now()),
+    createContentAttribute("source", "ai"),
+    createContentAttribute("model", "claude-4"),
+  ],
+);
+```
+
+Custom attributes are encoded, stored, and filtered alongside standard attributes.
+The insert/delete distinction comes from which side of the ContentMap they live on,
+not from the attribute name.
+
+## Creating a ContentMap
+
+The typical server-side flow:
+
+```typescript
+import {
+  createContentIdsFromUpdate,
+  createContentMapFromContentIds,
+  createContentAttribute,
+  encodeContentMap,
+} from "teleportal/attribution";
+
+// 1. Extract operation IDs from the incoming Y.js update
+const contentIds = createContentIdsFromUpdate(update);
+
+// 2. Tag with attribution metadata
+const contentMap = createContentMapFromContentIds(
+  contentIds,
+  [createContentAttribute("insert", userId), createContentAttribute("insertAt", Date.now())],
+  [createContentAttribute("delete", userId), createContentAttribute("deleteAt", Date.now())],
+);
+
+// 3. Encode to binary for storage
+const encoded = encodeContentMap(contentMap);
+```
+
+## Set Operations
+
+All operations are pure — they return new instances without mutating inputs.
+
+### Merge
+
+Combine multiple ContentMaps (e.g. from concurrent updates):
+
+```typescript
+import { mergeContentMaps } from "teleportal/attribution";
+
+const merged = mergeContentMaps([mapA, mapB, mapC]);
+```
+
+When ranges overlap, the most-recently-added range wins the contested span.
+
+### Filter
+
+Keep only ranges whose attributes match a predicate:
+
+```typescript
+import { filterContentMap } from "teleportal/attribution";
+
+const filtered = filterContentMap(contentMap, (attrs) => {
+  const userAttr = attrs.find((a) => a.name === "insert");
+  return userAttr?.val === "user-123";
+});
+```
+
+`filterContentMap` accepts separate predicates for inserts and deletes. When only one
+is provided, it is used for both.
+
+### Intersect
+
+Keep only ranges present in both a ContentMap and ContentIds:
+
+```typescript
+import { intersectContentMap } from "teleportal/attribution";
+
+// Attribution scoped to a milestone's operations
+const scoped = intersectContentMap(fullMap, milestoneIds);
+```
+
+### Exclude
+
+Remove ranges already present in a ContentIds set (prevents double-attribution):
+
+```typescript
+import { excludeContentMap } from "teleportal/attribution";
+
+const newOnly = excludeContentMap(fullMap, alreadyAttributedIds);
+```
+
+### ContentIds operations
+
+The same algebra exists at the `ContentIds` / `IdSet` level (without attributes):
+
+```typescript
+import { mergeContentIds, excludeContentIds, intersectContentIds } from "teleportal/attribution";
+
+const merged = mergeContentIds([idsA, idsB]);
+const diff = excludeContentIds(toIds, fromIds); // operations in `to` but not `from`
+const common = intersectContentIds(idsA, idsB); // operations in both
+```
+
+## Binary Encoding
+
+ContentMaps and ContentIds encode to compact binary using `lib0`'s variable-length
+integer encoding with two layers of deduplication:
+
+- **Attribute deduplication**: identical `(name, value)` pairs are written once and
+  referenced by index thereafter.
+- **Name deduplication**: attribute names are written once and referenced by index.
+- **Delta encoding**: operation clocks are delta-encoded within each client's range list.
+
+```typescript
+import {
+  encodeContentMap,
+  decodeContentMap,
+  encodeContentIds,
+  decodeContentIds,
+} from "teleportal/attribution";
+
+const encoded = encodeContentMap(contentMap); // Uint8Array (branded as EncodedContentMap)
+const decoded = decodeContentMap(encoded); // ContentMap
+
+const encodedIds = encodeContentIds(contentIds); // Uint8Array (branded as EncodedContentIds)
+const decodedIds = decodeContentIds(encodedIds); // ContentIds
+```
+
+## Query Helpers
+
+### Activity Timeline
+
+Extract a sorted timeline of editing activity from a ContentMap:
+
+```typescript
+import { getActivity } from "teleportal/attribution";
+
+const activity = getActivity(contentMap, {
+  from: startTimestamp, // optional, ms
+  to: endTimestamp, // optional, ms
+  userId: "user-123", // optional
+  attributes: { "insert:source": "ai" }, // optional, equality match
+});
+// → [{ from, to, userId, attributes: { insert, insertAt, "insert:source", ... } }, ...]
+```
+
+Each entry includes an `attributes` record containing all attributes (standard and custom)
+on the underlying operations. Adjacent entries from the same user within 1 second are
+grouped into a single entry, but only when their `attributes` records are identical —
+entries from the same user but different custom attributes stay separate.
+
+### Point Lookup
+
+Resolve who authored a specific Y.js item by its CRDT ID:
+
+```typescript
+import { resolveItemAttribution } from "teleportal/attribution";
+
+const result = resolveItemAttribution(contentMap, clientID, clock);
+// → { userId, timestamp, attributes: Record<string, unknown> } | null
+```
+
+## Milestone Composition
+
+Attribution can be scoped to milestones using pure set operations — no Y.js document
+dependency at this layer.
+
+```typescript
+import { milestoneContentMap, changesetContentMap } from "teleportal/attribution";
+
+// Who authored the content present in a milestone?
+const scoped = milestoneContentMap(fullMap, milestoneIds);
+// → intersectContentMap(fullMap, milestoneIds)
+
+// Who made the changes between two milestones?
+const changeset = changesetContentMap(fullMap, fromIds, toIds);
+// → intersectContentMap(fullMap, excludeContentIds(toIds, fromIds))
+```
+
+The milestone snapshot → ContentIds extraction step happens at the call site (typically
+the client), which is what keeps this E2EE-safe: the server never needs to see the
+decrypted snapshot.
+
+## Exports
+
+All public API is exported from `teleportal/attribution`:
+
+```typescript
+// Data structures
+(ContentAttribute, createContentAttribute);
+(IdSet, IdRange, IdRanges, MaybeIdRange, ContentIds, createContentIds);
+(IdMap, AttrRange, MaybeAttrRange, AttrRanges, ContentMap, createContentMap);
+
+// Construction
+createContentIdsFromUpdate; // Y.js update → ContentIds
+createContentMapFromContentIds; // ContentIds + attrs → ContentMap
+createContentIdsFromContentMap; // ContentMap → ContentIds (strip attrs)
+
+// Set operations
+(mergeContentIds, excludeContentIds, intersectContentIds);
+(mergeContentMaps, filterContentMap, excludeContentMap, intersectContentMap);
+(mergeIdSets, diffIdSet, intersectIdSets);
+
+// Encoding
+EncodedContentIds;
+(encodeContentIds, decodeContentIds, getEmptyEncodedContentIds);
+(encodeContentMap, decodeContentMap);
+
+// Queries
+(ActivityEntry, getActivity, resolveItemAttribution);
+
+// Milestone composition
+(milestoneContentMap, changesetContentMap);
+```
+
+## See Also
+
+- [`teleportal/protocols/attribution`](../../protocols/attribution/README.md) — RPC methods and client-side range resolution
+- [`teleportal/providers`](../../providers/README.md) — Provider API for attribution queries
+- [`teleportal/storage`](../../storage/README.md) — Storage interface (`handleUpdate`, `retrieveAttribution`)

--- a/src/lib/attribution/attribution.test.ts
+++ b/src/lib/attribution/attribution.test.ts
@@ -318,7 +318,11 @@ describe("queries", () => {
     ]);
 
     const result = resolveItemAttribution(map, 42, 5);
-    expect(result).toEqual({ userId: "user-1", timestamp: 1_700_000_000 });
+    expect(result).toEqual({
+      userId: "user-1",
+      timestamp: 1_700_000_000,
+      attributes: { insert: "user-1", insertAt: 1_700_000_000 },
+    });
 
     expect(resolveItemAttribution(map, 42, 10)).toBeNull();
     expect(resolveItemAttribution(map, 99, 0)).toBeNull();
@@ -391,6 +395,91 @@ describe("queries", () => {
 
     expect(activity.length).toBe(1);
     expect(activity[0].userId).toBe("user-2");
+  });
+
+  it("includes all attributes on activity entries", () => {
+    const ids = createContentIds();
+    ids.inserts.add(1, 0, 5);
+    const map = createContentMapFromContentIds(ids, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("source", "ai"),
+    ]);
+
+    const activity = getActivity(map);
+    expect(activity.length).toBe(1);
+    expect(activity[0].attributes).toEqual({
+      insert: "user-1",
+      insertAt: 1000,
+      source: "ai",
+    });
+  });
+
+  it("filters activity by custom attributes", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("source", "ai"),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 2000),
+      createContentAttribute("source", "human"),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+
+    const aiOnly = getActivity(merged, { attributes: { source: "ai" } });
+    expect(aiOnly.length).toBe(1);
+    expect(aiOnly[0].attributes.source).toBe("ai");
+
+    const humanOnly = getActivity(merged, { attributes: { source: "human" } });
+    expect(humanOnly.length).toBe(1);
+    expect(humanOnly[0].attributes.source).toBe("human");
+  });
+
+  it("does not merge adjacent entries with different custom attributes", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("source", "ai"),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("source", "human"),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+    const activity = getActivity(merged);
+    expect(activity.length).toBe(2);
+  });
+
+  it("resolveItemAttribution includes all attributes", () => {
+    const ids = createContentIds();
+    ids.inserts.add(42, 0, 10);
+    const map = createContentMapFromContentIds(ids, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("model", "claude-4"),
+    ]);
+
+    const result = resolveItemAttribution(map, 42, 5);
+    expect(result).toEqual({
+      userId: "user-1",
+      timestamp: 1000,
+      attributes: { insert: "user-1", insertAt: 1000, model: "claude-4" },
+    });
   });
 });
 
@@ -486,4 +575,225 @@ describe("AttrRanges.getIds overlap flattening", () => {
         u: r.attrs.find((a) => a.name === "delete")?.val,
       }));
   }
+});
+
+describe("attribution insert/delete separation and custom attribute prefixing", () => {
+  function attrsOf(
+    map: ReturnType<typeof createContentMapFromContentIds>,
+    side: "inserts" | "deletes",
+    client: number,
+  ) {
+    const ranges = map[side].clients.get(client);
+    if (!ranges) return [];
+    return ranges.getIds().map((r) => Object.fromEntries(r.attrs.map((a) => [a.name, a.val])));
+  }
+
+  it("insert-only update: attrs land on inserts, deletes side is empty", () => {
+    const doc = new Y.Doc();
+    doc.getText("t").insert(0, "hello");
+    const update = Y.encodeStateAsUpdateV2(doc);
+
+    const ids = createContentIdsFromUpdate({ version: 2, data: update as UpdateV2 });
+
+    expect(ids.inserts.isEmpty()).toBe(false);
+    expect(ids.deletes.isEmpty()).toBe(true);
+
+    const map = createContentMapFromContentIds(
+      ids,
+      [createContentAttribute("insert", "alice"), createContentAttribute("insertAt", 1000)],
+      [createContentAttribute("delete", "alice"), createContentAttribute("deleteAt", 1000)],
+    );
+
+    expect(attrsOf(map, "inserts", doc.clientID)).toEqual([{ insert: "alice", insertAt: 1000 }]);
+    expect(map.deletes.isEmpty()).toBe(true);
+  });
+
+  it("delete-only: attrs land on deletes side only", () => {
+    const ids = createContentIds();
+    ids.deletes.add(1, 0, 3);
+
+    const map = createContentMapFromContentIds(
+      ids,
+      [createContentAttribute("insert", "bob"), createContentAttribute("insertAt", 2000)],
+      [createContentAttribute("delete", "bob"), createContentAttribute("deleteAt", 2000)],
+    );
+
+    expect(map.inserts.isEmpty()).toBe(true);
+    expect(attrsOf(map, "deletes", 1)).toEqual([{ delete: "bob", deleteAt: 2000 }]);
+  });
+
+  it("mixed insert+delete update: each side gets only its own attrs", () => {
+    const doc = new Y.Doc();
+    doc.getText("t").insert(0, "abcde");
+    doc.getText("t").delete(1, 2);
+    const update = Y.encodeStateAsUpdateV2(doc);
+
+    const ids = createContentIdsFromUpdate({ version: 2, data: update as UpdateV2 });
+
+    expect(ids.inserts.isEmpty()).toBe(false);
+    expect(ids.deletes.isEmpty()).toBe(false);
+
+    const map = createContentMapFromContentIds(
+      ids,
+      [createContentAttribute("insert", "carol"), createContentAttribute("insertAt", 3000)],
+      [createContentAttribute("delete", "carol"), createContentAttribute("deleteAt", 3000)],
+    );
+
+    for (const attrs of attrsOf(map, "inserts", doc.clientID)) {
+      expect(attrs).toHaveProperty("insert", "carol");
+      expect(attrs).toHaveProperty("insertAt", 3000);
+      expect(attrs).not.toHaveProperty("delete");
+      expect(attrs).not.toHaveProperty("deleteAt");
+    }
+
+    for (const attrs of attrsOf(map, "deletes", doc.clientID)) {
+      expect(attrs).toHaveProperty("delete", "carol");
+      expect(attrs).toHaveProperty("deleteAt", 3000);
+      expect(attrs).not.toHaveProperty("insert");
+      expect(attrs).not.toHaveProperty("insertAt");
+    }
+  });
+
+  it("custom attributes round-trip through encoding on both sides", () => {
+    const ids = createContentIds();
+    ids.inserts.add(1, 0, 5);
+    ids.deletes.add(1, 10, 3);
+
+    const customAttrs = [
+      createContentAttribute("source", "ai"),
+      createContentAttribute("model", "claude-4"),
+    ];
+    const insertAttrs = [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      ...customAttrs,
+    ];
+    const deleteAttrs = [
+      createContentAttribute("delete", "user-1"),
+      createContentAttribute("deleteAt", 1000),
+      ...customAttrs,
+    ];
+
+    const map = createContentMapFromContentIds(ids, insertAttrs, deleteAttrs);
+
+    const encoded = encodeContentMap(map);
+    const decoded = decodeContentMap(encoded);
+
+    expect(attrsOf(decoded, "inserts", 1)).toEqual([
+      { insert: "user-1", insertAt: 1000, source: "ai", model: "claude-4" },
+    ]);
+
+    expect(attrsOf(decoded, "deletes", 1)).toEqual([
+      { delete: "user-1", deleteAt: 1000, source: "ai", model: "claude-4" },
+    ]);
+  });
+
+  it("simulates server #computeAttribution: custom attrs stored flat on both sides", () => {
+    const doc = new Y.Doc();
+    doc.getText("t").insert(0, "hello");
+    doc.getText("t").delete(0, 2);
+    const update = Y.encodeStateAsUpdateV2(doc);
+
+    const contentIds = createContentIdsFromUpdate({ version: 2, data: update as UpdateV2 });
+    const userId = "user-1";
+    const now = 5000;
+
+    const customAttrs = [
+      createContentAttribute("source", "ai"),
+      createContentAttribute("model", "claude-4"),
+    ];
+
+    const insertAttrs = [
+      createContentAttribute("insert", userId),
+      createContentAttribute("insertAt", now),
+      ...customAttrs,
+    ];
+    const deleteAttrs = [
+      createContentAttribute("delete", userId),
+      createContentAttribute("deleteAt", now),
+      ...customAttrs,
+    ];
+
+    const map = createContentMapFromContentIds(contentIds, insertAttrs, deleteAttrs);
+    const encoded = encodeContentMap(map);
+    const decoded = decodeContentMap(encoded);
+
+    for (const attrs of attrsOf(decoded, "inserts", doc.clientID)) {
+      expect(attrs).toEqual({
+        insert: "user-1",
+        insertAt: 5000,
+        source: "ai",
+        model: "claude-4",
+      });
+    }
+
+    for (const attrs of attrsOf(decoded, "deletes", doc.clientID)) {
+      expect(attrs).toEqual({
+        delete: "user-1",
+        deleteAt: 5000,
+        source: "ai",
+        model: "claude-4",
+      });
+    }
+
+    const activity = getActivity(decoded);
+    expect(activity.length).toBeGreaterThanOrEqual(1);
+    for (const entry of activity) {
+      expect(entry.userId).toBe("user-1");
+      expect(entry.attributes).toHaveProperty("source", "ai");
+      expect(entry.attributes).toHaveProperty("model", "claude-4");
+    }
+  });
+
+  it("getActivity returns delete-side activity with flat custom attrs", () => {
+    const ids = createContentIds();
+    ids.deletes.add(1, 0, 5);
+
+    const map = createContentMapFromContentIds(
+      ids,
+      [],
+      [
+        createContentAttribute("delete", "user-1"),
+        createContentAttribute("deleteAt", 9000),
+        createContentAttribute("source", "human"),
+      ],
+    );
+
+    const activity = getActivity(map);
+    expect(activity).toEqual([
+      {
+        from: 9000,
+        to: 9000,
+        userId: "user-1",
+        attributes: { delete: "user-1", deleteAt: 9000, source: "human" },
+      },
+    ]);
+  });
+
+  it("resolveItemAttribution only looks at the insert side", () => {
+    const ids = createContentIds();
+    ids.inserts.add(1, 0, 5);
+    ids.deletes.add(1, 0, 5);
+
+    const map = createContentMapFromContentIds(
+      ids,
+      [
+        createContentAttribute("insert", "inserter"),
+        createContentAttribute("insertAt", 1000),
+        createContentAttribute("source", "ai"),
+      ],
+      [
+        createContentAttribute("delete", "deleter"),
+        createContentAttribute("deleteAt", 2000),
+        createContentAttribute("source", "human"),
+      ],
+    );
+
+    const result = resolveItemAttribution(map, 1, 2);
+    expect(result).toEqual({
+      userId: "inserter",
+      timestamp: 1000,
+      attributes: { insert: "inserter", insertAt: 1000, source: "ai" },
+    });
+  });
 });

--- a/src/lib/attribution/attribution.test.ts
+++ b/src/lib/attribution/attribution.test.ts
@@ -443,6 +443,63 @@ describe("queries", () => {
     expect(humanOnly[0].attributes.source).toBe("human");
   });
 
+  it("filters activity by structured (non-primitive) custom attribute values", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("meta", { kind: "ai", tags: ["a", "b"] }),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 2000),
+      createContentAttribute("meta", { kind: "human", tags: [] }),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+
+    // A fresh filter object (different reference, same value) must still match.
+    const aiOnly = getActivity(merged, { attributes: { meta: { kind: "ai", tags: ["a", "b"] } } });
+    expect(aiOnly.length).toBe(1);
+    expect(aiOnly[0].attributes.meta).toEqual({ kind: "ai", tags: ["a", "b"] });
+  });
+
+  it("does not merge adjacent entries with different structured custom attributes", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("meta", { kind: "ai" }),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1500),
+      createContentAttribute("meta", { kind: "human" }),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+    expect(getActivity(merged).length).toBe(2);
+
+    // Structurally-equal (but distinct-reference) meta should merge.
+    const ids3 = createContentIds();
+    ids3.inserts.add(3, 0, 2);
+    const map3 = createContentMapFromContentIds(ids3, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1200),
+      createContentAttribute("meta", { kind: "ai" }),
+    ]);
+    const sameMeta = mergeContentMaps([map1, map3]);
+    expect(getActivity(sameMeta).length).toBe(1);
+  });
+
   it("does not merge adjacent entries with different custom attributes", () => {
     const ids1 = createContentIds();
     ids1.inserts.add(1, 0, 5);

--- a/src/lib/attribution/attribution.test.ts
+++ b/src/lib/attribution/attribution.test.ts
@@ -465,6 +465,30 @@ describe("queries", () => {
     expect(activity.length).toBe(2);
   });
 
+  it("merges adjacent entries from the same user with matching custom attributes despite differing timestamps", () => {
+    const ids1 = createContentIds();
+    ids1.inserts.add(1, 0, 5);
+    const map1 = createContentMapFromContentIds(ids1, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1000),
+      createContentAttribute("source", "ai"),
+    ]);
+
+    const ids2 = createContentIds();
+    ids2.inserts.add(2, 0, 3);
+    const map2 = createContentMapFromContentIds(ids2, [
+      createContentAttribute("insert", "user-1"),
+      createContentAttribute("insertAt", 1500),
+      createContentAttribute("source", "ai"),
+    ]);
+
+    const merged = mergeContentMaps([map1, map2]);
+    const activity = getActivity(merged);
+    expect(activity.length).toBe(1);
+    expect(activity[0].from).toBe(1000);
+    expect(activity[0].to).toBe(1500);
+  });
+
   it("resolveItemAttribution includes all attributes", () => {
     const ids = createContentIds();
     ids.inserts.add(42, 0, 10);

--- a/src/lib/attribution/content-map.ts
+++ b/src/lib/attribution/content-map.ts
@@ -27,6 +27,10 @@ export function attrsToRecord(attrs: ContentAttribute[]): Record<string, unknown
   return Object.fromEntries(attrs.map((a) => [a.name, a.val]));
 }
 
+export function recordToAttrs(record: Record<string, unknown>): ContentAttribute[] {
+  return Object.entries(record).map(([name, val]) => new ContentAttribute(name, val));
+}
+
 // --- AttrRange ---
 
 export class AttrRange {

--- a/src/lib/attribution/content-map.ts
+++ b/src/lib/attribution/content-map.ts
@@ -23,6 +23,10 @@ export function createContentAttribute<V>(name: string, val: V): ContentAttribut
   return new ContentAttribute(name, val);
 }
 
+export function attrsToRecord(attrs: ContentAttribute[]): Record<string, unknown> {
+  return Object.fromEntries(attrs.map((a) => [a.name, a.val]));
+}
+
 // --- AttrRange ---
 
 export class AttrRange {

--- a/src/lib/attribution/encoding.ts
+++ b/src/lib/attribution/encoding.ts
@@ -7,7 +7,7 @@
  *
  * Format (IdSet):
  *   VarUint: numClients
- *   For each client (sorted by clientID):
+ *   For each client (sorted by clientID descending):
  *     VarUint: clientID
  *     VarUint: numberOfRanges
  *     For each range (delta-encoded):
@@ -15,7 +15,11 @@
  *       VarUint: length - 1
  *
  * Format (IdMap / ContentMap):
- *   Same as IdSet but each range also has:
+ *   VarUint: numClients
+ *   For each client (sorted by clientID ascending):
+ *     VarUint: clientID delta from previous (first client is absolute)
+ *     VarUint: numberOfRanges
+ *     For each range (delta-encoded clock/len as IdSet, plus):
  *     VarUint: numberOfAttributes
  *     For each attribute:
  *       VarUint: attrIndex (into deduplication table)
@@ -41,7 +45,7 @@ import {
 // --- IdSet encoding ---
 
 function writeIdSet(encoder: encoding.Encoder, idSet: IdSet) {
-  const clients = [...idSet.clients.entries()].sort(([a], [b]) => a - b);
+  const clients = [...idSet.clients.entries()].sort(([a], [b]) => b - a);
   encoding.writeVarUint(encoder, clients.length);
 
   for (const [client, ranges] of clients) {
@@ -118,8 +122,10 @@ function writeIdMap(encoder: encoding.Encoder, idMap: IdMap) {
   const clients = [...idMap.clients.entries()].sort(([a], [b]) => a - b);
   encoding.writeVarUint(encoder, clients.length);
 
+  let lastClient = 0;
   for (const [client, ranges] of clients) {
-    encoding.writeVarUint(encoder, client);
+    encoding.writeVarUint(encoder, client - lastClient);
+    lastClient = client;
     const ids = ranges.getIds();
     encoding.writeVarUint(encoder, ids.length);
 
@@ -168,8 +174,10 @@ function readIdMap(decoder: decoding.Decoder): IdMap {
 
   const numClients = decoding.readVarUint(decoder);
 
+  let lastClient = 0;
   for (let i = 0; i < numClients; i++) {
-    const client = decoding.readVarUint(decoder);
+    const client = lastClient + decoding.readVarUint(decoder);
+    lastClient = client;
     const numRanges = decoding.readVarUint(decoder);
     const ranges: AttrRange[] = [];
 

--- a/src/lib/attribution/index.ts
+++ b/src/lib/attribution/index.ts
@@ -16,6 +16,7 @@ export {
 export {
   ContentAttribute,
   createContentAttribute,
+  attrsToRecord,
   AttrRange,
   type MaybeAttrRange,
   AttrRanges,

--- a/src/lib/attribution/index.ts
+++ b/src/lib/attribution/index.ts
@@ -17,6 +17,7 @@ export {
   ContentAttribute,
   createContentAttribute,
   attrsToRecord,
+  recordToAttrs,
   AttrRange,
   type MaybeAttrRange,
   AttrRanges,

--- a/src/lib/attribution/queries.ts
+++ b/src/lib/attribution/queries.ts
@@ -16,6 +16,22 @@ export interface ActivityEntry {
 }
 
 /**
+ * The built-in authorship attributes. These are compared via `userId` (insert/
+ * delete) or are per-update timestamps (insertAt/deleteAt), so they are excluded
+ * when deciding whether two adjacent activity entries can be grouped — otherwise
+ * the differing timestamps would defeat the time-window merge below.
+ */
+const BUILTIN_ATTR_NAMES = new Set(["insert", "insertAt", "delete", "deleteAt"]);
+
+function customAttributes(attributes: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [name, val] of Object.entries(attributes)) {
+    if (!BUILTIN_ATTR_NAMES.has(name)) out[name] = val;
+  }
+  return out;
+}
+
+/**
  * Extract an activity timeline from a ContentMap.
  * Returns a sorted list of time ranges with the user who made changes.
  */
@@ -89,7 +105,7 @@ export function getActivity(
       last &&
       last.userId === entry.userId &&
       entry.from - last.to < 1000 &&
-      equalFlat(last.attributes, entry.attributes)
+      equalFlat(customAttributes(last.attributes), customAttributes(entry.attributes))
     ) {
       last.to = entry.to;
     } else {

--- a/src/lib/attribution/queries.ts
+++ b/src/lib/attribution/queries.ts
@@ -5,7 +5,7 @@
  * but as pure functions over ContentMap.
  */
 
-import { equalFlat } from "lib0/object";
+import { equalityDeep } from "lib0/function";
 import { type ContentMap, attrsToRecord, filterContentMap } from "./content-map";
 
 export interface ActivityEntry {
@@ -59,7 +59,7 @@ export function getActivity(
     if (options?.attributes) {
       for (const [name, val] of Object.entries(options.attributes)) {
         const attr = attrs.find((a) => a.name === name);
-        if (!attr || attr.val !== val) return false;
+        if (!attr || !equalityDeep(attr.val, val)) return false;
       }
     }
     return true;
@@ -105,7 +105,7 @@ export function getActivity(
       last &&
       last.userId === entry.userId &&
       entry.from - last.to < 1000 &&
-      equalFlat(customAttributes(last.attributes), customAttributes(entry.attributes))
+      equalityDeep(customAttributes(last.attributes), customAttributes(entry.attributes))
     ) {
       last.to = entry.to;
     } else {

--- a/src/lib/attribution/queries.ts
+++ b/src/lib/attribution/queries.ts
@@ -5,12 +5,14 @@
  * but as pure functions over ContentMap.
  */
 
-import { type ContentMap, filterContentMap } from "./content-map";
+import { equalFlat } from "lib0/object";
+import { type ContentMap, attrsToRecord, filterContentMap } from "./content-map";
 
 export interface ActivityEntry {
   from: number;
   to: number;
   userId: string | null;
+  attributes: Record<string, unknown>;
 }
 
 /**
@@ -23,6 +25,7 @@ export function getActivity(
     from?: number;
     to?: number;
     userId?: string;
+    attributes?: Record<string, unknown>;
   },
 ): ActivityEntry[] {
   const filtered = filterContentMap(contentMap, (attrs) => {
@@ -36,6 +39,12 @@ export function getActivity(
     if (options?.userId !== undefined) {
       const userAttr = attrs.find((a) => a.name === "insert" || a.name === "delete");
       if (!userAttr || userAttr.val !== options.userId) return false;
+    }
+    if (options?.attributes) {
+      for (const [name, val] of Object.entries(options.attributes)) {
+        const attr = attrs.find((a) => a.name === name);
+        if (!attr || attr.val !== val) return false;
+      }
     }
     return true;
   });
@@ -51,6 +60,7 @@ export function getActivity(
         from: t,
         to: t,
         userId: userAttr ? (userAttr.val as string) : null,
+        attributes: attrsToRecord(attrs),
       });
     }
   });
@@ -64,6 +74,7 @@ export function getActivity(
         from: t,
         to: t,
         userId: userAttr ? (userAttr.val as string) : null,
+        attributes: attrsToRecord(attrs),
       });
     }
   });
@@ -74,7 +85,12 @@ export function getActivity(
   const grouped: ActivityEntry[] = [];
   for (const entry of activity) {
     const last = grouped.at(-1);
-    if (last && last.userId === entry.userId && entry.from - last.to < 1000) {
+    if (
+      last &&
+      last.userId === entry.userId &&
+      entry.from - last.to < 1000 &&
+      equalFlat(last.attributes, entry.attributes)
+    ) {
       last.to = entry.to;
     } else {
       grouped.push({ ...entry });
@@ -92,7 +108,7 @@ export function resolveItemAttribution(
   contentMap: ContentMap,
   clientID: number,
   clock: number,
-): { userId: string; timestamp: number } | null {
+): { userId: string; timestamp: number; attributes: Record<string, unknown> } | null {
   const ranges = contentMap.inserts.clients.get(clientID);
   if (!ranges) return null;
 
@@ -105,7 +121,7 @@ export function resolveItemAttribution(
         if (attr.name === "insertAt") timestamp = attr.val as number;
       }
       if (userId !== undefined && timestamp !== undefined) {
-        return { userId, timestamp };
+        return { userId, timestamp, attributes: attrsToRecord(range.attrs) };
       }
       return null;
     }

--- a/src/lib/protocol/types.ts
+++ b/src/lib/protocol/types.ts
@@ -303,6 +303,14 @@ export interface RpcServerRequestHandler<
   ) => Promise<{
     response: Response | RpcError;
     stream?: AsyncIterable<Stream>;
+    /**
+     * Override the `encrypted` flag on the response message.  When omitted
+     * the response inherits the flag from the incoming request.  Set this
+     * when the response payload's encryption state differs from the
+     * request's — e.g. a plaintext request that returns an encrypted
+     * snapshot.
+     */
+    encrypted?: boolean;
   }>;
 
   /**

--- a/src/protocols/attribution/README.md
+++ b/src/protocols/attribution/README.md
@@ -37,7 +37,7 @@ Use the `rpcMethod` field for method-level authorization:
 
 ```typescript
 const server = new Server({
-  getStorage: async (ctx) => storage,
+  storage: async (ctx) => storage,
   checkPermission: async ({ context, documentId, rpcMethod }) => {
     if (rpcMethod === "attributionActivity" || rpcMethod === "attributionGet") {
       return canReadAttribution(context.userId, documentId);
@@ -167,7 +167,7 @@ ContentMap:
 import { Server } from "teleportal/server";
 
 const server = new Server({
-  getStorage: async (ctx) => storage,
+  storage: async (ctx) => storage,
   attributionConfig: {
     getAttributes: ({ context }) => ({
       source: context.source ?? "human",

--- a/src/protocols/attribution/README.md
+++ b/src/protocols/attribution/README.md
@@ -6,10 +6,11 @@ Read-only RPC methods that surface document **attribution** (authorship) to clie
 
 When attribution storage is enabled, the server records an encoded **ContentMap**
 per document — a mapping from CRDT operation ID ranges `(clientID, clock)` to
-`userId` + `timestamp`. See [`teleportal/attribution`](../../lib/attribution) and the
-`DocumentStorage.retrieveAttribution()` storage hook.
+authorship metadata (userId, timestamp, and optional custom attributes). See
+[`teleportal/attribution`](../../lib/attribution/README.md) for the data model and
+`DocumentStorage.retrieveAttribution()` for the storage hook.
 
-This protocol exposes that latent data on demand (it is **not** synced continuously).
+This protocol exposes that data on demand (it is **not** synced continuously).
 It answers two questions:
 
 - **"What happened, and when?"** — an activity timeline, optionally filtered by user
@@ -54,13 +55,15 @@ const provider = await Provider.create({
   document: "my-doc",
 });
 
-// Activity timeline (optionally filtered).
+// Activity timeline — composable filters
 const activity = await provider.getActivity({ userId: "user-1" });
+const milestoneActivity = await provider.getActivity({ milestone: milestoneId });
+const changeset = await provider.getActivity({ changeset: [fromId, toId] });
 
 // Who wrote characters 0..40 of a Y.Text?
 const text = provider.doc.getText("body");
 const segments = await provider.getAttributionForRange(text, 0, 40);
-// -> [{ from, to, userId, timestamp }, ...]
+// -> [{ from, to, userId, timestamp, attributes }, ...]
 
 // Point lookup by CRDT id, or the raw decoded ContentMap.
 const author = await provider.resolveAttribution(clientID, clock);
@@ -76,22 +79,24 @@ helpers reuse that cache, fetching once on first use.
 
 Activity timeline for the document.
 
-**Request:** `{ from?: number; to?: number; userId?: string }` (timestamps in ms)
+**Request:** `{ from?: number; to?: number; userId?: string; attributes?: Record<string, unknown> }`
+(timestamps in ms; `attributes` is an equality-match filter on attribute values by name)
 
-**Response:** `{ activity: Array<{ from: number; to: number; userId: string | null }> }`
+**Response:** `{ activity: Array<{ from, to, userId, attributes }> }` — each entry
+includes an `attributes` record with all standard and custom attributes.
 
-Works for **encrypted** documents — it is derived purely from authorship and
-timestamps and never needs the document content.
+Works for **encrypted** documents — it is derived purely from authorship metadata
+and never needs the document content.
 
 ### attributionGet
 
 The encoded ContentMap for client-side resolution.
 
-**Request:** `{ filter?: { from?: number; to?: number; userId?: string } }`
+**Request:** `{ filter?: { from?: number; to?: number; userId?: string; attributes?: Record<string, unknown> } }`
 
 **Response:** `{ contentMap: Uint8Array | null }` — `null` when the storage has no
-attribution for the document. When a filter is supplied, the map is narrowed
-server-side before encoding.
+attribution for the document. When a filter is supplied (including custom attribute
+filters), the map is narrowed server-side before encoding.
 
 ## Milestones
 
@@ -136,8 +141,52 @@ document. `getAttributionForRange` (and the `resolveRangeAttribution` /
 `collectRangeIds` utilities behind it) therefore run entirely client-side and work
 identically for encrypted and unencrypted documents.
 
+## Custom Attributes
+
+Attribution supports custom metadata beyond the standard `userId` / `timestamp` fields.
+To attach custom attributes, provide an `attributionConfig` when creating the server.
+The returned attributes are stored as-is on both the insert and delete sides of the
+ContentMap:
+
+```typescript
+import { Server } from "teleportal/server";
+
+const server = new Server({
+  getStorage: async (ctx) => storage,
+  attributionConfig: {
+    getAttributes: ({ context }) => ({
+      source: context.source ?? "human",
+    }),
+  },
+  rpcHandlers: {
+    ...getAttributionRpcHandlers(),
+  },
+});
+```
+
+Custom attributes are encoded, stored, and transmitted alongside standard attributes.
+They can be used for AI agent tagging, change source tracking, or any domain-specific
+metadata.
+
+## Server Events
+
+The server emits a `document-attribution` event on every attributed update, providing
+a hook for implementations that need to react to attribution changes in real-time:
+
+```typescript
+server.on(
+  "document-attribution",
+  ({ documentId, namespacedDocumentId, sessionId, userId, timestamp, contentMap }) => {
+    // contentMap is the EncodedContentMap for just this update (not the full document)
+  },
+);
+```
+
+This event fires for both encrypted and unencrypted documents.
+
 ## See Also
 
-- [`teleportal/attribution`](../../lib/attribution) - ContentMap types and query helpers
-- [Protocols Overview](../README.md) - Package overview
-- [Milestone Methods](../milestone/README.md) - Milestone CRUD operations via RPC
+- [`teleportal/attribution`](../../lib/attribution/README.md) — ContentMap data model, set operations, and query helpers
+- [Protocols Overview](../README.md) — Package overview
+- [Milestone Methods](../milestone/README.md) — Milestone CRUD operations via RPC
+- [`teleportal/providers`](../../providers/README.md) — Provider API for attribution queries

--- a/src/protocols/attribution/README.md
+++ b/src/protocols/attribution/README.md
@@ -143,10 +143,16 @@ The underlying pure helpers live in `teleportal/attribution`:
 
 ## Encryption boundary
 
-For end-to-end-encrypted documents the server holds only ciphertext plus the
-plaintext ContentMap. It **can** answer `attributionActivity`, but it **cannot** map
-a content position to a CRDT id — only the client can, against its decrypted
-document. `getAttributionForRange` (and the `resolveRangeAttribution` /
+Attribution works for E2EE documents. The encrypted client extracts CRDT operation
+IDs `(clientID, clock)` from the plaintext update **before** encrypting, and sends
+them alongside the ciphertext in the encrypted wire format. These IDs are structural
+metadata — they reveal which client wrote how many operations, but never the content
+itself. The server tags them with userId/timestamp and stores the resulting ContentMap
+exactly as it does for unencrypted documents.
+
+The server **can** answer `attributionActivity` (derived from metadata only), but it
+**cannot** map a content position to a CRDT id — only the client can, against its
+decrypted document. `getAttributionForRange` (and the `resolveRangeAttribution` /
 `collectRangeIds` utilities behind it) therefore run entirely client-side and work
 identically for encrypted and unencrypted documents.
 

--- a/src/protocols/attribution/README.md
+++ b/src/protocols/attribution/README.md
@@ -32,16 +32,25 @@ const server = new Server({
 });
 ```
 
-RPC messages bypass the server's global permission check, so attribution-specific
-authorization is supplied here:
+Attribution methods are covered by the server's global `checkPermission` hook.
+Use the `rpcMethod` field for method-level authorization:
 
 ```typescript
-getAttributionRpcHandlers({
-  checkPermission: (ctx) => canReadAttribution(ctx.userId, ctx.documentId),
+const server = new Server({
+  getStorage: async (ctx) => storage,
+  checkPermission: async ({ context, documentId, rpcMethod }) => {
+    if (rpcMethod === "attributionActivity" || rpcMethod === "attributionGet") {
+      return canReadAttribution(context.userId, documentId);
+    }
+    // ... other permission logic
+  },
+  rpcHandlers: {
+    ...getAttributionRpcHandlers(),
+  },
 });
 ```
 
-When `checkPermission` returns `false` (or throws), the call fails with a `403`.
+When `checkPermission` returns `false` (or throws), the RPC call fails with a `403`.
 
 ## Client Integration
 

--- a/src/protocols/attribution/attribution.test.ts
+++ b/src/protocols/attribution/attribution.test.ts
@@ -6,6 +6,7 @@ import type { EncodedContentMap } from "teleportal/storage";
 import {
   changesetContentMap,
   createContentAttribute,
+  createContentIds,
   createContentIdsFromUpdate,
   createContentMapFromContentIds,
   decodeContentMap,
@@ -223,6 +224,43 @@ describe("getAttributionRpcHandlers", () => {
       };
       expect(response.contentMap).toBeNull();
     });
+
+    it("narrows the ContentMap by custom attributes", async () => {
+      const ids1 = createContentIds();
+      ids1.inserts.add(1, 0, 5);
+      const map1 = createContentMapFromContentIds(ids1, [
+        createContentAttribute("insert", "user-1"),
+        createContentAttribute("insertAt", 1000),
+        createContentAttribute("source", "ai"),
+      ]);
+
+      const ids2 = createContentIds();
+      ids2.inserts.add(2, 0, 3);
+      const map2 = createContentMapFromContentIds(ids2, [
+        createContentAttribute("insert", "user-1"),
+        createContentAttribute("insertAt", 2000),
+        createContentAttribute("source", "human"),
+      ]);
+
+      const merged = mergeContentMaps([map1, map2]);
+      const encoded = encodeContentMap(merged);
+      const handler = getAttributionRpcHandlers().attributionGet;
+
+      const { response } = (await handler.handler(
+        { filter: { attributes: { source: "ai" } } },
+        mockContext(async () => encoded),
+      )) as { response: { contentMap: EncodedContentMap | null } };
+
+      const decoded = decodeContentMap(response.contentMap!);
+      const sources = [...decoded.inserts.clients.values()].flatMap((r) =>
+        r
+          .getIds()
+          .flatMap((range) =>
+            range.attrs.filter((a) => a.name === "source").map((a) => a.val as string),
+          ),
+      );
+      expect([...new Set(sources)]).toEqual(["ai"]);
+    });
   });
 });
 
@@ -231,19 +269,125 @@ describe("resolveRangeAttribution", () => {
     const { text, map } = twoUserDoc();
 
     const hello = resolveRangeAttribution(text, 0, 6, map);
-    expect(hello).toEqual([{ from: 0, to: 6, userId: "user-1", timestamp: 1000 }]);
+    expect(hello).toEqual([
+      {
+        from: 0,
+        to: 6,
+        userId: "user-1",
+        timestamp: 1000,
+        attributes: { insert: "user-1", insertAt: 1000 },
+      },
+    ]);
 
     const world = resolveRangeAttribution(text, 6, 5, map);
-    expect(world).toEqual([{ from: 6, to: 11, userId: "user-2", timestamp: 2000 }]);
+    expect(world).toEqual([
+      {
+        from: 6,
+        to: 11,
+        userId: "user-2",
+        timestamp: 2000,
+        attributes: { insert: "user-2", insertAt: 2000 },
+      },
+    ]);
   });
 
   it("splits a range spanning both authors", () => {
     const { text, map } = twoUserDoc();
     const all = resolveRangeAttribution(text, 0, 11, map);
     expect(all).toEqual([
-      { from: 0, to: 6, userId: "user-1", timestamp: 1000 },
-      { from: 6, to: 11, userId: "user-2", timestamp: 2000 },
+      {
+        from: 0,
+        to: 6,
+        userId: "user-1",
+        timestamp: 1000,
+        attributes: { insert: "user-1", insertAt: 1000 },
+      },
+      {
+        from: 6,
+        to: 11,
+        userId: "user-2",
+        timestamp: 2000,
+        attributes: { insert: "user-2", insertAt: 2000 },
+      },
     ]);
+  });
+
+  it("includes custom attributes on segments", () => {
+    const doc = new Y.Doc();
+    let u!: Uint8Array;
+    doc.on("updateV2", (update: Uint8Array) => (u = update));
+    doc.getText("t").insert(0, "Hello");
+
+    const map = decodeContentMap(
+      encodeContentMap(
+        createContentMapFromContentIds(
+          createContentIdsFromUpdate({ version: 2, data: u as UpdateV2 }),
+          [
+            createContentAttribute("insert", "user-1"),
+            createContentAttribute("insertAt", 1000),
+            createContentAttribute("source", "ai"),
+          ],
+        ),
+      ),
+    );
+
+    const segments = resolveRangeAttribution(doc.getText("t"), 0, 5, map);
+    expect(segments.length).toBe(1);
+    expect(segments[0].attributes).toEqual({
+      insert: "user-1",
+      insertAt: 1000,
+      source: "ai",
+    });
+  });
+
+  it("does not merge adjacent segments with different custom attributes", () => {
+    const doc = new Y.Doc();
+    const updates: Uint8Array[] = [];
+    doc.on("updateV2", (u: Uint8Array) => updates.push(u));
+    doc.getText("t").insert(0, "AB");
+
+    const doc2 = new Y.Doc();
+    const updates2: Uint8Array[] = [];
+    doc2.on("updateV2", (u: Uint8Array) => updates2.push(u));
+    doc2.getText("t").insert(0, "A");
+
+    const doc3 = new Y.Doc();
+    Y.applyUpdateV2(doc3, Y.encodeStateAsUpdateV2(doc2));
+    const updates3: Uint8Array[] = [];
+    doc3.on("updateV2", (u: Uint8Array) => updates3.push(u));
+    doc3.getText("t").insert(1, "B");
+
+    const splitMap = mergeContentMaps([
+      decodeContentMap(
+        encodeContentMap(
+          createContentMapFromContentIds(
+            createContentIdsFromUpdate({ version: 2, data: updates2[0] as UpdateV2 }),
+            [
+              createContentAttribute("insert", "user-1"),
+              createContentAttribute("insertAt", 1000),
+              createContentAttribute("source", "ai"),
+            ],
+          ),
+        ),
+      ),
+      decodeContentMap(
+        encodeContentMap(
+          createContentMapFromContentIds(
+            createContentIdsFromUpdate({ version: 2, data: updates3[0] as UpdateV2 }),
+            [
+              createContentAttribute("insert", "user-1"),
+              createContentAttribute("insertAt", 1000),
+              createContentAttribute("source", "human"),
+            ],
+          ),
+        ),
+      ),
+    ]);
+
+    const segments = resolveRangeAttribution(doc3.getText("t"), 0, 2, splitMap);
+    expect(segments.length).toBe(2);
+    expect(segments[0].attributes["source"]).toBe("ai");
+    expect(segments[1].attributes["source"]).toBe("human");
   });
 
   it("collectRangeIds skips deleted content", () => {
@@ -291,13 +435,25 @@ describe("milestone-scoped attribution", () => {
     // As of milestone 1 the text is just "Hello " — all user-1.
     const m1Doc = docFromSnapshot(s1);
     expect(resolveRangeAttribution(m1Doc.getText("t"), 0, 6, full)).toEqual([
-      { from: 0, to: 6, userId: "user-1", timestamp: 1000 },
+      {
+        from: 0,
+        to: 6,
+        userId: "user-1",
+        timestamp: 1000,
+        attributes: { insert: "user-1", insertAt: 1000 },
+      },
     ]);
 
     // As of milestone 2, "World" is user-2.
     const m2Doc = docFromSnapshot(s2);
     expect(resolveRangeAttribution(m2Doc.getText("t"), 6, 5, full)).toEqual([
-      { from: 6, to: 11, userId: "user-2", timestamp: 2000 },
+      {
+        from: 6,
+        to: 11,
+        userId: "user-2",
+        timestamp: 2000,
+        attributes: { insert: "user-2", insertAt: 2000 },
+      },
     ]);
   });
 

--- a/src/protocols/attribution/attribution.test.ts
+++ b/src/protocols/attribution/attribution.test.ts
@@ -164,6 +164,24 @@ describe("getAttributionRpcHandlers", () => {
       expect(response.activity).toEqual([]);
     });
 
+    it("returns a timeline from content-id-based attribution (encrypted path)", async () => {
+      const ids = createContentIds();
+      ids.inserts.add(100, 0, 10);
+      const map = createContentMapFromContentIds(
+        ids,
+        [createContentAttribute("insert", "enc-user"), createContentAttribute("insertAt", 5000)],
+        [createContentAttribute("delete", "enc-user"), createContentAttribute("deleteAt", 5000)],
+      );
+      const encoded = encodeContentMap(map);
+      const handler = getAttributionRpcHandlers().attributionActivity;
+
+      const { response } = (await handler.handler(
+        {},
+        mockContext(async () => encoded),
+      )) as { response: { activity: { userId: string | null }[] } };
+
+      expect(response.activity.map((e) => e.userId)).toEqual(["enc-user"]);
+    });
   });
 
   describe("attributionGet", () => {

--- a/src/protocols/attribution/attribution.test.ts
+++ b/src/protocols/attribution/attribution.test.ts
@@ -164,21 +164,6 @@ describe("getAttributionRpcHandlers", () => {
       expect(response.activity).toEqual([]);
     });
 
-    it("denies when checkPermission rejects", async () => {
-      const { map } = twoUserDoc();
-      const encoded = encodeContentMap(map);
-      const handler = getAttributionRpcHandlers({
-        checkPermission: () => false,
-      }).attributionActivity;
-
-      const { response } = (await handler.handler(
-        {},
-        mockContext(async () => encoded),
-      )) as { response: { type?: string; statusCode?: number } };
-
-      expect(response.type).toBe("error");
-      expect(response.statusCode).toBe(403);
-    });
   });
 
   describe("attributionGet", () => {

--- a/src/protocols/attribution/index.ts
+++ b/src/protocols/attribution/index.ts
@@ -3,6 +3,7 @@ export { getAttributionRpcHandlers, type AttributionRpcOptions } from "./server-
 export { collectRangeIds, resolveRangeAttribution, type RangeId } from "./resolve";
 
 export type {
+  ActivityOptions,
   AttributionFilter,
   AttributionActivityRequest,
   AttributionActivityResponse,

--- a/src/protocols/attribution/index.ts
+++ b/src/protocols/attribution/index.ts
@@ -1,4 +1,4 @@
-export { getAttributionRpcHandlers, type AttributionRpcOptions } from "./server-handlers";
+export { getAttributionRpcHandlers } from "./server-handlers";
 
 export { collectRangeIds, resolveRangeAttribution, type RangeId } from "./resolve";
 

--- a/src/protocols/attribution/methods.ts
+++ b/src/protocols/attribution/methods.ts
@@ -9,6 +9,18 @@ export type AttributionFilter = {
   userId?: string;
   from?: number;
   to?: number;
+  attributes?: Record<string, unknown>;
+};
+
+/**
+ * Options for {@link Provider.getActivity}. Extends {@link AttributionFilter}
+ * with optional milestone/changeset scoping — all filters compose with AND.
+ */
+export type ActivityOptions = AttributionFilter & {
+  /** Scope to operations present in this milestone. */
+  milestone?: string;
+  /** Scope to operations added between two milestones: `[fromId, toId]`. */
+  changeset?: [from: string, to: string];
 };
 
 export type AttributionActivityRequest = AttributionFilter;
@@ -39,4 +51,5 @@ export type AttributedSegment = {
   to: number;
   userId: string | null;
   timestamp: number | null;
+  attributes: Record<string, unknown>;
 };

--- a/src/protocols/attribution/resolve.ts
+++ b/src/protocols/attribution/resolve.ts
@@ -11,8 +11,9 @@
  * to resolve content positions.
  */
 
+import { equalFlat } from "lib0/object";
 import type * as Y from "yjs";
-import type { ContentMap } from "teleportal/attribution";
+import { attrsToRecord, type ContentMap } from "teleportal/attribution";
 import type { AttributedSegment } from "./methods";
 
 /**
@@ -99,6 +100,7 @@ export function resolveRangeAttribution(
         to: from + (overlapEnd - overlapStart),
         userId: userAttr ? String(userAttr.val) : null,
         timestamp: timeAttr ? Number(timeAttr.val) : null,
+        attributes: attrsToRecord(range.attrs),
       });
     }
   }
@@ -113,7 +115,8 @@ export function resolveRangeAttribution(
       last &&
       last.to === segment.from &&
       last.userId === segment.userId &&
-      last.timestamp === segment.timestamp
+      last.timestamp === segment.timestamp &&
+      equalFlat(last.attributes, segment.attributes)
     ) {
       last.to = segment.to;
     } else {

--- a/src/protocols/attribution/resolve.ts
+++ b/src/protocols/attribution/resolve.ts
@@ -11,7 +11,7 @@
  * to resolve content positions.
  */
 
-import { equalFlat } from "lib0/object";
+import { equalityDeep } from "lib0/function";
 import type * as Y from "yjs";
 import { attrsToRecord, type ContentMap } from "teleportal/attribution";
 import type { AttributedSegment } from "./methods";
@@ -116,7 +116,7 @@ export function resolveRangeAttribution(
       last.to === segment.from &&
       last.userId === segment.userId &&
       last.timestamp === segment.timestamp &&
-      equalFlat(last.attributes, segment.attributes)
+      equalityDeep(last.attributes, segment.attributes)
     ) {
       last.to = segment.to;
     } else {

--- a/src/protocols/attribution/server-handlers.ts
+++ b/src/protocols/attribution/server-handlers.ts
@@ -1,3 +1,4 @@
+import { equalityDeep } from "lib0/function";
 import {
   type RpcError,
   type RpcHandlerRegistry,
@@ -47,7 +48,7 @@ function matchesFilter(filter: AttributionFilter): (attrs: ContentAttribute[]) =
     if (filter.attributes) {
       for (const [name, val] of Object.entries(filter.attributes)) {
         const attr = attrs.find((a) => a.name === name);
-        if (!attr || attr.val !== val) return false;
+        if (!attr || !equalityDeep(attr.val, val)) return false;
       }
     }
     return true;

--- a/src/protocols/attribution/server-handlers.ts
+++ b/src/protocols/attribution/server-handlers.ts
@@ -60,6 +60,12 @@ function matchesFilter(filter: AttributionFilter): (attrs: ContentAttribute[]) =
         if (filter.to !== undefined && t > filter.to) return false;
       }
     }
+    if (filter.attributes) {
+      for (const [name, val] of Object.entries(filter.attributes)) {
+        const attr = attrs.find((a) => a.name === name);
+        if (!attr || attr.val !== val) return false;
+      }
+    }
     return true;
   };
 }
@@ -81,6 +87,7 @@ const activityHandler =
         from: payload.from,
         to: payload.to,
         userId: payload.userId,
+        attributes: payload.attributes,
       });
       return { response: { activity } };
     } catch (error) {
@@ -110,7 +117,10 @@ const getHandler =
       const filter = payload.filter;
       if (
         filter &&
-        (filter.userId !== undefined || filter.from !== undefined || filter.to !== undefined)
+        (filter.userId !== undefined ||
+          filter.from !== undefined ||
+          filter.to !== undefined ||
+          (filter.attributes && Object.keys(filter.attributes).length > 0))
       ) {
         const predicate = matchesFilter(filter);
         const filtered = filterContentMap(decodeContentMap(encoded), predicate);

--- a/src/protocols/attribution/server-handlers.ts
+++ b/src/protocols/attribution/server-handlers.ts
@@ -20,22 +20,6 @@ import {
   type AttributionGetResponse,
 } from "./methods";
 
-export interface AttributionRpcOptions {
-  /**
-   * Optional gate for attribution reads. RPC messages bypass the server's
-   * global permission check, so attribution-specific authorization lives here.
-   * Return false (or throw) to deny. When omitted, reads are allowed for any
-   * client with an open session for the document (milestone parity).
-   */
-  checkPermission?: (context: RpcServerContext) => boolean | Promise<boolean>;
-}
-
-const FORBIDDEN: RpcError = {
-  type: "error",
-  statusCode: 403,
-  details: "Attribution access denied",
-};
-
 async function loadContentMap(context: RpcServerContext): Promise<EncodedContentMap | null> {
   const retrieve = context.session.storage.retrieveAttribution;
   if (!retrieve) return null;
@@ -70,74 +54,64 @@ function matchesFilter(filter: AttributionFilter): (attrs: ContentAttribute[]) =
   };
 }
 
-const activityHandler =
-  (options: AttributionRpcOptions) =>
-  async (
-    payload: AttributionActivityRequest,
-    context: RpcServerContext,
-  ): Promise<{ response: AttributionActivityResponse | RpcError }> => {
-    try {
-      if (options.checkPermission && !(await options.checkPermission(context))) {
-        return { response: FORBIDDEN };
-      }
-      const encoded = await loadContentMap(context);
-      if (!encoded) return { response: { activity: [] } };
+const activityHandler = async (
+  payload: AttributionActivityRequest,
+  context: RpcServerContext,
+): Promise<{ response: AttributionActivityResponse | RpcError }> => {
+  try {
+    const encoded = await loadContentMap(context);
+    if (!encoded) return { response: { activity: [] } };
 
-      const activity = getActivity(decodeContentMap(encoded), {
-        from: payload.from,
-        to: payload.to,
-        userId: payload.userId,
-        attributes: payload.attributes,
-      });
-      return { response: { activity } };
-    } catch (error) {
-      return {
-        response: {
-          type: "error",
-          statusCode: 500,
-          details: error instanceof Error ? error.message : "Failed to read attribution activity",
-        },
-      };
+    const activity = getActivity(decodeContentMap(encoded), {
+      from: payload.from,
+      to: payload.to,
+      userId: payload.userId,
+      attributes: payload.attributes,
+    });
+    return { response: { activity } };
+  } catch (error) {
+    return {
+      response: {
+        type: "error",
+        statusCode: 500,
+        details: error instanceof Error ? error.message : "Failed to read attribution activity",
+      },
+    };
+  }
+};
+
+const getHandler = async (
+  payload: AttributionGetRequest,
+  context: RpcServerContext,
+): Promise<{ response: AttributionGetResponse | RpcError }> => {
+  try {
+    const encoded = await loadContentMap(context);
+    if (!encoded) return { response: { contentMap: null } };
+
+    const filter = payload.filter;
+    if (
+      filter &&
+      (filter.userId !== undefined ||
+        filter.from !== undefined ||
+        filter.to !== undefined ||
+        (filter.attributes && Object.keys(filter.attributes).length > 0))
+    ) {
+      const predicate = matchesFilter(filter);
+      const filtered = filterContentMap(decodeContentMap(encoded), predicate);
+      return { response: { contentMap: encodeContentMap(filtered) } };
     }
-  };
 
-const getHandler =
-  (options: AttributionRpcOptions) =>
-  async (
-    payload: AttributionGetRequest,
-    context: RpcServerContext,
-  ): Promise<{ response: AttributionGetResponse | RpcError }> => {
-    try {
-      if (options.checkPermission && !(await options.checkPermission(context))) {
-        return { response: FORBIDDEN };
-      }
-      const encoded = await loadContentMap(context);
-      if (!encoded) return { response: { contentMap: null } };
-
-      const filter = payload.filter;
-      if (
-        filter &&
-        (filter.userId !== undefined ||
-          filter.from !== undefined ||
-          filter.to !== undefined ||
-          (filter.attributes && Object.keys(filter.attributes).length > 0))
-      ) {
-        const predicate = matchesFilter(filter);
-        const filtered = filterContentMap(decodeContentMap(encoded), predicate);
-        return { response: { contentMap: encodeContentMap(filtered) } };
-      }
-
-      return { response: { contentMap: encoded } };
-    } catch (error) {
-      return {
-        response: {
-          type: "error",
-          statusCode: 500,
-          details: error instanceof Error ? error.message : "Failed to read attribution",
-        },
-      };
-    }
-  };
+    return { response: { contentMap: encoded } };
+  } catch (error) {
+    return {
+      response: {
+        type: "error",
+        statusCode: 500,
+        details: error instanceof Error ? error.message : "Failed to read attribution",
+      },
+    };
+  }
+};
 
 /**
  * Creates read-only RPC handlers that expose document attribution to clients.
@@ -150,13 +124,13 @@ const getHandler =
  * - `attributionActivity` — activity timeline (works for encrypted documents).
  * - `attributionGet` — the encoded ContentMap for client-side range resolution.
  */
-export function getAttributionRpcHandlers(options: AttributionRpcOptions = {}): RpcHandlerRegistry {
+export function getAttributionRpcHandlers(): RpcHandlerRegistry {
   return {
     ["attributionActivity"]: {
-      handler: activityHandler(options),
+      handler: activityHandler,
     } as RpcServerRequestHandler<unknown, unknown, unknown, RpcServerContext>,
     ["attributionGet"]: {
-      handler: getHandler(options),
+      handler: getHandler,
     } as RpcServerRequestHandler<unknown, unknown, unknown, RpcServerContext>,
   };
 }

--- a/src/protocols/milestone/server-handlers.ts
+++ b/src/protocols/milestone/server-handlers.ts
@@ -182,7 +182,7 @@ const getMilestoneHandler =
   async (
     payload: MilestoneGetRequest,
     context: RpcServerContext,
-  ): Promise<{ response: GetResponse | RpcError }> => {
+  ): Promise<{ response: GetResponse | RpcError; encrypted?: boolean }> => {
     try {
       const milestone = await milestoneStorage.getMilestone(
         context.documentId,
@@ -206,6 +206,7 @@ const getMilestoneHandler =
           milestoneId: payload.milestoneId,
           snapshot: snapshot as Uint8Array,
         },
+        encrypted: context.session.encrypted,
       };
     } catch (error) {
       return {

--- a/src/providers/README.md
+++ b/src/providers/README.md
@@ -399,6 +399,54 @@ await provider.deleteMilestone(milestone.id);
 await provider.restoreMilestone(milestone.id);
 ```
 
+### Attribution
+
+The `Provider` exposes attribution (authorship tracking) via two primary methods and
+a few lower-level helpers. See [`teleportal/attribution`](../lib/attribution/README.md) for
+the data model and [`teleportal/protocols/attribution`](../protocols/attribution/README.md)
+for the RPC protocol.
+
+#### `getActivity` — who did what, when?
+
+Single composable entrypoint for activity timelines. All filters combine with AND:
+
+```typescript
+provider.getActivity(); // all activity
+provider.getActivity({ userId: "alice" }); // by user
+provider.getActivity({ from: hourAgo, to: now }); // time range
+provider.getActivity({ milestone: milestoneId }); // scoped to milestone
+provider.getActivity({ changeset: [fromId, toId] }); // between milestones
+provider.getActivity({ milestone: id, userId: "alice" }); // combine filters
+provider.getActivity({ attributes: { "insert:source": "ai" } }); // custom attrs
+// → [{ from, to, userId, attributes }, ...]
+```
+
+#### `getAttributionForRange` — who wrote this content?
+
+Positional attribution — maps content offsets to authors:
+
+```typescript
+const text = provider.doc.getText("body");
+const segments = await provider.getAttributionForRange(text, 0, 100);
+// → [{ from, to, userId, timestamp, attributes }, ...]
+```
+
+#### Lower-level methods
+
+```typescript
+// Raw ContentMap access (fetched once, cached)
+const map = await provider.getAttributionMap();
+const filtered = await provider.getAttributionMap({ userId: "alice" });
+provider.invalidateAttributionCache();
+
+// Point lookup by CRDT ID
+const author = await provider.resolveAttribution(clientID, clock);
+
+// Milestone-scoped ContentMaps (for advanced use)
+const milestoneMap = await provider.getMilestoneContentMap(milestoneId);
+const changesetMap = await provider.getChangesetContentMap(fromId, toId);
+```
+
 ### Subdocuments
 
 ```typescript

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -928,10 +928,13 @@ export class Provider<
    * provider.getActivity({ from: hourAgo, to: now })              // time range
    * provider.getActivity({ milestone: milestoneId })              // scoped to milestone
    * provider.getActivity({ changeset: [fromId, toId] })           // between milestones
-   * provider.getActivity({ attributes: { "insert:source": "ai" } }) // custom attrs
+   * provider.getActivity({ attributes: { source: "ai" } })          // custom attrs
    * ```
    */
   async getActivity(options?: ActivityOptions): Promise<ActivityEntry[]> {
+    if (options?.milestone && options?.changeset) {
+      throw new Error("getActivity: `milestone` and `changeset` are mutually exclusive");
+    }
     if (options?.milestone || options?.changeset) {
       const map = options.milestone
         ? await this.getMilestoneContentMap(options.milestone)

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -32,6 +32,7 @@ import {
 } from "../protocols/milestone";
 import {
   resolveRangeAttribution,
+  type ActivityOptions,
   type AttributedSegment,
   type AttributionActivityResponse,
   type AttributionFilter,
@@ -41,7 +42,7 @@ import {
   changesetContentMap,
   createContentIdsFromUpdate,
   decodeContentMap,
-  getActivity,
+  getActivity as getActivityFromMap,
   milestoneContentMap,
   resolveItemAttribution,
   type ActivityEntry,
@@ -913,15 +914,30 @@ export class Provider<
   }
 
   /**
-   * Fetch the attribution activity timeline for the current document.
+   * Attribution activity timeline — the single entrypoint for "who did what, when?"
    *
-   * Works for encrypted documents — the server resolves this from authorship
-   * and timestamps without needing the document content.
+   * All filters compose with AND semantics. Without `milestone` or `changeset`,
+   * the query runs server-side via RPC (efficient, no ContentMap fetch). With
+   * milestone/changeset scoping, the ContentMap is fetched and filtered client-side.
    *
-   * @param options - Optional time range (`from`/`to`, ms) and `userId` filter
-   * @returns A sorted list of activity entries
+   * @example
+   * ```ts
+   * provider.getActivity()                                        // all activity
+   * provider.getActivity({ userId: "alice" })                     // by user
+   * provider.getActivity({ from: hourAgo, to: now })              // time range
+   * provider.getActivity({ milestone: milestoneId })              // scoped to milestone
+   * provider.getActivity({ changeset: [fromId, toId] })           // between milestones
+   * provider.getActivity({ attributes: { "insert:source": "ai" } }) // custom attrs
+   * ```
    */
-  async getActivity(options?: AttributionFilter): Promise<ActivityEntry[]> {
+  async getActivity(options?: ActivityOptions): Promise<ActivityEntry[]> {
+    if (options?.milestone || options?.changeset) {
+      const map = options.milestone
+        ? await this.getMilestoneContentMap(options.milestone)
+        : await this.getChangesetContentMap(options.changeset![0], options.changeset![1]);
+      if (!map) return [];
+      return getActivityFromMap(map, options);
+    }
     const response = await this.#rpcClient.sendRequest<AttributionActivityResponse>(
       this.document,
       "attributionActivity",
@@ -943,8 +959,11 @@ export class Provider<
       "attributionGet",
       filter ? { filter } : {},
     );
-    this.#attributionMap = response.contentMap ? decodeContentMap(response.contentMap) : null;
-    return this.#attributionMap;
+    const decoded = response.contentMap ? decodeContentMap(response.contentMap) : null;
+    if (!filter) {
+      this.#attributionMap = decoded;
+    }
+    return decoded;
   }
 
   /**
@@ -964,7 +983,7 @@ export class Provider<
   async resolveAttribution(
     clientID: number,
     clock: number,
-  ): Promise<{ userId: string; timestamp: number } | null> {
+  ): Promise<{ userId: string; timestamp: number; attributes: Record<string, unknown> } | null> {
     const map = await this.#ensureAttributionMap();
     if (!map) return null;
     return resolveItemAttribution(map, clientID, clock);
@@ -992,23 +1011,21 @@ export class Provider<
   }
 
   /**
+   * Invalidate the cached attribution ContentMap. The next call to
+   * resolveAttribution, getAttributionForRange, or any milestone method
+   * will re-fetch the ContentMap from the server.
+   */
+  invalidateAttributionCache(): void {
+    this.#attributionMap = undefined;
+  }
+
+  /**
    * The operation IDs contained in a milestone, derived from its (decrypted)
    * snapshot. These identify which CRDT operations existed as of the milestone.
    */
   async #milestoneContentIds(milestoneId: string): Promise<ContentIds> {
     const snapshot = await this.getMilestoneSnapshot(milestoneId);
     return createContentIdsFromUpdate({ version: 2, data: snapshot as any });
-  }
-
-  /**
-   * Reconstruct the Y.Doc state captured by a milestone from its (decrypted)
-   * snapshot, for resolving content positions against that historical state.
-   */
-  async #milestoneDoc(milestoneId: string): Promise<Y.Doc> {
-    const snapshot = await this.getMilestoneSnapshot(milestoneId);
-    const doc = new Y.Doc();
-    Y.applyUpdateV2(doc, snapshot as unknown as Uint8Array);
-    return doc;
   }
 
   /**
@@ -1027,19 +1044,6 @@ export class Provider<
   }
 
   /**
-   * Activity timeline for the content present in a milestone.
-   * @param options - Optional time range (`from`/`to`, ms) and `userId` filter
-   */
-  async getMilestoneActivity(
-    milestoneId: string,
-    options?: AttributionFilter,
-  ): Promise<ActivityEntry[]> {
-    const map = await this.getMilestoneContentMap(milestoneId);
-    if (!map) return [];
-    return getActivity(map, options);
-  }
-
-  /**
    * Attribution for the changes made between two milestones — the operations
    * added from `fromMilestoneId` to `toMilestoneId` (both new inserts and new
    * deletes). Returns null when no attribution data exists.
@@ -1055,43 +1059,6 @@ export class Provider<
     ]);
     if (!map) return null;
     return changesetContentMap(map, fromIds, toIds);
-  }
-
-  /**
-   * Activity timeline for the changes made between two milestones.
-   * @param options - Optional time range (`from`/`to`, ms) and `userId` filter
-   */
-  async getChangesetActivity(
-    fromMilestoneId: string,
-    toMilestoneId: string,
-    options?: AttributionFilter,
-  ): Promise<ActivityEntry[]> {
-    const map = await this.getChangesetContentMap(fromMilestoneId, toMilestoneId);
-    if (!map) return [];
-    return getActivity(map, options);
-  }
-
-  /**
-   * Resolve attribution for a content range as it existed in a milestone.
-   * Rebuilds the milestone's document from its (decrypted) snapshot, selects the
-   * target Y type via `select`, and resolves the range against the document's
-   * full ContentMap. Runs entirely client-side, so it works for E2EE documents.
-   *
-   * @param select - Picks the Y type from the rebuilt milestone Y.Doc
-   *   (e.g. `(doc) => doc.getText("body")`)
-   */
-  async getMilestoneAttributionForRange(
-    milestoneId: string,
-    select: (doc: Y.Doc) => Y.AbstractType<any>,
-    index: number,
-    length: number,
-  ): Promise<AttributedSegment[]> {
-    const [map, doc] = await Promise.all([
-      this.#ensureAttributionMap(),
-      this.#milestoneDoc(milestoneId),
-    ]);
-    if (!map) return [];
-    return resolveRangeAttribution(select(doc), index, length, map);
   }
 
   /**

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -836,6 +836,7 @@ export class Provider<
         this.document,
         "milestoneCreate",
         { name, snapshot },
+        { encrypted: !!this.encryptionKey },
       );
 
       return this.#createMilestoneFromMeta(response.milestone);

--- a/src/server/check-permission.test.ts
+++ b/src/server/check-permission.test.ts
@@ -18,6 +18,7 @@ describe("checkPermissionWithTokenManager", () => {
     fileId?: string;
     message: any;
     type: "read" | "write";
+    rpcMethod?: string;
   }) => Promise<boolean>;
   let context: ServerContext;
 
@@ -83,28 +84,69 @@ describe("checkPermissionWithTokenManager", () => {
   });
 
   describe("RPC messages", () => {
-    it("should allow RPC messages without permission checks", async () => {
+    it("should allow read RPCs with read permission", async () => {
+      const token = await tokenManager.createToken("user-1", "room-1", [
+        { pattern: "test-doc", permissions: ["read"] },
+      ]);
+      const payload = await tokenManager.verifyToken(token);
+      if (!payload.valid || !payload.payload) throw new Error("Token verification failed");
+
       const rpcMessage = new RpcMessage(
         "test-doc",
         { type: "success", payload: { snapshotIds: [] } },
         "milestoneList",
         "request",
         undefined,
-        context,
+        { ...context, ...payload.payload } as ServerContext,
       );
 
       const result = await checkPermission({
-        context,
+        context: rpcMessage.context,
         documentId: "test-doc",
         fileId: undefined,
         message: rpcMessage,
         type: "read",
+        rpcMethod: "milestoneList",
       });
 
       expect(result).toBe(true);
     });
 
-    it("should allow fileUpload RPC messages", async () => {
+    it("should deny read RPCs without matching document access", async () => {
+      const token = await tokenManager.createToken("user-1", "room-1", [
+        { pattern: "other-doc", permissions: ["read"] },
+      ]);
+      const payload = await tokenManager.verifyToken(token);
+      if (!payload.valid || !payload.payload) throw new Error("Token verification failed");
+
+      const rpcMessage = new RpcMessage(
+        "test-doc",
+        { type: "success", payload: {} },
+        "attributionActivity",
+        "request",
+        undefined,
+        { ...context, ...payload.payload } as ServerContext,
+      );
+
+      const result = await checkPermission({
+        context: rpcMessage.context,
+        documentId: "test-doc",
+        fileId: undefined,
+        message: rpcMessage,
+        type: "read",
+        rpcMethod: "attributionActivity",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("should allow write RPCs with write permission", async () => {
+      const token = await tokenManager.createToken("user-1", "room-1", [
+        { pattern: "test-doc", permissions: ["write"] },
+      ]);
+      const payload = await tokenManager.verifyToken(token);
+      if (!payload.valid || !payload.payload) throw new Error("Token verification failed");
+
       const rpcMessage = new RpcMessage(
         "test-doc",
         {
@@ -114,32 +156,61 @@ describe("checkPermissionWithTokenManager", () => {
             filename: "test.txt",
             size: 100,
             mimeType: "text/plain",
-            lastModified: Date.now(),
+            lastModified: 1700000000,
             encrypted: false,
           },
         },
         "fileUpload",
         "request",
         undefined,
-        context,
+        { ...context, ...payload.payload } as ServerContext,
       );
 
       const result = await checkPermission({
-        context,
+        context: rpcMessage.context,
         documentId: "test-doc",
         fileId: "file-123",
         message: rpcMessage,
         type: "write",
+        rpcMethod: "fileUpload",
       });
 
       expect(result).toBe(true);
     });
 
-    it("should allow fileDownload RPC messages", async () => {
+    it("should deny write RPCs with only read permission", async () => {
+      const token = await tokenManager.createToken("user-1", "room-1", [
+        { pattern: "test-doc", permissions: ["read"] },
+      ]);
+      const payload = await tokenManager.verifyToken(token);
+      if (!payload.valid || !payload.payload) throw new Error("Token verification failed");
+
       const rpcMessage = new RpcMessage(
         "test-doc",
-        { type: "success", payload: { fileId: "file-123" } },
-        "fileDownload",
+        { type: "success", payload: {} },
+        "milestoneCreate",
+        "request",
+        undefined,
+        { ...context, ...payload.payload } as ServerContext,
+      );
+
+      const result = await checkPermission({
+        context: rpcMessage.context,
+        documentId: "test-doc",
+        fileId: undefined,
+        message: rpcMessage,
+        type: "read",
+        rpcMethod: "milestoneCreate",
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it("should allow RPCs without a documentId", async () => {
+      const rpcMessage = new RpcMessage(
+        undefined,
+        { type: "success", payload: {} },
+        "someGlobalRpc",
         "request",
         undefined,
         context,
@@ -147,10 +218,11 @@ describe("checkPermissionWithTokenManager", () => {
 
       const result = await checkPermission({
         context,
-        documentId: "test-doc",
-        fileId: "file-123",
+        documentId: undefined,
+        fileId: undefined,
         message: rpcMessage,
         type: "read",
+        rpcMethod: "someGlobalRpc",
       });
 
       expect(result).toBe(true);
@@ -362,7 +434,13 @@ describe("checkPermissionWithTokenManager", () => {
   });
 
   describe("RPC stream messages (file-parts)", () => {
-    it("should allow RPC stream messages (file-parts)", async () => {
+    it("should allow RPC stream messages with read permission", async () => {
+      const token = await tokenManager.createToken("user-1", "room-1", [
+        { pattern: "test-doc", permissions: ["read"] },
+      ]);
+      const payload = await tokenManager.verifyToken(token);
+      if (!payload.valid || !payload.payload) throw new Error("Token verification failed");
+
       const message = new RpcMessage<ServerContext>(
         "test-doc",
         {
@@ -380,16 +458,17 @@ describe("checkPermissionWithTokenManager", () => {
         "fileDownload",
         "stream",
         "original-request-id",
-        context,
+        { ...context, ...payload.payload } as ServerContext,
         false,
       );
 
       const result = await checkPermission({
-        context,
+        context: message.context,
         documentId: "test-doc",
         fileId: "file-123",
         message,
         type: "read",
+        rpcMethod: "fileDownload",
       });
 
       expect(result).toBe(true);

--- a/src/server/check-permission.ts
+++ b/src/server/check-permission.ts
@@ -1,10 +1,18 @@
 import type { ServerOptions } from "./server";
 import type { TokenManager, TokenPayload } from "teleportal/token";
 
+const WRITE_RPC_METHODS = new Set([
+  "milestoneCreate",
+  "milestoneUpdateName",
+  "milestoneDelete",
+  "milestoneRestore",
+  "fileUpload",
+]);
+
 export function checkPermissionWithTokenManager(
   tokenManager: TokenManager,
 ): ServerOptions<any>["checkPermission"] {
-  return async ({ context, documentId, message }) => {
+  return async ({ context, documentId, message, rpcMethod }) => {
     // ACK messages don't require permission checks - they're acknowledgments
     if (message.type === "ack") {
       return true;
@@ -15,10 +23,12 @@ export function checkPermissionWithTokenManager(
       return true;
     }
 
-    // RPC messages - permission checks are handled by the RPC handlers themselves
-    // based on the method being called
     if (message.type === "rpc") {
-      return true;
+      if (!documentId) return true;
+
+      const tokenPayload = context as unknown as TokenPayload;
+      const requiredPermission = WRITE_RPC_METHODS.has(rpcMethod!) ? "write" : "read";
+      return tokenManager.hasDocumentPermission(tokenPayload, documentId, requiredPermission);
     }
 
     if (message.type === "doc") {

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,5 +1,6 @@
-import type { Message, ServerContext } from "teleportal";
+import type { Message, ServerContext, VersionedUpdate } from "teleportal";
 import type { EncodedContentMap } from "teleportal/storage";
+import type { Server } from "./server";
 import type { Session } from "./session";
 
 export type DocumentUnloadReason = "cleanup" | "delete" | "dispose";
@@ -38,6 +39,18 @@ export type PresenceConfig<Context extends ServerContext = ServerContext> = {
    * 90_000 (90s, ~2 missed heartbeats).
    */
   presenceTtlMs?: number;
+};
+
+/**
+ * Configuration for attribution metadata attached to document updates.
+ */
+export type AttributionConfig<Context extends ServerContext = ServerContext> = {
+  getAttributes?: (ctx: {
+    context: Context;
+    update: VersionedUpdate;
+    server: Server<Context>;
+    clientId: string | undefined;
+  }) => Record<string, unknown> | Promise<Record<string, unknown>>;
 };
 
 export type SessionEvents<Context extends ServerContext = ServerContext> = {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -4,7 +4,7 @@ import * as Y from "yjs";
 import { Server } from "./server";
 import { checkPermissionWithTokenManager } from "./check-permission";
 import { Client } from "./client";
-import { AckMessage, InMemoryPubSub, DocMessage } from "teleportal";
+import { AckMessage, InMemoryPubSub, DocMessage, RpcMessage } from "teleportal";
 import { createTokenManager } from "teleportal/token";
 import type {
   ServerContext,
@@ -335,6 +335,62 @@ describe("Server", () => {
 
       expect(session).toBe(encryptedSession);
       expect(session.encrypted).toBe(true);
+    });
+
+    it("routes plaintext RPC messages to encrypted sessions", async () => {
+      // The `encrypted` flag on a message describes whether the payload
+      // needs decryption — it is a property of the message, not the
+      // document. A plaintext RPC (e.g. an attribution query) must reach
+      // an encrypted session without triggering an encryption mismatch.
+      const rpcServer = new Server<ServerContext>({
+        storage: mockGetStorage,
+        pubSub,
+        rpcHandlers: {
+          myQuery: {
+            handler: async () => ({ response: { ok: true } }),
+          },
+        },
+      });
+
+      await rpcServer.getOrOpenSession("enc-rpc-doc", {
+        encrypted: true,
+        context: { userId: "user-1", room: "room", clientId: "client-1" },
+      });
+
+      const transport = new MockTransport<ServerContext>();
+      const writtenMessages: Message<ServerContext>[] = [];
+      const customTransport = {
+        readable: transport.readable,
+        writable: new WritableStream({
+          write: (m) => {
+            writtenMessages.push(m);
+          },
+        }),
+      } as Transport<ServerContext>;
+      rpcServer.createClient({ transport: customTransport, id: "client-1" });
+
+      transport.enqueueMessage(
+        new RpcMessage<ServerContext>(
+          "enc-rpc-doc",
+          { type: "success", payload: { method: "myQuery" } },
+          "myQuery",
+          "request",
+          undefined,
+          { clientId: "client-1", userId: "user-1", room: "room" },
+          false, // plaintext RPC payload
+        ),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const rpcResponse = writtenMessages.find((m) => m.type === "rpc") as
+        | RpcMessage<ServerContext>
+        | undefined;
+      expect(rpcResponse).toBeDefined();
+      expect(rpcResponse!.payload.type).toBe("success");
+
+      transport.closeReadable();
+      await rpcServer[Symbol.asyncDispose]();
     });
 
     it("should call getStorage with correct parameters", async () => {

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -23,6 +23,25 @@ function createTestUpdate(content = "test"): VersionedUpdate {
   return { version: 2, data: Y.encodeStateAsUpdateV2(doc) as Update } as VersionedUpdate;
 }
 
+/**
+ * Poll `fn` until `predicate` is satisfied, returning its result. Avoids flaky
+ * fixed-duration sleeps when waiting for asynchronously produced state.
+ */
+async function waitFor<T>(
+  fn: () => T,
+  predicate: (value: T) => boolean,
+  timeoutMs = 2000,
+): Promise<T> {
+  const start = Date.now();
+  let value = fn();
+  while (!predicate(value)) {
+    if (Date.now() - start > timeoutMs) return value;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    value = fn();
+  }
+  return value;
+}
+
 // Mock DocumentStorage for testing
 class MockDocumentStorage implements DocumentStorage {
   readonly type = "document-storage" as const;
@@ -381,11 +400,10 @@ describe("Server", () => {
         ),
       );
 
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      const rpcResponse = writtenMessages.find((m) => m.type === "rpc") as
-        | RpcMessage<ServerContext>
-        | undefined;
+      const rpcResponse = (await waitFor(
+        () => writtenMessages.find((m) => m.type === "rpc"),
+        (m) => m !== undefined,
+      )) as RpcMessage<ServerContext> | undefined;
       expect(rpcResponse).toBeDefined();
       expect(rpcResponse!.payload.type).toBe("success");
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -619,9 +619,7 @@ export class Server<Context extends ServerContext> extends Observable<ServerEven
             message,
             type,
             rpcMethod:
-              message.type === "rpc"
-                ? (message as RpcMessage<Context>).rpcMethod
-                : undefined,
+              message.type === "rpc" ? (message as RpcMessage<Context>).rpcMethod : undefined,
           });
 
           if (!ok) {
@@ -717,9 +715,14 @@ export class Server<Context extends ServerContext> extends Observable<ServerEven
                 encrypted: message.encrypted,
                 client,
                 context: message.context,
-                // Presence is always cleartext metadata; it must attach to the
-                // existing session regardless of the document's encryption mode.
-                ignoreEncryptionMismatch: message.type === "presence",
+                // The `encrypted` flag on a message describes whether its
+                // payload is encrypted, not which session type it belongs to.
+                // Only `doc` messages use the flag for session routing (they
+                // carry document content processed differently per mode).
+                // Presence and RPC payloads are independent of the document's
+                // encryption state and must route to the existing session
+                // regardless of their own `encrypted` value.
+                ignoreEncryptionMismatch: message.type === "presence" || message.type === "rpc",
               });
               wideEvent.session_id = session.id;
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -49,6 +49,7 @@ export type ServerOptions<Context extends ServerContext> = {
     fileId?: string;
     message: Message<NoInfer<Context>>;
     type: "read" | "write";
+    rpcMethod?: string;
   }) => Promise<boolean>;
 
   /**
@@ -617,6 +618,10 @@ export class Server<Context extends ServerContext> extends Observable<ServerEven
             fileId,
             message,
             type,
+            rpcMethod:
+              message.type === "rpc"
+                ? (message as RpcMessage<Context>).rpcMethod
+                : undefined,
           });
 
           if (!ok) {
@@ -640,7 +645,7 @@ export class Server<Context extends ServerContext> extends Observable<ServerEven
                   {
                     type: "error",
                     statusCode: 403,
-                    details: "Permission denied for file upload",
+                    details: "Permission denied",
                   },
                   message.rpcMethod,
                   "response",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,7 +18,12 @@ import { type RateLimitRule, withRateLimit } from "teleportal/transports/rate-li
 import { Observable } from "../lib/utils";
 import { register } from "../monitoring/metrics";
 import { Client } from "./client";
-import type { ClientDisconnectReason, PresenceConfig, ServerEvents } from "./events";
+import type {
+  AttributionConfig,
+  ClientDisconnectReason,
+  PresenceConfig,
+  ServerEvents,
+} from "./events";
 import { Session } from "./session";
 
 export type ServerOptions<Context extends ServerContext> = {
@@ -77,6 +82,11 @@ export type ServerOptions<Context extends ServerContext> = {
    * a session's peers.
    */
   presenceConfig?: PresenceConfig<NoInfer<Context>>;
+
+  /**
+   * Configuration for custom attribution metadata on document updates.
+   */
+  attributionConfig?: AttributionConfig<NoInfer<Context>>;
 
   /**
    * RPC handlers for the server.
@@ -343,6 +353,7 @@ export class Server<Context extends ServerContext> extends Observable<ServerEven
           metricsCollector: this.#metrics,
           documentSizeConfig: this.#options.documentSizeConfig,
           presenceConfig: this.#options.presenceConfig,
+          attributionConfig: this.#options.attributionConfig,
           rpcHandlers: this.#options.rpcHandlers,
           server: this,
         });

--- a/src/server/session-rpc.test.ts
+++ b/src/server/session-rpc.test.ts
@@ -430,5 +430,95 @@ describe("Session RPC Integration", () => {
 
       await sessionWithHandlers[Symbol.asyncDispose]();
     });
+
+    it("should use handler's encrypted override on the response message", async () => {
+      await session.load();
+
+      const rpcHandlers = {
+        encryptedResponse: {
+          handler: async (_payload: unknown, _context: unknown) => {
+            return {
+              response: { snapshot: new Uint8Array([1, 2, 3]) },
+              encrypted: true,
+            };
+          },
+        },
+      };
+
+      const sessionWithHandlers = new Session({
+        documentId: "test-doc",
+        namespacedDocumentId: "test-doc",
+        id: "session-enc-override",
+        encrypted: false,
+        storage,
+        pubSub,
+        nodeId,
+        onCleanupScheduled: () => {},
+        rpcHandlers,
+        server: mockServer,
+      });
+
+      const rpcMessage = new RpcMessage<ServerContext>(
+        "test-doc",
+        { type: "success", payload: {} },
+        "encryptedResponse",
+        "request",
+        undefined,
+        { clientId: "client-1", userId: "user-1", room: "room" },
+        false,
+      );
+
+      await sessionWithHandlers.apply(rpcMessage, client as any);
+
+      expect(client.sentMessages.length).toBe(1);
+      const response = client.sentMessages[0];
+      expect(response).toBeInstanceOf(RpcMessage);
+      if (response instanceof RpcMessage) {
+        expect(response.encrypted).toBe(true);
+        expect(response.payload.type).toBe("success");
+      }
+
+      await sessionWithHandlers[Symbol.asyncDispose]();
+    });
+
+    it("should allow plaintext RPC messages on encrypted sessions", async () => {
+      const encryptedSession = new Session({
+        documentId: "enc-doc",
+        namespacedDocumentId: "enc-doc",
+        id: "session-enc",
+        encrypted: true,
+        storage,
+        pubSub,
+        nodeId,
+        onCleanupScheduled: () => {},
+        rpcHandlers: {
+          query: {
+            handler: async () => ({ response: { ok: true } }),
+          },
+        },
+        server: mockServer,
+      });
+
+      const rpcMessage = new RpcMessage<ServerContext>(
+        "enc-doc",
+        { type: "success", payload: {} },
+        "query",
+        "request",
+        undefined,
+        { clientId: "client-1", userId: "user-1", room: "room" },
+        false,
+      );
+
+      await encryptedSession.apply(rpcMessage, client as any);
+
+      expect(client.sentMessages.length).toBe(1);
+      const response = client.sentMessages[0];
+      expect(response).toBeInstanceOf(RpcMessage);
+      if (response instanceof RpcMessage) {
+        expect(response.payload.type).toBe("success");
+      }
+
+      await encryptedSession[Symbol.asyncDispose]();
+    });
   });
 });

--- a/src/server/session.test.ts
+++ b/src/server/session.test.ts
@@ -23,6 +23,11 @@ import {
   removeAwarenessStates,
 } from "y-protocols/awareness";
 import { createEncryptionKey, decryptUpdate, encryptUpdate } from "teleportal/encryption-key";
+import type { EncryptedBinary } from "teleportal/encryption-key";
+import type { DecodedEncryptedUpdatePayload, EncryptedSnapshot } from "teleportal/protocol/encryption";
+import { encodeEncryptedSnapshot, encodeEncryptedUpdateMessages } from "teleportal/protocol/encryption";
+import { createContentIds, decodeContentMap, encodeContentIds, IdSet } from "teleportal/attribution";
+import { EncryptedMemoryStorage } from "../storage/in-memory/encrypted";
 import { Session } from "./session";
 import { Server } from "./server";
 import { Client } from "./client";
@@ -58,6 +63,7 @@ class MockDocumentStorage implements DocumentStorage {
   public mockHandleUpdate = false;
   public mockHandleSyncStep2 = false;
   public storedUpdate: VersionedUpdate | null = null;
+  public storedAttribution: EncodedContentMap | null = null;
   public lastSyncStep2: VersionedSyncStep2Update | null = null;
   public metadata: Map<string, DocumentMetadata> = new Map();
 
@@ -80,10 +86,15 @@ class MockDocumentStorage implements DocumentStorage {
   async handleUpdate(
     _documentId: string,
     update: VersionedUpdate,
-    _attribution?: EncodedContentMap,
+    attribution?: EncodedContentMap,
   ): Promise<void> {
     this.mockHandleUpdate = true;
     this.storedUpdate = update;
+    if (attribution) this.storedAttribution = attribution;
+  }
+
+  async retrieveAttribution(_documentId: string): Promise<EncodedContentMap | null> {
+    return this.storedAttribution;
   }
 
   async getDocument(documentId: string): Promise<Document | null> {
@@ -633,6 +644,166 @@ describe("Session", () => {
         // Message should be published (we can't easily verify this without subscribing)
         await testSession[Symbol.asyncDispose]();
         await testPubSub[Symbol.asyncDispose]();
+      });
+    });
+
+    describe("attribution", () => {
+      it("stores attribution for unencrypted updates", async () => {
+        await session.load();
+        session.addClient(client1 as any);
+
+        const update = createTestUpdate("hello");
+        const context = { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext;
+        const message = new DocMessage("test-doc", { type: "update", update }, context, false);
+
+        await session.apply(message, client1 as any);
+
+        const attribution = await storage.retrieveAttribution("test-doc");
+        expect(attribution).not.toBeNull();
+
+        const map = decodeContentMap(attribution!);
+        const insertClients = [...map.inserts.clients.values()];
+        expect(insertClients.length).toBeGreaterThan(0);
+        const attrs = insertClients.flatMap((r) =>
+          r.getIds().flatMap((range) => range.attrs.filter((a) => a.name === "insert")),
+        );
+        expect(attrs.some((a) => a.val === "user-1")).toBe(true);
+      });
+
+      it("stores attribution for encrypted updates", async () => {
+        EncryptedMemoryStorage.docs.clear();
+        EncryptedMemoryStorage.attributionMaps.clear();
+        const encStorage = new EncryptedMemoryStorage();
+
+        const encSession = new Session({
+          documentId: "enc-doc",
+          namespacedDocumentId: "enc-doc",
+          id: "session-enc-attr",
+          encrypted: true,
+          storage: encStorage,
+          pubSub,
+          nodeId,
+          onCleanupScheduled: () => {},
+          server: mockServer,
+        });
+
+        await encSession.load();
+        encSession.addClient(client1 as any);
+
+        const snapshot: EncryptedSnapshot = {
+          id: "snap-1",
+          parentSnapshotId: null,
+          payload: new Uint8Array([0]) as EncryptedBinary,
+        };
+        await encSession.apply(
+          new DocMessage(
+            "enc-doc",
+            { type: "update", update: { version: 2, data: encodeEncryptedSnapshot(snapshot) } as VersionedUpdate },
+            { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
+            true,
+          ),
+          client1 as any,
+        );
+
+        const inserts = new IdSet();
+        inserts.add(100, 0, 5);
+        const payload = new Uint8Array([10, 20, 30]) as EncryptedBinary;
+        const updateMsg: DecodedEncryptedUpdatePayload = {
+          id: "test-update-id",
+          snapshotId: "snap-1",
+          timestamp: [1, 1],
+          payload,
+          contentIds: encodeContentIds(createContentIds(inserts, new IdSet())),
+        };
+
+        await encSession.apply(
+          new DocMessage(
+            "enc-doc",
+            { type: "update", update: { version: 2, data: encodeEncryptedUpdateMessages([updateMsg]) } as VersionedUpdate },
+            { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
+            true,
+          ),
+          client1 as any,
+        );
+
+        const attribution = await encStorage.retrieveAttribution("enc-doc");
+        expect(attribution).not.toBeNull();
+
+        const map = decodeContentMap(attribution!);
+        const insertClients = [...map.inserts.clients.values()];
+        expect(insertClients.length).toBeGreaterThan(0);
+        const attrs = insertClients.flatMap((r) =>
+          r.getIds().flatMap((range) => range.attrs.filter((a) => a.name === "insert")),
+        );
+        expect(attrs.some((a) => a.val === "user-1")).toBe(true);
+
+        await encSession[Symbol.asyncDispose]();
+      });
+
+      it("emits document-attribution event for encrypted updates", async () => {
+        EncryptedMemoryStorage.docs.clear();
+        EncryptedMemoryStorage.attributionMaps.clear();
+        const encStorage = new EncryptedMemoryStorage();
+
+        const encSession = new Session({
+          documentId: "enc-doc",
+          namespacedDocumentId: "enc-doc",
+          id: "session-enc-evt",
+          encrypted: true,
+          storage: encStorage,
+          pubSub,
+          nodeId,
+          onCleanupScheduled: () => {},
+          server: mockServer,
+        });
+
+        await encSession.load();
+        encSession.addClient(client1 as any);
+
+        const snapshot: EncryptedSnapshot = {
+          id: "snap-1",
+          parentSnapshotId: null,
+          payload: new Uint8Array([0]) as EncryptedBinary,
+        };
+        await encSession.apply(
+          new DocMessage(
+            "enc-doc",
+            { type: "update", update: { version: 2, data: encodeEncryptedSnapshot(snapshot) } as VersionedUpdate },
+            { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
+            true,
+          ),
+          client1 as any,
+        );
+
+        let attributionEventFired = false;
+        encSession.on("document-attribution", () => {
+          attributionEventFired = true;
+        });
+
+        const inserts = new IdSet();
+        inserts.add(200, 0, 3);
+        const payload = new Uint8Array([1, 2, 3]) as EncryptedBinary;
+        const updateMsg: DecodedEncryptedUpdatePayload = {
+          id: "test-update-evt",
+          snapshotId: "snap-1",
+          timestamp: [2, 1],
+          payload,
+          contentIds: encodeContentIds(createContentIds(inserts, new IdSet())),
+        };
+
+        await encSession.apply(
+          new DocMessage(
+            "enc-doc",
+            { type: "update", update: { version: 2, data: encodeEncryptedUpdateMessages([updateMsg]) } as VersionedUpdate },
+            { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
+            true,
+          ),
+          client1 as any,
+        );
+
+        expect(attributionEventFired).toBe(true);
+
+        await encSession[Symbol.asyncDispose]();
       });
     });
 

--- a/src/server/session.test.ts
+++ b/src/server/session.test.ts
@@ -24,9 +24,20 @@ import {
 } from "y-protocols/awareness";
 import { createEncryptionKey, decryptUpdate, encryptUpdate } from "teleportal/encryption-key";
 import type { EncryptedBinary } from "teleportal/encryption-key";
-import type { DecodedEncryptedUpdatePayload, EncryptedSnapshot } from "teleportal/protocol/encryption";
-import { encodeEncryptedSnapshot, encodeEncryptedUpdateMessages } from "teleportal/protocol/encryption";
-import { createContentIds, decodeContentMap, encodeContentIds, IdSet } from "teleportal/attribution";
+import type {
+  DecodedEncryptedUpdatePayload,
+  EncryptedSnapshot,
+} from "teleportal/protocol/encryption";
+import {
+  encodeEncryptedSnapshot,
+  encodeEncryptedUpdateMessages,
+} from "teleportal/protocol/encryption";
+import {
+  createContentIds,
+  decodeContentMap,
+  encodeContentIds,
+  IdSet,
+} from "teleportal/attribution";
 import { EncryptedMemoryStorage } from "../storage/in-memory/encrypted";
 import { Session } from "./session";
 import { Server } from "./server";
@@ -698,7 +709,10 @@ describe("Session", () => {
         await encSession.apply(
           new DocMessage(
             "enc-doc",
-            { type: "update", update: { version: 2, data: encodeEncryptedSnapshot(snapshot) } as VersionedUpdate },
+            {
+              type: "update",
+              update: { version: 2, data: encodeEncryptedSnapshot(snapshot) } as VersionedUpdate,
+            },
             { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
             true,
           ),
@@ -719,7 +733,13 @@ describe("Session", () => {
         await encSession.apply(
           new DocMessage(
             "enc-doc",
-            { type: "update", update: { version: 2, data: encodeEncryptedUpdateMessages([updateMsg]) } as VersionedUpdate },
+            {
+              type: "update",
+              update: {
+                version: 2,
+                data: encodeEncryptedUpdateMessages([updateMsg]),
+              } as VersionedUpdate,
+            },
             { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
             true,
           ),
@@ -768,7 +788,10 @@ describe("Session", () => {
         await encSession.apply(
           new DocMessage(
             "enc-doc",
-            { type: "update", update: { version: 2, data: encodeEncryptedSnapshot(snapshot) } as VersionedUpdate },
+            {
+              type: "update",
+              update: { version: 2, data: encodeEncryptedSnapshot(snapshot) } as VersionedUpdate,
+            },
             { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
             true,
           ),
@@ -794,7 +817,13 @@ describe("Session", () => {
         await encSession.apply(
           new DocMessage(
             "enc-doc",
-            { type: "update", update: { version: 2, data: encodeEncryptedUpdateMessages([updateMsg]) } as VersionedUpdate },
+            {
+              type: "update",
+              update: {
+                version: 2,
+                data: encodeEncryptedUpdateMessages([updateMsg]),
+              } as VersionedUpdate,
+            },
             { clientId: "client-1", userId: "user-1", room: "room" } as ServerContext,
             true,
           ),

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -817,9 +817,12 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
     client?: { id: string; send: (m: Message<Context>) => Promise<void> },
     replicationMeta?: { sourceNodeId: string; deduped: boolean },
   ) {
-    // Presence messages are always cleartext metadata (they carry no document
-    // content), so they are exempt from the document's encryption requirement.
-    if (message.type !== "presence" && message.encrypted !== this.encrypted) {
+    // The `encrypted` flag describes whether the message payload needs
+    // decryption — it is a property of the message, not the document.
+    // Only `doc` messages must match the session's encryption mode because
+    // the server processes their content differently per mode.  Presence and
+    // RPC payloads are independent of the document's encryption state.
+    if (message.type === "doc" && message.encrypted !== this.encrypted) {
       const error = new Error("Message encryption and document encryption are mismatched");
       emitWideEvent("error", {
         event_type: "encryption_mismatch",
@@ -1154,7 +1157,9 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
                     details?: string;
                   };
                   stream?: AsyncIterable<unknown>;
+                  encrypted?: boolean;
                 };
+                const responseEncrypted = result.encrypted ?? rpcMessage.encrypted;
 
                 if ("stream" in result && result.stream) {
                   for await (const chunk of result.stream) {
@@ -1171,7 +1176,7 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
                       "stream",
                       rpcMessage.id,
                       rpcMessage.context,
-                      rpcMessage.encrypted,
+                      responseEncrypted,
                       undefined,
                       serializer,
                     );
@@ -1208,7 +1213,7 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
                   "response",
                   rpcMessage.id,
                   rpcMessage.context,
-                  rpcMessage.encrypted,
+                  responseEncrypted,
                   undefined,
                   serializer,
                 );

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -34,6 +34,7 @@ import {
   decodeContentIds,
   encodeContentMap,
   mergeContentIds,
+  recordToAttrs,
 } from "teleportal/attribution";
 import { Observable } from "../lib/utils";
 import { Client } from "./client";
@@ -731,11 +732,9 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
         server: this.#server,
         clientId,
       });
-      for (const [name, val] of Object.entries(custom)) {
-        const attr = createContentAttribute(name, val);
-        insertAttrs.push(attr);
-        deleteAttrs.push(attr);
-      }
+      const customAttrs = recordToAttrs(custom);
+      insertAttrs.push(...customAttrs);
+      deleteAttrs.push(...customAttrs);
     }
 
     return encodeContentMap(createContentMapFromContentIds(contentIds, insertAttrs, deleteAttrs));

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -889,9 +889,29 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
                   : null;
 
               if (encryptedStorage) {
+                let encryptedAttribution: EncodedContentMap | undefined;
+                if (messageSource === "client" && message.context?.userId) {
+                  try {
+                    encryptedAttribution = await this.#computeAttribution(
+                      message.payload.update,
+                      message.context,
+                      client?.id,
+                    );
+                  } catch (error) {
+                    emitWideEvent("error", {
+                      event_type: "attribution_compute_failed",
+                      timestamp: new Date().toISOString(),
+                      document_id: this.documentId,
+                      session_id: this.id,
+                      error,
+                    });
+                  }
+                }
+
                 const storedUpdate = await encryptedStorage.handleEncryptedUpdate(
                   this.namespacedDocumentId,
                   message.payload.update.data as EncryptedUpdatePayload,
+                  encryptedAttribution,
                 );
                 if (!storedUpdate) {
                   await Promise.all([
@@ -910,6 +930,16 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
                     replicationMeta?.deduped,
                   );
                   return;
+                }
+                if (encryptedAttribution) {
+                  this.call("document-attribution", {
+                    documentId: this.documentId,
+                    namespacedDocumentId: this.namespacedDocumentId,
+                    sessionId: this.id,
+                    userId: message.context!.userId,
+                    timestamp: Date.now(),
+                    contentMap: encryptedAttribution,
+                  });
                 }
                 this.call("document-write", {
                   documentId: this.documentId,

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -26,6 +26,7 @@ import type { EncodedContentMap } from "teleportal/storage";
 import type { EncryptedUpdatePayload } from "teleportal/protocol/encryption";
 import { decodeEncryptedUpdate } from "teleportal/protocol/encryption";
 import {
+  ContentAttribute,
   type ContentIds,
   createContentAttribute,
   createContentIdsFromUpdate,
@@ -37,7 +38,12 @@ import {
 import { Observable } from "../lib/utils";
 import { Client } from "./client";
 import { TtlDedupe } from "./dedupe";
-import type { DocumentMessageSource, PresenceConfig, SessionEvents } from "./events";
+import type {
+  AttributionConfig,
+  DocumentMessageSource,
+  PresenceConfig,
+  SessionEvents,
+} from "./events";
 import { emitWideEvent } from "./logger";
 import type { Server } from "./server";
 
@@ -77,6 +83,7 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
   #rpcHandlers: RpcHandlerRegistry;
   #server: Server<Context>;
   #presenceConfig: PresenceConfig<Context> | undefined;
+  #attributionConfig: AttributionConfig<Context> | undefined;
   /**
    * The presence of each connected (local) client, keyed by session client id.
    * Records the numeric awareness clientID a client announced (cleartext, so it
@@ -120,6 +127,7 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
     metricsCollector?: MetricsCollector;
     documentSizeConfig?: { warningThreshold?: number; limit?: number };
     presenceConfig?: PresenceConfig<Context>;
+    attributionConfig?: AttributionConfig<Context>;
     rpcHandlers?: RpcHandlerRegistry;
     server: Server<Context>;
   }) {
@@ -134,6 +142,7 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
     this.#metrics = args.metricsCollector;
     this.#documentSizeConfig = args.documentSizeConfig;
     this.#presenceConfig = args.presenceConfig;
+    this.#attributionConfig = args.attributionConfig;
     this.#heartbeatIntervalMs = args.presenceConfig?.heartbeatIntervalMs ?? 30_000;
     this.#presenceTtlMs = args.presenceConfig?.presenceTtlMs ?? 90_000;
     this.#rpcHandlers = args.rpcHandlers ?? {};
@@ -639,12 +648,13 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
     update: VersionedUpdate,
     context?: Context,
     source: DocumentMessageSource = "client",
+    clientId?: string,
   ) {
     try {
       let attribution: EncodedContentMap | undefined;
       if (source === "client" && context?.userId) {
         try {
-          attribution = this.#computeAttribution(update, context);
+          attribution = await this.#computeAttribution(update, context, clientId);
         } catch (error) {
           emitWideEvent("error", {
             event_type: "attribution_compute_failed",
@@ -689,7 +699,7 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
     }
   }
 
-  #computeAttribution(update: VersionedUpdate, context: Context) {
+  async #computeAttribution(update: VersionedUpdate, context: Context, clientId?: string) {
     let contentIds: ContentIds;
     if (this.encrypted) {
       const message = decodeEncryptedUpdate(update.data as unknown as EncryptedUpdatePayload);
@@ -704,13 +714,31 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
     }
     const now = Date.now();
     const userId = context.userId;
-    return encodeContentMap(
-      createContentMapFromContentIds(
-        contentIds,
-        [createContentAttribute("insert", userId), createContentAttribute("insertAt", now)],
-        [createContentAttribute("delete", userId), createContentAttribute("deleteAt", now)],
-      ),
-    );
+
+    const insertAttrs: ContentAttribute[] = [
+      createContentAttribute("insert", userId),
+      createContentAttribute("insertAt", now),
+    ];
+    const deleteAttrs: ContentAttribute[] = [
+      createContentAttribute("delete", userId),
+      createContentAttribute("deleteAt", now),
+    ];
+
+    if (this.#attributionConfig?.getAttributes) {
+      const custom = await this.#attributionConfig.getAttributes({
+        context,
+        update,
+        server: this.#server,
+        clientId,
+      });
+      for (const [name, val] of Object.entries(custom)) {
+        const attr = createContentAttribute(name, val);
+        insertAttrs.push(attr);
+        deleteAttrs.push(attr);
+      }
+    }
+
+    return encodeContentMap(createContentMapFromContentIds(contentIds, insertAttrs, deleteAttrs));
   }
 
   async #updateDocumentSizeMetrics(context?: Context) {
@@ -920,7 +948,7 @@ export class Session<Context extends ServerContext> extends Observable<SessionEv
                 return;
               }
 
-              await this.write(message.payload.update, message.context, messageSource);
+              await this.write(message.payload.update, message.context, messageSource, client?.id);
 
               await Promise.all([
                 this.broadcast(message, client?.id),

--- a/src/storage/encrypted/document-storage.ts
+++ b/src/storage/encrypted/document-storage.ts
@@ -181,14 +181,15 @@ export abstract class EncryptedDocumentStorage implements DocumentStorage {
   async handleUpdate(
     key: string,
     update: VersionedUpdate,
-    _attribution?: EncodedContentMap,
+    attribution?: EncodedContentMap,
   ): Promise<void> {
-    await this.handleEncryptedUpdate(key, update.data as EncryptedUpdatePayload);
+    await this.handleEncryptedUpdate(key, update.data as EncryptedUpdatePayload, attribution);
   }
 
   async handleEncryptedUpdate(
     key: string,
     update: EncryptedUpdatePayload,
+    attribution?: EncodedContentMap,
   ): Promise<EncryptedUpdatePayload | null> {
     return this.transaction(key, async () => {
       const decoded = decodeEncryptedUpdate(update);
@@ -212,8 +213,18 @@ export abstract class EncryptedDocumentStorage implements DocumentStorage {
         return null;
       }
       const storedUpdates = await this.storeUpdates(key, decoded.updates);
-      return storedUpdates.length > 0 ? encodeEncryptedUpdateMessages(storedUpdates) : null;
+      if (storedUpdates.length === 0) {
+        return null;
+      }
+      if (attribution) {
+        await this.storeAttribution(key, attribution);
+      }
+      return encodeEncryptedUpdateMessages(storedUpdates);
     });
+  }
+
+  protected async storeAttribution(_key: string, _attribution: EncodedContentMap): Promise<void> {
+    // Subclasses override to persist attribution data.
   }
 
   async handleEncryptedSyncStep2(

--- a/src/storage/in-memory/encrypted.test.ts
+++ b/src/storage/in-memory/encrypted.test.ts
@@ -580,7 +580,7 @@ describe("EncryptedMemoryStorage", () => {
       const message: DecodedEncryptedUpdatePayload = {
         id: messageId,
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload,
         contentIds: getEmptyEncodedContentIds(),
       };
@@ -608,7 +608,7 @@ describe("EncryptedMemoryStorage", () => {
       const message: DecodedEncryptedUpdatePayload = {
         id: messageId,
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload,
         contentIds: getEmptyEncodedContentIds(),
       };
@@ -628,14 +628,14 @@ describe("EncryptedMemoryStorage", () => {
       const msg1: DecodedEncryptedUpdatePayload = {
         id: toBase64(digest(payload1)),
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload: payload1,
         contentIds: getEmptyEncodedContentIds(),
       };
       const msg2: DecodedEncryptedUpdatePayload = {
         id: toBase64(digest(payload2)),
         snapshotId: attrSnapshotId,
-        timestamp: [2, 0],
+        timestamp: [2, 1],
         payload: payload2,
         contentIds: getEmptyEncodedContentIds(),
       };
@@ -664,7 +664,7 @@ describe("EncryptedMemoryStorage", () => {
       const msg: DecodedEncryptedUpdatePayload = {
         id: toBase64(digest(payload)),
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload,
         contentIds: getEmptyEncodedContentIds(),
       };

--- a/src/storage/in-memory/encrypted.ts
+++ b/src/storage/in-memory/encrypted.ts
@@ -1,4 +1,3 @@
-import type { VersionedUpdate } from "teleportal";
 import type { EncryptedSnapshot } from "teleportal/protocol/encryption";
 import { decodeContentMap, encodeContentMap, mergeContentMaps } from "teleportal/attribution";
 import {
@@ -165,20 +164,16 @@ export class EncryptedMemoryStorage extends EncryptedDocumentStorage {
       .sort((a, b) => a.serverVersion - b.serverVersion);
   }
 
-  override async handleUpdate(
+  protected override async storeAttribution(
     key: string,
-    update: VersionedUpdate,
-    attribution?: EncodedContentMap,
+    attribution: EncodedContentMap,
   ): Promise<void> {
-    await super.handleUpdate(key, update);
-    if (attribution) {
-      let list = EncryptedMemoryStorage.attributionMaps.get(key);
-      if (!list) {
-        list = [];
-        EncryptedMemoryStorage.attributionMaps.set(key, list);
-      }
-      list.push(attribution);
+    let list = EncryptedMemoryStorage.attributionMaps.get(key);
+    if (!list) {
+      list = [];
+      EncryptedMemoryStorage.attributionMaps.set(key, list);
     }
+    list.push(attribution);
   }
 
   async deleteDocument(key: string): Promise<void> {

--- a/src/storage/unstorage/encrypted.test.ts
+++ b/src/storage/unstorage/encrypted.test.ts
@@ -110,7 +110,7 @@ describe("UnstorageEncryptedDocumentStorage", () => {
       const message: DecodedEncryptedUpdatePayload = {
         id: messageId,
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload,
         contentIds: getEmptyEncodedContentIds(),
       };
@@ -138,7 +138,7 @@ describe("UnstorageEncryptedDocumentStorage", () => {
       const message: DecodedEncryptedUpdatePayload = {
         id: messageId,
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload,
         contentIds: getEmptyEncodedContentIds(),
       };
@@ -158,14 +158,14 @@ describe("UnstorageEncryptedDocumentStorage", () => {
       const msg1: DecodedEncryptedUpdatePayload = {
         id: toBase64(digest(payload1)),
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload: payload1,
         contentIds: getEmptyEncodedContentIds(),
       };
       const msg2: DecodedEncryptedUpdatePayload = {
         id: toBase64(digest(payload2)),
         snapshotId: attrSnapshotId,
-        timestamp: [2, 0],
+        timestamp: [2, 1],
         payload: payload2,
         contentIds: getEmptyEncodedContentIds(),
       };
@@ -194,7 +194,7 @@ describe("UnstorageEncryptedDocumentStorage", () => {
       const msg: DecodedEncryptedUpdatePayload = {
         id: toBase64(digest(payload)),
         snapshotId: attrSnapshotId,
-        timestamp: [1, 0],
+        timestamp: [1, 1],
         payload,
         contentIds: getEmptyEncodedContentIds(),
       };

--- a/src/storage/unstorage/encrypted.ts
+++ b/src/storage/unstorage/encrypted.ts
@@ -2,7 +2,6 @@ import { fromBase64, toBase64 } from "lib0/buffer";
 import { uuidv4 } from "lib0/random";
 import type { Storage } from "unstorage";
 
-import type { VersionedUpdate } from "teleportal";
 import { EncryptedBinary } from "teleportal/encryption-key";
 import type { EncryptedSnapshot } from "teleportal/protocol/encryption";
 import {
@@ -194,15 +193,11 @@ export class UnstorageEncryptedDocumentStorage extends EncryptedDocumentStorage 
       .map(deserializeUpdate);
   }
 
-  override async handleUpdate(
+  protected override async storeAttribution(
     key: string,
-    update: VersionedUpdate,
-    attribution?: EncodedContentMap,
+    attribution: EncodedContentMap,
   ): Promise<void> {
-    await super.handleUpdate(key, update);
-    if (attribution) {
-      await this.storage.setItemRaw(this.#getAttributionKey(key), attribution);
-    }
+    await this.storage.setItemRaw(this.#getAttributionKey(key), attribution);
   }
 
   async retrieveAttribution(key: string): Promise<EncodedContentMap | null> {

--- a/src/transports/encrypted/client.ts
+++ b/src/transports/encrypted/client.ts
@@ -34,7 +34,11 @@ import {
   getEncryptedStateVector,
   LamportClock,
 } from "teleportal/protocol/encryption";
-import { getEmptyEncodedContentIds } from "teleportal/attribution";
+import {
+  createContentIdsFromUpdate,
+  encodeContentIds,
+  getEmptyEncodedContentIds,
+} from "teleportal/attribution";
 import { applyAwarenessUpdate, Awareness, encodeAwarenessUpdate } from "y-protocols/awareness.js";
 import * as Y from "yjs";
 import { getSyncTransactionOrigin, YDocSinkHandler, YDocSourceHandler } from "../ydoc";
@@ -295,7 +299,10 @@ export class EncryptionClient
     return snapshot;
   }
 
-  private createUpdatePayload(payload: EncryptedBinary): DecodedEncryptedUpdatePayload {
+  private createUpdatePayload(
+    payload: EncryptedBinary,
+    contentIds = getEmptyEncodedContentIds(),
+  ): DecodedEncryptedUpdatePayload {
     if (!this.activeSnapshotId) {
       throw new Error("Cannot create update without an active snapshot");
     }
@@ -305,7 +312,7 @@ export class EncryptionClient
       snapshotId: this.activeSnapshotId,
       timestamp,
       payload,
-      contentIds: getEmptyEncodedContentIds(),
+      contentIds,
     };
     this.markSeen(update);
     this.pendingUpdates.set(this.getUpdateKey(update.snapshotId, timestamp), update);
@@ -461,8 +468,9 @@ export class EncryptionClient
       return this.createSnapshotMessage();
     }
     const v2 = convertToV2(update);
+    const contentIds = encodeContentIds(createContentIdsFromUpdate(update));
     const encryptedUpdate = await this.encryptUpdate(v2);
-    const updatePayload = this.createUpdatePayload(encryptedUpdate);
+    const updatePayload = this.createUpdatePayload(encryptedUpdate, contentIds);
     return new DocMessage(
       this.document,
       {

--- a/src/transports/encrypted/e2e.test.ts
+++ b/src/transports/encrypted/e2e.test.ts
@@ -12,6 +12,7 @@ import {
 } from "teleportal";
 import type { EncryptedStateVector } from "teleportal/protocol/encryption";
 import { EncryptedMemoryStorage, YDocStorage } from "teleportal/storage";
+import { getAttributionRpcHandlers } from "teleportal/protocols/attribution";
 import { Server } from "../../server/server";
 import { Client } from "../../server/client";
 import type { Session } from "../../server/session";
@@ -891,5 +892,164 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
     expect(states).toContain("connecting");
     expect(states).toContain("connected");
     expect(states).toContain("disconnected");
+  });
+});
+
+// ─── Attribution e2e: encrypted vs unencrypted ──────────────────────────────
+
+describe("attribution e2e: full WebSocket transport", () => {
+  let pubSub: InMemoryPubSub;
+  let server: Server<Ctx>;
+  let key: CryptoKey;
+  let bunServer: ReturnType<typeof Bun.serve>;
+  let baseUrl: string;
+  const cleanups: Array<() => void | Promise<void>> = [];
+
+  beforeEach(async () => {
+    EncryptedMemoryStorage.docs.clear();
+    EncryptedMemoryStorage.attributionMaps.clear();
+    pubSub = new InMemoryPubSub();
+    key = await createEncryptionKey();
+
+    server = new Server<Ctx>({
+      storage: async (ctx) => {
+        if (ctx.encrypted) {
+          return new EncryptedMemoryStorage();
+        }
+        return new YDocStorage();
+      },
+      pubSub,
+      rpcHandlers: {
+        ...getAttributionRpcHandlers(),
+      },
+    });
+
+    const ws = crossws({
+      hooks: getWebsocketHandlers<Ctx>({
+        server,
+        onUpgrade: async () => ({
+          context: { userId: "test-user", room: "test" },
+        }),
+      }),
+    });
+
+    bunServer = Bun.serve({
+      port: 0,
+      websocket: ws.websocket,
+      async fetch(request, bunSrv) {
+        if (request.headers.get("upgrade") === "websocket") {
+          return ws.handleUpgrade(request, bunSrv);
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+
+    baseUrl = `ws://localhost:${bunServer.port}`;
+  });
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0)) {
+      await cleanup();
+    }
+    bunServer.stop(true);
+    await server[Symbol.asyncDispose]();
+    await pubSub[Symbol.asyncDispose]();
+  });
+
+  function createWsConnection() {
+    const conn = new WebSocketConnection({
+      url: baseUrl,
+      connect: true,
+      maxReconnectAttempts: 0,
+      batchIntervalMs: 0,
+    });
+    cleanups.push(() => conn.destroy());
+    return conn;
+  }
+
+  async function createProvider(
+    document: string,
+    opts?: { ydoc?: Y.Doc; encryptionKey?: CryptoKey },
+  ) {
+    const conn = createWsConnection();
+    await conn.connected;
+    const provider = await Provider.create({
+      connection: conn,
+      document,
+      ydoc: opts?.ydoc,
+      encryptionKey: opts?.encryptionKey,
+      enableOfflinePersistence: false,
+    });
+    cleanups.push(() => provider.destroy());
+    return { provider, connection: conn };
+  }
+
+  function waitForSync(provider: Provider, timeoutMs = 5000): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`Sync timed out after ${timeoutMs}ms`)),
+        timeoutMs,
+      );
+      if (provider.transport.synced) {
+        provider.transport.synced.then(() => {
+          clearTimeout(timer);
+          resolve();
+        });
+      } else {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  }
+
+  it("unencrypted: getActivity returns attributed edits", async () => {
+    const { provider } = await createProvider("attr-unenc");
+    await waitForSync(provider);
+
+    provider.doc.getText("body").insert(0, "hello world");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const activity = await provider.getActivity();
+    expect(activity.length).toBeGreaterThan(0);
+    expect(activity[0].userId).toBe("test-user");
+  });
+
+  it("encrypted: getActivity returns attributed edits", async () => {
+    const { provider } = await createProvider("attr-enc", { encryptionKey: key });
+    await waitForSync(provider);
+
+    provider.doc.getText("body").insert(0, "encrypted hello");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const activity = await provider.getActivity();
+    expect(activity.length).toBeGreaterThan(0);
+    expect(activity[0].userId).toBe("test-user");
+  });
+
+  it("encrypted: getAttributionForRange resolves character-level authorship", async () => {
+    const { provider } = await createProvider("attr-enc-range", { encryptionKey: key });
+    await waitForSync(provider);
+
+    provider.doc.getText("body").insert(0, "hello");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const text = provider.doc.getText("body");
+    const segments = await provider.getAttributionForRange(text, 0, 5);
+    expect(segments.length).toBeGreaterThan(0);
+    expect(segments[0].userId).toBe("test-user");
+    expect(segments[0].from).toBe(0);
+    expect(segments[0].to).toBe(5);
+  });
+
+  it("encrypted: getAttributionMap returns non-null ContentMap", async () => {
+    const { provider } = await createProvider("attr-enc-map", { encryptionKey: key });
+    await waitForSync(provider);
+
+    provider.doc.getText("body").insert(0, "data");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const map = await provider.getAttributionMap();
+    expect(map).not.toBeNull();
+    expect(map!.inserts.clients.size).toBeGreaterThan(0);
   });
 });

--- a/src/transports/encrypted/e2e.test.ts
+++ b/src/transports/encrypted/e2e.test.ts
@@ -1002,14 +1002,35 @@ describe("attribution e2e: full WebSocket transport", () => {
     });
   }
 
+  /**
+   * Poll `fn` until `predicate` holds, returning its result. Replaces fixed
+   * sleeps when waiting for the server to persist attribution asynchronously,
+   * so the tests stay deterministic under slow CI.
+   */
+  async function waitFor<T>(
+    fn: () => Promise<T>,
+    predicate: (value: T) => boolean,
+    timeoutMs = 5000,
+  ): Promise<T> {
+    const start = Date.now();
+    while (true) {
+      const value = await fn();
+      if (predicate(value)) return value;
+      if (Date.now() - start > timeoutMs) return value;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  }
+
   it("unencrypted: getActivity returns attributed edits", async () => {
     const { provider } = await createProvider("attr-unenc");
     await waitForSync(provider);
 
     provider.doc.getText("body").insert(0, "hello world");
-    await new Promise((r) => setTimeout(r, 50));
 
-    const activity = await provider.getActivity();
+    const activity = await waitFor(
+      () => provider.getActivity(),
+      (a) => a.length > 0,
+    );
     expect(activity.length).toBeGreaterThan(0);
     expect(activity[0].userId).toBe("test-user");
   });
@@ -1019,9 +1040,11 @@ describe("attribution e2e: full WebSocket transport", () => {
     await waitForSync(provider);
 
     provider.doc.getText("body").insert(0, "encrypted hello");
-    await new Promise((r) => setTimeout(r, 50));
 
-    const activity = await provider.getActivity();
+    const activity = await waitFor(
+      () => provider.getActivity(),
+      (a) => a.length > 0,
+    );
     expect(activity.length).toBeGreaterThan(0);
     expect(activity[0].userId).toBe("test-user");
   });
@@ -1031,10 +1054,15 @@ describe("attribution e2e: full WebSocket transport", () => {
     await waitForSync(provider);
 
     provider.doc.getText("body").insert(0, "hello");
-    await new Promise((r) => setTimeout(r, 50));
 
     const text = provider.doc.getText("body");
-    const segments = await provider.getAttributionForRange(text, 0, 5);
+    const segments = await waitFor(
+      () => {
+        provider.invalidateAttributionCache();
+        return provider.getAttributionForRange(text, 0, 5);
+      },
+      (s) => s.length > 0,
+    );
     expect(segments.length).toBeGreaterThan(0);
     expect(segments[0].userId).toBe("test-user");
     expect(segments[0].from).toBe(0);
@@ -1046,9 +1074,11 @@ describe("attribution e2e: full WebSocket transport", () => {
     await waitForSync(provider);
 
     provider.doc.getText("body").insert(0, "data");
-    await new Promise((r) => setTimeout(r, 50));
 
-    const map = await provider.getAttributionMap();
+    const map = await waitFor(
+      () => provider.getAttributionMap(),
+      (m) => m !== null && m.inserts.clients.size > 0,
+    );
     expect(map).not.toBeNull();
     expect(map!.inserts.clients.size).toBeGreaterThan(0);
   });


### PR DESCRIPTION
Adds support for custom attribution attributes on document updates (via a new `attributionConfig.getAttributes` hook), surfaced through `getActivity`/`resolveAttribution`/`AttributedSegment` and filterable in the attribution RPC methods. Enables attribution for encrypted documents: the encryption client now populates `contentIds` on update payloads, and encrypted storage persists attribution via a `storeAttribution` hook. Unifies RPC authorization into the global `checkPermission` hook (write methods gated by an allowlist, reads default to `read` permission), removing the per-handler attribution gate. Also consolidates the provider's milestone/changeset activity APIs into a single `getActivity({ milestone | changeset })` entrypoint, delta-encodes IdMap client IDs, and adds extensive docs and tests.

Fixes a grouping bug in `getActivity`: built-in keys (`insert`/`insertAt`/`delete`/`deleteAt`) are now excluded from the entry-merge comparison so the 1s time-window grouping works again instead of being defeated by differing per-update timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added attribution system for collaborative documents with support for tracking authorship and custom metadata attributes.
  * Added activity filtering capabilities by user, milestone, and changeset.

* **Improvements**
  * Enhanced encryption handling for RPC messages and responses.
  * Strengthened permission controls for RPC method execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->