### PR TITLE
feat(storage): add TieredDocumentStorage, IDB file cache, benchmarks, and misc fixes

### DIFF
--- a/benchmarks/file.bench.test.ts
+++ b/benchmarks/file.bench.test.ts
@@ -6,7 +6,7 @@ import {
   verifyMerkleProof,
   serializeMerkleTree,
   deserializeMerkleTree,
-  createMerkleTreeTransformStream,
+  chunkFile,
   CHUNK_SIZE,
 } from "../src/merkle-tree/merkle-tree";
 import { InMemoryFileStorage } from "../src/storage/in-memory/file-storage";
@@ -121,7 +121,7 @@ describe("File Upload & Download Benchmarks", () => {
       );
     });
 
-    it("createMerkleTreeTransformStream vs plain function", async () => {
+    it("chunkFile (async generator) vs plain function", async () => {
       for (const sizeMB of [0.1, 1, 10]) {
         const fileSize = Math.floor(sizeMB * 1024 * 1024);
         const data = new Uint8Array(fileSize);
@@ -129,27 +129,22 @@ describe("File Upload & Download Benchmarks", () => {
         const iters = sizeMB >= 10 ? 5 : 20;
 
         await bench(
-          `transformStream (${sizeMB}MB)`,
+          `chunkFile (${sizeMB}MB)`,
           async () => {
-            const stream = createMerkleTreeTransformStream(fileSize);
-            const writer = stream.writable.getWriter();
-
-            const drain = (async () => {
-              const reader = stream.readable.getReader();
-              while (true) {
-                const { done } = await reader.read();
-                if (done) break;
-              }
-            })();
-
-            let offset = 0;
-            while (offset < fileSize) {
-              const end = Math.min(offset + CHUNK_SIZE, fileSize);
-              await writer.write(data.subarray(offset, end));
-              offset = end;
+            const stream = new ReadableStream<Uint8Array>({
+              start(controller) {
+                let offset = 0;
+                while (offset < fileSize) {
+                  const end = Math.min(offset + CHUNK_SIZE, fileSize);
+                  controller.enqueue(data.subarray(offset, end));
+                  offset = end;
+                }
+                controller.close();
+              },
+            });
+            for await (const _part of chunkFile(stream, fileSize)) {
+              // consume
             }
-            await writer.close();
-            await drain;
           },
           { iterations: iters },
         );

--- a/benchmarks/file.bench.test.ts
+++ b/benchmarks/file.bench.test.ts
@@ -1,0 +1,364 @@
+import { describe, it } from "bun:test";
+import { toBase64 } from "lib0/buffer";
+import {
+  buildMerkleTree,
+  generateMerkleProof,
+  verifyMerkleProof,
+  serializeMerkleTree,
+  deserializeMerkleTree,
+  createMerkleTreeTransformStream,
+  CHUNK_SIZE,
+} from "../src/merkle-tree/merkle-tree";
+import { InMemoryFileStorage } from "../src/storage/in-memory/file-storage";
+import { InMemoryTemporaryUploadStorage } from "../src/storage/in-memory/temporary-upload-storage";
+import type { FileMetadata } from "../src/storage/types";
+import { bench, benchBatch, formatBytes } from "./helpers";
+
+function makeChunks(fileSize: number): Uint8Array[] {
+  const count = Math.max(1, Math.ceil(fileSize / CHUNK_SIZE));
+  const chunks: Uint8Array[] = [];
+  let remaining = fileSize;
+  for (let i = 0; i < count; i++) {
+    const size = Math.min(CHUNK_SIZE, remaining);
+    const chunk = new Uint8Array(size);
+    crypto.getRandomValues(chunk);
+    chunks.push(chunk);
+    remaining -= size;
+  }
+  return chunks;
+}
+
+function makeMetadata(fileSize: number): FileMetadata {
+  return {
+    filename: "bench-file.bin",
+    size: fileSize,
+    mimeType: "application/octet-stream",
+    encrypted: false,
+    lastModified: Date.now(),
+    documentId: "bench-doc",
+  };
+}
+
+async function uploadFile(
+  temp: InMemoryTemporaryUploadStorage,
+  fileStorage: InMemoryFileStorage,
+  chunks: Uint8Array[],
+  fileSize: number,
+) {
+  const uploadId = `upload-${Math.random()}`;
+  const merkleTree = buildMerkleTree(chunks);
+  const fileId = toBase64(merkleTree.nodes.at(-1)!.hash!);
+
+  await temp.beginUpload(uploadId, makeMetadata(fileSize));
+  for (let i = 0; i < chunks.length; i++) {
+    await temp.storeChunk(uploadId, i, chunks[i], []);
+  }
+  const result = await temp.completeUpload(uploadId, fileId);
+  await fileStorage.storeFileFromUpload(result);
+  return fileId;
+}
+
+describe("File Upload & Download Benchmarks", () => {
+  describe("Merkle Tree", () => {
+    it("buildMerkleTree - various chunk counts", async () => {
+      for (const count of [1, 10, 100, 1000]) {
+        const chunks = makeChunks(count * CHUNK_SIZE);
+        console.log(`    ${count} chunks → ${formatBytes(count * CHUNK_SIZE)}`);
+        await bench(
+          `buildMerkleTree (${count} chunks)`,
+          () => { buildMerkleTree(chunks); },
+          { iterations: count > 100 ? 20 : 100 },
+        );
+      }
+    });
+
+    it("generateMerkleProof", async () => {
+      const chunks = makeChunks(100 * CHUNK_SIZE);
+      const tree = buildMerkleTree(chunks);
+
+      let i = 0;
+      await bench(
+        "generateMerkleProof (100-chunk tree)",
+        () => { generateMerkleProof(tree, i++ % 100); },
+        { iterations: 1000 },
+      );
+    });
+
+    it("verifyMerkleProof", async () => {
+      const chunks = makeChunks(100 * CHUNK_SIZE);
+      const tree = buildMerkleTree(chunks);
+      const root = tree.nodes.at(-1)!.hash!;
+      const proofs = chunks.map((_, i) => generateMerkleProof(tree, i));
+
+      let i = 0;
+      await bench(
+        "verifyMerkleProof (100-chunk tree)",
+        () => {
+          const idx = i++ % 100;
+          verifyMerkleProof(chunks[idx], proofs[idx], root, idx);
+        },
+        { iterations: 1000 },
+      );
+    });
+
+    it("serialize + deserialize merkle tree", async () => {
+      const chunks = makeChunks(100 * CHUNK_SIZE);
+      const tree = buildMerkleTree(chunks);
+
+      await bench(
+        "serializeMerkleTree (100 chunks)",
+        () => { serializeMerkleTree(tree); },
+        { iterations: 500 },
+      );
+
+      const serialized = serializeMerkleTree(tree);
+      console.log(`    serialized size: ${formatBytes(serialized.byteLength)}`);
+
+      await bench(
+        "deserializeMerkleTree (100 chunks)",
+        () => { deserializeMerkleTree(serialized, 100); },
+        { iterations: 500 },
+      );
+    });
+
+    it("createMerkleTreeTransformStream vs plain function", async () => {
+      for (const sizeMB of [0.1, 1, 10]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const data = new Uint8Array(fileSize);
+        crypto.getRandomValues(data);
+        const iters = sizeMB >= 10 ? 5 : 20;
+
+        await bench(
+          `transformStream (${sizeMB}MB)`,
+          async () => {
+            const stream = createMerkleTreeTransformStream(fileSize);
+            const writer = stream.writable.getWriter();
+
+            const drain = (async () => {
+              const reader = stream.readable.getReader();
+              while (true) {
+                const { done } = await reader.read();
+                if (done) break;
+              }
+            })();
+
+            let offset = 0;
+            while (offset < fileSize) {
+              const end = Math.min(offset + CHUNK_SIZE, fileSize);
+              await writer.write(data.subarray(offset, end));
+              offset = end;
+            }
+            await writer.close();
+            await drain;
+          },
+          { iterations: iters },
+        );
+
+        await bench(
+          `plain chunk+tree+proofs (${sizeMB}MB)`,
+          () => {
+            const chunks: Uint8Array[] = [];
+            let offset = 0;
+            while (offset < fileSize) {
+              const end = Math.min(offset + CHUNK_SIZE, fileSize);
+              chunks.push(data.subarray(offset, end));
+              offset = end;
+            }
+            const tree = buildMerkleTree(chunks);
+            for (let i = 0; i < chunks.length; i++) {
+              generateMerkleProof(tree, i);
+            }
+          },
+          { iterations: iters },
+        );
+      }
+    });
+  });
+
+  describe("Upload Pipeline", () => {
+    it("beginUpload", async () => {
+      const temp = new InMemoryTemporaryUploadStorage();
+      let i = 0;
+      await bench(
+        "beginUpload",
+        () => temp.beginUpload(`upload-${i++}`, makeMetadata(1024)),
+        { iterations: 1000 },
+      );
+    });
+
+    it("storeChunk - single chunk", async () => {
+      const temp = new InMemoryTemporaryUploadStorage();
+      const chunk = new Uint8Array(CHUNK_SIZE);
+      crypto.getRandomValues(chunk);
+
+      await temp.beginUpload("store-bench", makeMetadata(CHUNK_SIZE));
+
+      await bench(
+        `storeChunk (${formatBytes(CHUNK_SIZE)})`,
+        async () => {
+          await temp.storeChunk("store-bench", 0, chunk, []);
+        },
+        { iterations: 500 },
+      );
+    });
+
+    it("full upload - small file (single chunk)", async () => {
+      const temp = new InMemoryTemporaryUploadStorage();
+      const fileStorage = new InMemoryFileStorage({ temporaryUploadStorage: temp });
+
+      const fileSize = 1024;
+      const chunks = makeChunks(fileSize);
+
+      await bench(
+        `full upload (${formatBytes(fileSize)})`,
+        async () => {
+          await uploadFile(temp, fileStorage, chunks, fileSize);
+        },
+        { iterations: 200 },
+      );
+    });
+
+    it("full upload - various sizes", async () => {
+      for (const sizeMB of [0.064, 0.5, 1, 5]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunks = makeChunks(fileSize);
+        const temp = new InMemoryTemporaryUploadStorage();
+        const fileStorage = new InMemoryFileStorage({ temporaryUploadStorage: temp });
+
+        console.log(`    ${sizeMB}MB → ${chunks.length} chunks`);
+        await bench(
+          `full upload (${sizeMB}MB, ${chunks.length} chunks)`,
+          () => uploadFile(temp, fileStorage, chunks, fileSize),
+          { iterations: sizeMB >= 5 ? 5 : 20 },
+        );
+      }
+    });
+
+    it("completeUpload (merkle build + validation)", async () => {
+      for (const count of [1, 10, 100]) {
+        const fileSize = count * CHUNK_SIZE;
+        const chunks = makeChunks(fileSize);
+        const merkleTree = buildMerkleTree(chunks);
+        const fileId = toBase64(merkleTree.nodes.at(-1)!.hash!);
+
+        await bench(
+          `completeUpload (${count} chunks)`,
+          async () => {
+            const temp = new InMemoryTemporaryUploadStorage();
+            const uploadId = `complete-${Math.random()}`;
+            await temp.beginUpload(uploadId, makeMetadata(fileSize));
+            for (let i = 0; i < chunks.length; i++) {
+              await temp.storeChunk(uploadId, i, chunks[i], []);
+            }
+            await temp.completeUpload(uploadId, fileId);
+          },
+          { iterations: count > 50 ? 10 : 50 },
+        );
+      }
+    });
+  });
+
+  describe("Download Pipeline", () => {
+    it("getFile - various sizes", async () => {
+      for (const sizeMB of [0.064, 1, 5]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunks = makeChunks(fileSize);
+        const temp = new InMemoryTemporaryUploadStorage();
+        const fileStorage = new InMemoryFileStorage({ temporaryUploadStorage: temp });
+        const fileId = await uploadFile(temp, fileStorage, chunks, fileSize);
+
+        await bench(
+          `getFile (${sizeMB}MB)`,
+          () => fileStorage.getFile(fileId),
+          { iterations: 500 },
+        );
+      }
+    });
+
+    it("rebuild merkle tree + generate all proofs (download prep)", async () => {
+      for (const count of [10, 100]) {
+        const chunks = makeChunks(count * CHUNK_SIZE);
+
+        await bench(
+          `build tree + all proofs (${count} chunks)`,
+          () => {
+            const tree = buildMerkleTree(chunks);
+            for (let i = 0; i < count; i++) {
+              generateMerkleProof(tree, i);
+            }
+          },
+          { iterations: count > 50 ? 10 : 50 },
+        );
+      }
+    });
+
+    it("full download simulation (getFile + verify all chunks)", async () => {
+      for (const sizeMB of [0.064, 1]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunks = makeChunks(fileSize);
+        const temp = new InMemoryTemporaryUploadStorage();
+        const fileStorage = new InMemoryFileStorage({ temporaryUploadStorage: temp });
+        const fileId = await uploadFile(temp, fileStorage, chunks, fileSize);
+
+        await bench(
+          `full download + verify (${sizeMB}MB)`,
+          async () => {
+            const file = await fileStorage.getFile(fileId);
+            if (!file) throw new Error("File not found");
+            const tree = buildMerkleTree(file.chunks);
+            const root = tree.nodes.at(-1)!.hash!;
+            for (let i = 0; i < file.chunks.length; i++) {
+              const proof = generateMerkleProof(tree, i);
+              verifyMerkleProof(file.chunks[i], proof, root, i);
+            }
+          },
+          { iterations: 20 },
+        );
+      }
+    });
+  });
+
+  describe("Chunk-level I/O", () => {
+    it("storeChunk throughput", async () => {
+      const chunk = new Uint8Array(CHUNK_SIZE);
+      crypto.getRandomValues(chunk);
+
+      const batchSize = 100;
+      await benchBatch(
+        `store ${batchSize} chunks (${formatBytes(CHUNK_SIZE)} each)`,
+        async () => {
+          const temp = new InMemoryTemporaryUploadStorage();
+          await temp.beginUpload("throughput", makeMetadata(batchSize * CHUNK_SIZE));
+          for (let i = 0; i < batchSize; i++) {
+            await temp.storeChunk("throughput", i, chunk, []);
+          }
+        },
+        { batchSize, iterations: 10 },
+      );
+    });
+
+    it("getChunk throughput (from completed upload)", async () => {
+      const count = 100;
+      const fileSize = count * CHUNK_SIZE;
+      const chunks = makeChunks(fileSize);
+      const merkleTree = buildMerkleTree(chunks);
+      const fileId = toBase64(merkleTree.nodes.at(-1)!.hash!);
+
+      await benchBatch(
+        `getChunk ×${count} (${formatBytes(CHUNK_SIZE)} each)`,
+        async () => {
+          const temp = new InMemoryTemporaryUploadStorage();
+          await temp.beginUpload("getchunk", makeMetadata(fileSize));
+          for (let i = 0; i < count; i++) {
+            await temp.storeChunk("getchunk", i, chunks[i], []);
+          }
+          const result = await temp.completeUpload("getchunk", fileId);
+          for (let i = 0; i < count; i++) {
+            await result.getChunk(i);
+          }
+        },
+        { batchSize: count, iterations: 10 },
+      );
+    });
+  });
+});

--- a/benchmarks/file.bench.test.ts
+++ b/benchmarks/file.bench.test.ts
@@ -12,6 +12,9 @@ import {
 import { InMemoryFileStorage } from "../src/storage/in-memory/file-storage";
 import { InMemoryTemporaryUploadStorage } from "../src/storage/in-memory/temporary-upload-storage";
 import type { FileMetadata } from "../src/storage/types";
+import { createEncryptionKey } from "../src/encryption-key";
+import { encryptUpdate, decryptUpdate } from "../src/encryption-key";
+import { FileHandler } from "../src/protocols/file/server";
 import { bench, benchBatch, formatBytes } from "./helpers";
 
 function makeChunks(fileSize: number): Uint8Array[] {
@@ -66,7 +69,9 @@ describe("File Upload & Download Benchmarks", () => {
         console.log(`    ${count} chunks → ${formatBytes(count * CHUNK_SIZE)}`);
         await bench(
           `buildMerkleTree (${count} chunks)`,
-          () => { buildMerkleTree(chunks); },
+          () => {
+            buildMerkleTree(chunks);
+          },
           { iterations: count > 100 ? 20 : 100 },
         );
       }
@@ -79,7 +84,9 @@ describe("File Upload & Download Benchmarks", () => {
       let i = 0;
       await bench(
         "generateMerkleProof (100-chunk tree)",
-        () => { generateMerkleProof(tree, i++ % 100); },
+        () => {
+          generateMerkleProof(tree, i++ % 100);
+        },
         { iterations: 1000 },
       );
     });
@@ -107,7 +114,9 @@ describe("File Upload & Download Benchmarks", () => {
 
       await bench(
         "serializeMerkleTree (100 chunks)",
-        () => { serializeMerkleTree(tree); },
+        () => {
+          serializeMerkleTree(tree);
+        },
         { iterations: 500 },
       );
 
@@ -116,7 +125,9 @@ describe("File Upload & Download Benchmarks", () => {
 
       await bench(
         "deserializeMerkleTree (100 chunks)",
-        () => { deserializeMerkleTree(serialized, 100); },
+        () => {
+          deserializeMerkleTree(serialized, 100);
+        },
         { iterations: 500 },
       );
     });
@@ -174,11 +185,9 @@ describe("File Upload & Download Benchmarks", () => {
     it("beginUpload", async () => {
       const temp = new InMemoryTemporaryUploadStorage();
       let i = 0;
-      await bench(
-        "beginUpload",
-        () => temp.beginUpload(`upload-${i++}`, makeMetadata(1024)),
-        { iterations: 1000 },
-      );
+      await bench("beginUpload", () => temp.beginUpload(`upload-${i++}`, makeMetadata(1024)), {
+        iterations: 1000,
+      });
     });
 
     it("storeChunk - single chunk", async () => {
@@ -262,11 +271,9 @@ describe("File Upload & Download Benchmarks", () => {
         const fileStorage = new InMemoryFileStorage({ temporaryUploadStorage: temp });
         const fileId = await uploadFile(temp, fileStorage, chunks, fileSize);
 
-        await bench(
-          `getFile (${sizeMB}MB)`,
-          () => fileStorage.getFile(fileId),
-          { iterations: 500 },
-        );
+        await bench(`getFile (${sizeMB}MB)`, () => fileStorage.getFile(fileId), {
+          iterations: 500,
+        });
       }
     });
 
@@ -354,6 +361,131 @@ describe("File Upload & Download Benchmarks", () => {
         },
         { batchSize: count, iterations: 10 },
       );
+    });
+  });
+
+  describe("Encrypted Download Breakdown", () => {
+    it("server: streamFileParts (build tree + proofs + yield)", async () => {
+      for (const sizeMB of [0.5, 1, 5]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunks = makeChunks(fileSize);
+        const temp = new InMemoryTemporaryUploadStorage();
+        const fileStorage = new InMemoryFileStorage({ temporaryUploadStorage: temp });
+        const fileId = await uploadFile(temp, fileStorage, chunks, fileSize);
+        const handler = new FileHandler(fileStorage);
+
+        await bench(
+          `streamFileParts (${sizeMB}MB, ${chunks.length} chunks)`,
+          async () => {
+            for await (const _part of handler.streamFileParts(fileId)) {
+              // consume
+            }
+          },
+          { iterations: sizeMB >= 5 ? 5 : 20 },
+        );
+      }
+    });
+
+    it("client: decrypt all chunks", async () => {
+      const key = await createEncryptionKey();
+
+      for (const sizeMB of [0.5, 1, 5]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunkCount = Math.ceil(fileSize / CHUNK_SIZE);
+        const encrypted: Uint8Array[] = [];
+        for (let i = 0; i < chunkCount; i++) {
+          const plain = new Uint8Array(CHUNK_SIZE);
+          crypto.getRandomValues(plain);
+          encrypted.push(await encryptUpdate(key, plain));
+        }
+
+        await bench(
+          `decrypt ${chunkCount} chunks (${sizeMB}MB)`,
+          async () => {
+            for (const enc of encrypted) {
+              await decryptUpdate(key, enc);
+            }
+          },
+          { iterations: sizeMB >= 5 ? 5 : 20 },
+        );
+      }
+    });
+
+    it("client: verify all chunks (merkle proof)", async () => {
+      for (const sizeMB of [0.5, 1, 5]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunks = makeChunks(fileSize);
+        const tree = buildMerkleTree(chunks);
+        const root = tree.nodes.at(-1)!.hash!;
+        const proofs = chunks.map((_, i) => generateMerkleProof(tree, i));
+
+        await bench(
+          `verify ${chunks.length} chunks (${sizeMB}MB)`,
+          () => {
+            for (let i = 0; i < chunks.length; i++) {
+              verifyMerkleProof(chunks[i], proofs[i], root, i);
+            }
+          },
+          { iterations: sizeMB >= 5 ? 5 : 20 },
+        );
+      }
+    });
+
+    it("client: reassemble file from chunks", async () => {
+      for (const sizeMB of [0.5, 1, 5]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunks = makeChunks(fileSize);
+        const chunkMap = new Map(chunks.map((c, i) => [i, c]));
+
+        await bench(
+          `reassemble (${sizeMB}MB, ${chunks.length} chunks)`,
+          () => {
+            const buf = new Uint8Array(chunks.length * CHUNK_SIZE);
+            let offset = 0;
+            for (let i = 0; i < chunks.length; i++) {
+              const chunk = chunkMap.get(i)!;
+              buf.set(chunk, offset);
+              offset += chunk.length;
+            }
+            new File([buf.slice(0, offset)], "bench.bin", { type: "application/octet-stream" });
+          },
+          { iterations: 20 },
+        );
+      }
+    });
+
+    it("full encrypted download (optimized: parallel verify+decrypt, BlobParts)", async () => {
+      const key = await createEncryptionKey();
+
+      for (const sizeMB of [0.5, 1, 3, 5]) {
+        const fileSize = Math.floor(sizeMB * 1024 * 1024);
+        const chunkCount = Math.ceil(fileSize / CHUNK_SIZE);
+
+        const plainChunks = makeChunks(fileSize);
+        const encryptedChunks: Uint8Array[] = [];
+        for (const chunk of plainChunks) {
+          encryptedChunks.push(await encryptUpdate(key, chunk));
+        }
+
+        const tree = buildMerkleTree(encryptedChunks);
+        const root = tree.nodes.at(-1)!.hash!;
+        const proofs = encryptedChunks.map((_, i) => generateMerkleProof(tree, i));
+
+        await bench(
+          `full encrypted download (${sizeMB}MB, ${chunkCount} chunks)`,
+          async () => {
+            const parts: Uint8Array[] = [];
+            for (let i = 0; i < chunkCount; i++) {
+              // Kick off decrypt before sync verify (matches optimized client code)
+              const decryptPromise = decryptUpdate(key, encryptedChunks[i]);
+              verifyMerkleProof(encryptedChunks[i], proofs[i], root, i);
+              parts.push(await decryptPromise);
+            }
+            new File(parts as BlobPart[], "bench.bin", { type: "image/png" });
+          },
+          { iterations: sizeMB >= 5 ? 5 : 10 },
+        );
+      }
     });
   });
 });

--- a/benchmarks/helpers.ts
+++ b/benchmarks/helpers.ts
@@ -1,0 +1,254 @@
+import * as Y from "yjs";
+import { Server } from "../src/server/server";
+import { Connection } from "../src/providers/connection";
+import { Provider } from "../src/providers/provider";
+import { MemoryDocumentStorage } from "../src/storage/in-memory/document-storage";
+import { createMemoryTransportPair } from "../src/providers/transports/memory";
+import {
+  InMemoryPubSub,
+  type Message,
+  type ServerContext,
+  type Transport,
+} from "teleportal";
+import { createChannel } from "../src/lib/iter";
+
+class BenchTransport<Context extends ServerContext> implements Transport<Context> {
+  public source: AsyncIterable<Message<Context>[]>;
+  #channel = createChannel<Message<Context>>();
+
+  constructor() {
+    this.source = this.#channel;
+  }
+
+  write(_message: Message<Context>): void {}
+  close(): void {}
+  async destroy() {}
+
+  enqueueMessage(message: Message<Context>) {
+    try {
+      this.#channel.send(message);
+    } catch {}
+  }
+
+  closeReadable() {
+    this.#channel.close();
+  }
+
+  [key: string]: unknown;
+}
+
+export function createBenchServer(storage?: MemoryDocumentStorage) {
+  const pubSub = new InMemoryPubSub();
+  const docStorage = storage ?? new MemoryDocumentStorage(false);
+  const server = new Server<ServerContext>({
+    storage: docStorage,
+    pubSub,
+  });
+  return { server, storage: docStorage, pubSub };
+}
+
+export async function createBenchServerWithClient(
+  storage?: MemoryDocumentStorage,
+) {
+  const { server, storage: docStorage, pubSub } = createBenchServer(storage);
+  const transport = new BenchTransport<ServerContext>();
+  const client = server.createClient({ transport });
+  return { server, storage: docStorage, pubSub, transport, client };
+}
+
+export async function createConnectedProviderPair(opts?: {
+  document?: string;
+}) {
+  const document = opts?.document ?? "bench-doc";
+  const storage = new MemoryDocumentStorage(false);
+  const { server, pubSub } = createBenchServer(storage);
+
+  const transport1 = new BenchTransport<ServerContext>();
+  server.createClient({ transport: transport1 });
+
+  const transport2 = new BenchTransport<ServerContext>();
+  server.createClient({ transport: transport2 });
+
+  const [clientTransport1, _serverTransport1] = createMemoryTransportPair();
+  const conn1 = new Connection({
+    transports: [clientTransport1],
+    connect: false,
+    batchIntervalMs: 0,
+  });
+
+  const [clientTransport2, _serverTransport2] = createMemoryTransportPair();
+  const conn2 = new Connection({
+    transports: [clientTransport2],
+    connect: false,
+    batchIntervalMs: 0,
+  });
+
+  await Promise.all([conn1.connect(), conn2.connect()]);
+
+  const provider1 = new Provider({
+    connection: conn1,
+    document,
+    encryptionKey: false,
+    enableOfflinePersistence: false,
+  });
+
+  const provider2 = new Provider({
+    connection: conn2,
+    document,
+    encryptionKey: false,
+    enableOfflinePersistence: false,
+  });
+
+  return {
+    provider1,
+    provider2,
+    conn1,
+    conn2,
+    server,
+    storage,
+    pubSub,
+    async cleanup() {
+      provider1.destroy();
+      provider2.destroy();
+      await server[Symbol.asyncDispose]();
+      await pubSub[Symbol.asyncDispose]();
+    },
+  };
+}
+
+export function flush(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+export function createTestUpdate(content = "test"): Uint8Array {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, content);
+  return Y.encodeStateAsUpdateV2(doc);
+}
+
+export function createLargeDoc(charCount: number): Y.Doc {
+  const doc = new Y.Doc();
+  const text = doc.getText("content");
+  const chunk = "x".repeat(Math.min(charCount, 1000));
+  for (let i = 0; i < charCount; i += chunk.length) {
+    text.insert(i, chunk.substring(0, Math.min(chunk.length, charCount - i)));
+  }
+  return doc;
+}
+
+export function formatOps(ops: number, durationMs: number): string {
+  const opsPerSec = (ops / durationMs) * 1000;
+  if (opsPerSec >= 1_000_000) return `${(opsPerSec / 1_000_000).toFixed(1)}M ops/s`;
+  if (opsPerSec >= 1_000) return `${(opsPerSec / 1_000).toFixed(1)}K ops/s`;
+  return `${opsPerSec.toFixed(0)} ops/s`;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${bytes} B`;
+}
+
+export function formatDuration(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  if (ms >= 1) return `${ms.toFixed(2)}ms`;
+  return `${(ms * 1000).toFixed(0)}μs`;
+}
+
+type BenchResult = {
+  name: string;
+  iterations: number;
+  totalMs: number;
+  avgMs: number;
+  minMs: number;
+  maxMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  p99Ms: number;
+  opsPerSec: number;
+};
+
+export async function bench(
+  name: string,
+  fn: () => unknown,
+  opts?: { iterations?: number; warmup?: number },
+): Promise<BenchResult> {
+  const iterations = opts?.iterations ?? 100;
+  const warmup = opts?.warmup ?? Math.min(10, Math.floor(iterations / 10));
+
+  for (let i = 0; i < warmup; i++) {
+    await fn();
+  }
+
+  const times: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now();
+    await fn();
+    times.push(performance.now() - start);
+  }
+
+  times.sort((a, b) => a - b);
+  const totalMs = times.reduce((s, t) => s + t, 0);
+
+  const result: BenchResult = {
+    name,
+    iterations,
+    totalMs,
+    avgMs: totalMs / iterations,
+    minMs: times[0],
+    maxMs: times[times.length - 1],
+    p50Ms: times[Math.floor(iterations * 0.5)],
+    p95Ms: times[Math.floor(iterations * 0.95)],
+    p99Ms: times[Math.floor(iterations * 0.99)],
+    opsPerSec: (iterations / totalMs) * 1000,
+  };
+
+  console.log(
+    `  ${name}: avg=${formatDuration(result.avgMs)} p50=${formatDuration(result.p50Ms)} p95=${formatDuration(result.p95Ms)} p99=${formatDuration(result.p99Ms)} (${formatOps(iterations, totalMs)})`,
+  );
+
+  return result;
+}
+
+export async function benchBatch(
+  name: string,
+  fn: () => unknown,
+  opts: { batchSize: number; iterations?: number; warmup?: number },
+): Promise<BenchResult> {
+  const iterations = opts.iterations ?? 10;
+  const warmup = opts.warmup ?? 2;
+
+  for (let i = 0; i < warmup; i++) {
+    await fn();
+  }
+
+  const times: number[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const start = performance.now();
+    await fn();
+    times.push(performance.now() - start);
+  }
+
+  times.sort((a, b) => a - b);
+  const totalMs = times.reduce((s, t) => s + t, 0);
+  const totalOps = iterations * opts.batchSize;
+
+  const result: BenchResult = {
+    name,
+    iterations,
+    totalMs,
+    avgMs: totalMs / iterations,
+    minMs: times[0],
+    maxMs: times[times.length - 1],
+    p50Ms: times[Math.floor(iterations * 0.5)],
+    p95Ms: times[Math.floor(iterations * 0.95)],
+    p99Ms: times[Math.floor(iterations * 0.99)],
+    opsPerSec: (totalOps / totalMs) * 1000,
+  };
+
+  console.log(
+    `  ${name}: avg=${formatDuration(result.avgMs)} p50=${formatDuration(result.p50Ms)} p95=${formatDuration(result.p95Ms)} (${formatOps(totalOps, totalMs)}, ${opts.batchSize} ops/iter)`,
+  );
+
+  return result;
+}

--- a/benchmarks/helpers.ts
+++ b/benchmarks/helpers.ts
@@ -4,12 +4,7 @@ import { Connection } from "../src/providers/connection";
 import { Provider } from "../src/providers/provider";
 import { MemoryDocumentStorage } from "../src/storage/in-memory/document-storage";
 import { createMemoryTransportPair } from "../src/providers/transports/memory";
-import {
-  InMemoryPubSub,
-  type Message,
-  type ServerContext,
-  type Transport,
-} from "teleportal";
+import { InMemoryPubSub, type Message, type ServerContext, type Transport } from "teleportal";
 import { createChannel } from "../src/lib/iter";
 
 class BenchTransport<Context extends ServerContext> implements Transport<Context> {
@@ -47,18 +42,14 @@ export function createBenchServer(storage?: MemoryDocumentStorage) {
   return { server, storage: docStorage, pubSub };
 }
 
-export async function createBenchServerWithClient(
-  storage?: MemoryDocumentStorage,
-) {
+export async function createBenchServerWithClient(storage?: MemoryDocumentStorage) {
   const { server, storage: docStorage, pubSub } = createBenchServer(storage);
   const transport = new BenchTransport<ServerContext>();
   const client = server.createClient({ transport });
   return { server, storage: docStorage, pubSub, transport, client };
 }
 
-export async function createConnectedProviderPair(opts?: {
-  document?: string;
-}) {
+export async function createConnectedProviderPair(opts?: { document?: string }) {
   const document = opts?.document ?? "bench-doc";
   const storage = new MemoryDocumentStorage(false);
   const { server, pubSub } = createBenchServer(storage);

--- a/benchmarks/protocol.bench.test.ts
+++ b/benchmarks/protocol.bench.test.ts
@@ -1,0 +1,172 @@
+import { describe, it } from "bun:test";
+import * as Y from "yjs";
+import {
+  encodeContentEncryptedPayload,
+  decodeContentEncryptedPayload,
+  getEmptyContentEncryptedPayload,
+} from "../src/lib/protocol/encryption/encoding";
+import { createEncryptionKey } from "../src/encryption-key";
+import { EncryptionClient } from "../src/transports/encrypted";
+import { bench, createLargeDoc, formatBytes } from "./helpers";
+
+describe("Protocol Benchmarks", () => {
+  describe("Content Encrypted Payload encoding", () => {
+    it("encode - empty payload", async () => {
+      await bench(
+        "encode empty payload",
+        () => { getEmptyContentEncryptedPayload(); },
+        { iterations: 5000 },
+      );
+    });
+
+    it("encode - small payload", async () => {
+      const doc = new Y.Doc();
+      doc.getText("t").insert(0, "hello world");
+      const update = Y.encodeStateAsUpdateV2(doc);
+
+      await bench(
+        "encode small payload",
+        () => {
+          encodeContentEncryptedPayload({
+            structureUpdate: update,
+            encryptedSidecars: [],
+          });
+        },
+        { iterations: 2000 },
+      );
+    });
+
+    it("encode - payload with sidecars", async () => {
+      const doc = createLargeDoc(5_000);
+      const update = Y.encodeStateAsUpdateV2(doc);
+      const sidecar = new Uint8Array(1024);
+      crypto.getRandomValues(sidecar);
+
+      await bench(
+        "encode payload with 1 sidecar",
+        () => {
+          encodeContentEncryptedPayload({
+            structureUpdate: update,
+            encryptedSidecars: [sidecar],
+          });
+        },
+        { iterations: 500 },
+      );
+    });
+
+    it("decode - round trip", async () => {
+      const doc = createLargeDoc(1_000);
+      const update = Y.encodeStateAsUpdateV2(doc);
+      const encoded = encodeContentEncryptedPayload({
+        structureUpdate: update,
+        encryptedSidecars: [],
+      });
+      console.log(`    encoded size: ${formatBytes(encoded.byteLength)}`);
+
+      await bench(
+        "decode payload (1K chars)",
+        () => { decodeContentEncryptedPayload(encoded); },
+        { iterations: 2000 },
+      );
+    });
+
+    it("encode+decode throughput - various sizes", async () => {
+      for (const size of [100, 1_000, 10_000]) {
+        const doc = createLargeDoc(size);
+        const update = Y.encodeStateAsUpdateV2(doc);
+
+        await bench(
+          `encode+decode (${size} chars)`,
+          () => {
+            const encoded = encodeContentEncryptedPayload({
+              structureUpdate: update,
+              encryptedSidecars: [],
+            });
+            decodeContentEncryptedPayload(encoded);
+          },
+          { iterations: size > 5_000 ? 100 : 500 },
+        );
+      }
+    });
+  });
+
+  describe("Encryption", () => {
+    it("createEncryptionKey", async () => {
+      await bench(
+        "createEncryptionKey",
+        () => createEncryptionKey(),
+        { iterations: 200 },
+      );
+    });
+
+    it("EncryptionClient - encrypt small update", async () => {
+      const key = await createEncryptionKey();
+      const doc = new Y.Doc();
+      doc.getText("t").insert(0, "hello");
+
+      const client = new EncryptionClient({
+        document: "bench-doc",
+        ydoc: doc,
+        awareness: null as any,
+        key,
+      });
+
+      const update = Y.encodeStateAsUpdateV2(doc);
+
+      await bench(
+        "encrypt small update",
+        async () => {
+          await client.encryptUpdate(update);
+        },
+        { iterations: 500 },
+      );
+    });
+
+    it("EncryptionClient - encrypt large update", async () => {
+      const key = await createEncryptionKey();
+      const doc = createLargeDoc(10_000);
+
+      const client = new EncryptionClient({
+        document: "bench-doc",
+        ydoc: doc,
+        awareness: null as any,
+        key,
+      });
+
+      const update = Y.encodeStateAsUpdateV2(doc);
+      console.log(`    update size: ${formatBytes(update.byteLength)}`);
+
+      await bench(
+        "encrypt large update (10K chars)",
+        async () => {
+          await client.encryptUpdate(update);
+        },
+        { iterations: 100 },
+      );
+    });
+
+    it("EncryptionClient - encrypt + decrypt round trip", async () => {
+      const key = await createEncryptionKey();
+      const doc = new Y.Doc();
+      doc.getText("t").insert(0, "benchmark content");
+
+      const client = new EncryptionClient({
+        document: "bench-doc",
+        ydoc: doc,
+        awareness: null as any,
+        key,
+      });
+
+      const update = Y.encodeStateAsUpdateV2(doc);
+
+      await bench(
+        "encrypt + decrypt round trip",
+        async () => {
+          const encrypted = await client.encryptUpdate(update);
+          await client.decryptUpdate(encrypted);
+        },
+        { iterations: 200 },
+      );
+    });
+  });
+});

--- a/benchmarks/protocol.bench.test.ts
+++ b/benchmarks/protocol.bench.test.ts
@@ -14,7 +14,9 @@ describe("Protocol Benchmarks", () => {
     it("encode - empty payload", async () => {
       await bench(
         "encode empty payload",
-        () => { getEmptyContentEncryptedPayload(); },
+        () => {
+          getEmptyContentEncryptedPayload();
+        },
         { iterations: 5000 },
       );
     });
@@ -65,7 +67,9 @@ describe("Protocol Benchmarks", () => {
 
       await bench(
         "decode payload (1K chars)",
-        () => { decodeContentEncryptedPayload(encoded); },
+        () => {
+          decodeContentEncryptedPayload(encoded);
+        },
         { iterations: 2000 },
       );
     });
@@ -92,11 +96,7 @@ describe("Protocol Benchmarks", () => {
 
   describe("Encryption", () => {
     it("createEncryptionKey", async () => {
-      await bench(
-        "createEncryptionKey",
-        () => createEncryptionKey(),
-        { iterations: 200 },
-      );
+      await bench("createEncryptionKey", () => createEncryptionKey(), { iterations: 200 });
     });
 
     it("EncryptionClient - encrypt small update", async () => {

--- a/benchmarks/server.bench.test.ts
+++ b/benchmarks/server.bench.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, beforeEach, afterEach } from "bun:test";
+import * as Y from "yjs";
+import { Server } from "../src/server/server";
+import { MemoryDocumentStorage } from "../src/storage/in-memory/document-storage";
+import {
+  DocMessage,
+  InMemoryPubSub,
+  type Message,
+  type ServerContext,
+  type StateVector,
+  type Transport,
+  type Update,
+  type VersionedUpdate,
+} from "teleportal";
+import { createChannel } from "../src/lib/iter";
+import { bench, benchBatch, flush } from "./helpers";
+
+class BenchTransport<Context extends ServerContext> implements Transport<Context> {
+  public source: AsyncIterable<Message<Context>[]>;
+  #channel = createChannel<Message<Context>>();
+
+  constructor() {
+    this.source = this.#channel;
+  }
+
+  write(_message: Message<Context>): void {}
+  close(): void {}
+  async destroy() {}
+
+  enqueueMessage(message: Message<Context>) {
+    try {
+      this.#channel.send(message);
+    } catch {}
+  }
+
+  closeReadable() {
+    this.#channel.close();
+  }
+
+  [key: string]: unknown;
+}
+
+function makeDocUpdate(docId: string, content: string): DocMessage<ServerContext> {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, content);
+  const update = Y.encodeStateAsUpdateV2(doc);
+  return new DocMessage(
+    docId,
+    {
+      type: "update",
+      update: { version: 2, data: update as Update } as VersionedUpdate,
+    },
+    { userId: "bench-user", room: "bench", clientId: "bench-client" },
+    false,
+  );
+}
+
+function makeSyncStep1(docId: string): DocMessage<ServerContext> {
+  const doc = new Y.Doc();
+  const sv = Y.encodeStateVector(doc);
+  return new DocMessage(
+    docId,
+    { type: "sync-step-1", sv: sv as StateVector },
+    { userId: "bench-user", room: "bench", clientId: "bench-client" },
+    false,
+  );
+}
+
+describe("Server Benchmarks", () => {
+  let server: Server<ServerContext>;
+  let storage: MemoryDocumentStorage;
+  let pubSub: InMemoryPubSub;
+
+  beforeEach(() => {
+    MemoryDocumentStorage.docs.clear();
+    MemoryDocumentStorage.attributionMaps.clear();
+    pubSub = new InMemoryPubSub();
+    storage = new MemoryDocumentStorage(false);
+    server = new Server<ServerContext>({
+      storage,
+      pubSub,
+    });
+  });
+
+  afterEach(async () => {
+    await server[Symbol.asyncDispose]();
+    await pubSub[Symbol.asyncDispose]();
+  });
+
+  describe("Session Management", () => {
+    it("getOrOpenSession - new session", async () => {
+      let i = 0;
+      await bench(
+        "open new session",
+        () =>
+          server.getOrOpenSession(`session-doc-${i++}`, {
+            encrypted: false,
+            context: { userId: "user-1", room: "bench", clientId: "client-1" },
+          }),
+        { iterations: 200 },
+      );
+    });
+
+    it("getOrOpenSession - existing session", async () => {
+      await server.getOrOpenSession("existing-doc", {
+        encrypted: false,
+        context: { userId: "user-1", room: "bench", clientId: "client-1" },
+      });
+
+      await bench(
+        "get existing session",
+        () =>
+          server.getOrOpenSession("existing-doc", {
+            encrypted: false,
+            context: { userId: "user-1", room: "bench", clientId: "client-1" },
+          }),
+        { iterations: 1000 },
+      );
+    });
+  });
+
+  describe("Client Management", () => {
+    it("createClient", async () => {
+      await bench(
+        "createClient",
+        () => {
+          const transport = new BenchTransport<ServerContext>();
+          server.createClient({ transport });
+          transport.closeReadable();
+        },
+        { iterations: 500 },
+      );
+    });
+
+    it("createClient + disconnect", async () => {
+      await bench(
+        "createClient + disconnect",
+        () => {
+          const transport = new BenchTransport<ServerContext>();
+          const client = server.createClient({ transport });
+          server.disconnectClient(client);
+          transport.closeReadable();
+        },
+        { iterations: 500 },
+      );
+    });
+  });
+
+  describe("Message Processing", () => {
+    it("process update message through server", async () => {
+      const transport = new BenchTransport<ServerContext>();
+      server.createClient({ transport });
+
+      let i = 0;
+      await bench(
+        "process update message",
+        async () => {
+          transport.enqueueMessage(makeDocUpdate("msg-doc", `update-${i++}`));
+          await flush();
+        },
+        { iterations: 200 },
+      );
+      transport.closeReadable();
+    });
+
+    it("process sync-step-1 through server", async () => {
+      const transport = new BenchTransport<ServerContext>();
+      server.createClient({ transport });
+
+      await bench(
+        "process sync-step-1",
+        async () => {
+          transport.enqueueMessage(makeSyncStep1("sync-doc"));
+          await flush();
+        },
+        { iterations: 200 },
+      );
+      transport.closeReadable();
+    });
+
+    it("burst of updates to same document", async () => {
+      const transport = new BenchTransport<ServerContext>();
+      server.createClient({ transport });
+
+      const batchSize = 50;
+      await benchBatch(
+        `burst ${batchSize} updates`,
+        async () => {
+          for (let j = 0; j < batchSize; j++) {
+            transport.enqueueMessage(makeDocUpdate("burst-doc", `u${j}`));
+          }
+          await flush();
+          await new Promise((r) => setTimeout(r, 1));
+        },
+        { batchSize, iterations: 20 },
+      );
+      transport.closeReadable();
+    });
+
+    it("updates to many different documents", async () => {
+      const transport = new BenchTransport<ServerContext>();
+      server.createClient({ transport });
+
+      let docNum = 0;
+      const batchSize = 20;
+      await benchBatch(
+        `updates to ${batchSize} different docs`,
+        async () => {
+          for (let j = 0; j < batchSize; j++) {
+            transport.enqueueMessage(makeDocUpdate(`multi-doc-${docNum++}`, "content"));
+          }
+          await flush();
+          await new Promise((r) => setTimeout(r, 1));
+        },
+        { batchSize, iterations: 20 },
+      );
+      transport.closeReadable();
+    });
+  });
+
+  describe("Multi-Client", () => {
+    it("fan-out to multiple clients on same doc", async () => {
+      const clientCount = 10;
+      const transports: BenchTransport<ServerContext>[] = [];
+      for (let i = 0; i < clientCount; i++) {
+        const transport = new BenchTransport<ServerContext>();
+        server.createClient({ transport });
+        transports.push(transport);
+      }
+
+      // Open the session for all clients
+      for (const t of transports) {
+        t.enqueueMessage(makeSyncStep1("fanout-doc"));
+      }
+      await flush();
+      await new Promise((r) => setTimeout(r, 10));
+
+      await bench(
+        `fan-out update to ${clientCount} clients`,
+        async () => {
+          transports[0].enqueueMessage(makeDocUpdate("fanout-doc", "x"));
+          await flush();
+        },
+        { iterations: 100 },
+      );
+
+      for (const t of transports) t.closeReadable();
+    });
+  });
+});

--- a/benchmarks/storage.bench.test.ts
+++ b/benchmarks/storage.bench.test.ts
@@ -4,6 +4,13 @@ import { MemoryDocumentStorage } from "../src/storage/in-memory/document-storage
 import { VirtualStorage } from "../src/storage/virtual-storage";
 import { encodeContentEncryptedPayload } from "../src/lib/protocol/encryption/encoding";
 import type { VersionedUpdate, Update, StateVector } from "teleportal";
+import {
+  decodeContentEncryptedPayload,
+  type EncryptedUpdatePayload,
+} from "../src/lib/protocol/encryption/encoding";
+import {
+  buildSidecarIndexFromUpdateMeta,
+} from "../src/lib/protocol/encryption/content-cipher";
 import { bench, benchBatch, createLargeDoc, formatBytes } from "./helpers";
 
 function wrapUpdate(rawV2: Uint8Array): VersionedUpdate {
@@ -227,6 +234,81 @@ describe("Storage Benchmarks", () => {
           Y.applyUpdateV2(doc, update);
         },
         { iterations: 200 },
+      );
+    });
+  });
+
+  describe("handleUpdate sub-system overhead", () => {
+    it("parseUpdateMetaV2 — cost that's skipped for unencrypted", async () => {
+      for (const size of [100, 1_000, 10_000]) {
+        const doc = createLargeDoc(size);
+        const update = Y.encodeStateAsUpdateV2(doc);
+        await bench(
+          `parseUpdateMetaV2 (${size} chars)`,
+          () => { Y.parseUpdateMetaV2(update); },
+          { iterations: size > 5_000 ? 100 : 500 },
+        );
+      }
+    });
+
+    it("parseUpdateMetaV2 + buildSidecarIndex — skipped for unencrypted", async () => {
+      const doc = createLargeDoc(1_000);
+      const update = Y.encodeStateAsUpdateV2(doc);
+      await bench(
+        "parseUpdateMetaV2 + buildSidecarIndex (1K)",
+        () => {
+          const meta = Y.parseUpdateMetaV2(update);
+          buildSidecarIndexFromUpdateMeta(meta);
+        },
+        { iterations: 500 },
+      );
+    });
+
+    it("decodeContentEncryptedPayload — per-update envelope cost", async () => {
+      for (const size of [100, 1_000, 10_000]) {
+        const doc = createLargeDoc(size);
+        const vUpdate = wrapUpdate(Y.encodeStateAsUpdateV2(doc));
+        await bench(
+          `decodeContentEncryptedPayload (${size} chars)`,
+          () => { decodeContentEncryptedPayload(vUpdate.data as EncryptedUpdatePayload); },
+          { iterations: size > 5_000 ? 200 : 1000 },
+        );
+      }
+    });
+
+    it("handleUpdate breakdown — incremental update on growing doc", async () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      const storage = new MemoryDocumentStorage(false);
+
+      const doc = new Y.Doc();
+      // Pre-populate with 500 chars so we measure steady-state cost
+      for (let i = 0; i < 500; i++) {
+        doc.getText("content").insert(i, "x");
+      }
+      const fullUpdate = wrapUpdate(Y.encodeStateAsUpdateV2(doc));
+      await storage.handleUpdate("breakdown-doc", fullUpdate);
+
+      let j = 0;
+      await bench(
+        "handleUpdate incremental (500-char doc, steady state)",
+        () => {
+          const update = makeIncrementalUpdate(doc, "y", j++ % 100);
+          return storage.handleUpdate("breakdown-doc", update);
+        },
+        { iterations: 300 },
+      );
+
+      // Breakdown: what does mergeUpdatesV2 cost alone at this doc size?
+      const existing = Y.encodeStateAsUpdateV2(doc);
+      const sv = Y.encodeStateVector(doc);
+      doc.getText("content").insert(0, "z");
+      const incremental = Y.encodeStateAsUpdateV2(doc, sv);
+
+      await bench(
+        "mergeUpdatesV2 alone (500-char base + 1 char)",
+        () => { Y.mergeUpdatesV2([existing, incremental]); },
+        { iterations: 500 },
       );
     });
   });

--- a/benchmarks/storage.bench.test.ts
+++ b/benchmarks/storage.bench.test.ts
@@ -4,12 +4,7 @@ import { MemoryDocumentStorage } from "../src/storage/in-memory/document-storage
 import { VirtualStorage } from "../src/storage/virtual-storage";
 import { encodeContentEncryptedPayload } from "../src/lib/protocol/encryption/encoding";
 import type { VersionedUpdate, Update, StateVector } from "teleportal";
-import {
-  bench,
-  benchBatch,
-  createLargeDoc,
-  formatBytes,
-} from "./helpers";
+import { bench, benchBatch, createLargeDoc, formatBytes } from "./helpers";
 
 function wrapUpdate(rawV2: Uint8Array): VersionedUpdate {
   const payload = encodeContentEncryptedPayload({
@@ -77,11 +72,9 @@ describe("Storage Benchmarks", () => {
 
     it("handleSyncStep1 - empty doc", async () => {
       const sv = Y.encodeStateVector(new Y.Doc()) as StateVector;
-      await bench(
-        "handleSyncStep1 (empty doc)",
-        () => storage.handleSyncStep1("empty-doc", sv),
-        { iterations: 1000 },
-      );
+      await bench("handleSyncStep1 (empty doc)", () => storage.handleSyncStep1("empty-doc", sv), {
+        iterations: 1000,
+      });
     });
 
     it("handleSyncStep1 - doc with content", async () => {
@@ -89,11 +82,9 @@ describe("Storage Benchmarks", () => {
       await storage.handleUpdate("full-doc", update);
 
       const sv = Y.encodeStateVector(new Y.Doc()) as StateVector;
-      await bench(
-        "handleSyncStep1 (1K char doc)",
-        () => storage.handleSyncStep1("full-doc", sv),
-        { iterations: 500 },
-      );
+      await bench("handleSyncStep1 (1K char doc)", () => storage.handleSyncStep1("full-doc", sv), {
+        iterations: 500,
+      });
     });
 
     it("handleSyncStep1 - large doc with partial sync", async () => {
@@ -114,11 +105,9 @@ describe("Storage Benchmarks", () => {
       const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(5_000)));
       await storage.handleUpdate("get-doc", update);
 
-      await bench(
-        "getDocument (5K chars)",
-        () => storage.getDocument("get-doc"),
-        { iterations: 1000 },
-      );
+      await bench("getDocument (5K chars)", () => storage.getDocument("get-doc"), {
+        iterations: 1000,
+      });
     });
 
     it("writeDocumentMetadata + getDocumentMetadata", async () => {
@@ -184,7 +173,9 @@ describe("Storage Benchmarks", () => {
         const doc = createLargeDoc(size);
         await bench(
           `encodeStateAsUpdateV2 (${size} chars)`,
-          () => { Y.encodeStateAsUpdateV2(doc); },
+          () => {
+            Y.encodeStateAsUpdateV2(doc);
+          },
           { iterations: size > 10_000 ? 50 : 200 },
         );
         const encoded = Y.encodeStateAsUpdateV2(doc);
@@ -203,7 +194,9 @@ describe("Storage Benchmarks", () => {
 
       await bench(
         "mergeUpdatesV2 (100 updates)",
-        () => { Y.mergeUpdatesV2(updates); },
+        () => {
+          Y.mergeUpdatesV2(updates);
+        },
         { iterations: 200 },
       );
     });
@@ -216,7 +209,9 @@ describe("Storage Benchmarks", () => {
 
       await bench(
         "diffUpdateV2 (10K doc, 50% diff)",
-        () => { Y.diffUpdateV2(fullUpdate, sv); },
+        () => {
+          Y.diffUpdateV2(fullUpdate, sv);
+        },
         { iterations: 200 },
       );
     });

--- a/benchmarks/storage.bench.test.ts
+++ b/benchmarks/storage.bench.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, beforeEach } from "bun:test";
+import * as Y from "yjs";
+import { MemoryDocumentStorage } from "../src/storage/in-memory/document-storage";
+import { VirtualStorage } from "../src/storage/virtual-storage";
+import { encodeContentEncryptedPayload } from "../src/lib/protocol/encryption/encoding";
+import type { VersionedUpdate, Update, StateVector } from "teleportal";
+import {
+  bench,
+  benchBatch,
+  createLargeDoc,
+  formatBytes,
+} from "./helpers";
+
+function wrapUpdate(rawV2: Uint8Array): VersionedUpdate {
+  const payload = encodeContentEncryptedPayload({
+    structureUpdate: rawV2,
+    encryptedSidecars: [],
+  });
+  return { version: 2, data: payload as Update } as VersionedUpdate;
+}
+
+function makeUpdate(content: string): VersionedUpdate {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, content);
+  return wrapUpdate(Y.encodeStateAsUpdateV2(doc));
+}
+
+function makeIncrementalUpdate(doc: Y.Doc, text: string, pos: number): VersionedUpdate {
+  const sv = Y.encodeStateVector(doc);
+  doc.getText("content").insert(pos, text);
+  const diff = Y.encodeStateAsUpdateV2(doc, sv);
+  return wrapUpdate(diff);
+}
+
+describe("Storage Benchmarks", () => {
+  describe("MemoryDocumentStorage", () => {
+    let storage: MemoryDocumentStorage;
+
+    beforeEach(() => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      storage = new MemoryDocumentStorage(false);
+    });
+
+    it("handleUpdate - single small update", async () => {
+      const update = makeUpdate("hello world");
+      await bench(
+        "handleUpdate (small)",
+        () => storage.handleUpdate(`doc-${Math.random()}`, update),
+        { iterations: 1000 },
+      );
+    });
+
+    it("handleUpdate - incremental updates to same doc", async () => {
+      const doc = new Y.Doc();
+      let i = 0;
+      await bench(
+        "handleUpdate (incremental, same doc)",
+        () => {
+          const update = makeIncrementalUpdate(doc, "x", i++ % 100);
+          return storage.handleUpdate("bench-doc", update);
+        },
+        { iterations: 500 },
+      );
+    });
+
+    it("handleUpdate - large update", async () => {
+      const largeDoc = createLargeDoc(10_000);
+      const update = wrapUpdate(Y.encodeStateAsUpdateV2(largeDoc));
+      console.log(`    update size: ${formatBytes(update.data.byteLength)}`);
+      await bench(
+        "handleUpdate (10K chars)",
+        () => storage.handleUpdate(`doc-${Math.random()}`, update),
+        { iterations: 100 },
+      );
+    });
+
+    it("handleSyncStep1 - empty doc", async () => {
+      const sv = Y.encodeStateVector(new Y.Doc()) as StateVector;
+      await bench(
+        "handleSyncStep1 (empty doc)",
+        () => storage.handleSyncStep1("empty-doc", sv),
+        { iterations: 1000 },
+      );
+    });
+
+    it("handleSyncStep1 - doc with content", async () => {
+      const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(1_000)));
+      await storage.handleUpdate("full-doc", update);
+
+      const sv = Y.encodeStateVector(new Y.Doc()) as StateVector;
+      await bench(
+        "handleSyncStep1 (1K char doc)",
+        () => storage.handleSyncStep1("full-doc", sv),
+        { iterations: 500 },
+      );
+    });
+
+    it("handleSyncStep1 - large doc with partial sync", async () => {
+      const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(50_000)));
+      await storage.handleUpdate("large-doc", update);
+
+      const clientDoc = new Y.Doc();
+      Y.applyUpdateV2(clientDoc, Y.encodeStateAsUpdateV2(createLargeDoc(25_000)));
+      const sv = Y.encodeStateVector(clientDoc) as StateVector;
+      await bench(
+        "handleSyncStep1 (50K doc, partial sync)",
+        () => storage.handleSyncStep1("large-doc", sv),
+        { iterations: 100 },
+      );
+    });
+
+    it("getDocument", async () => {
+      const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(5_000)));
+      await storage.handleUpdate("get-doc", update);
+
+      await bench(
+        "getDocument (5K chars)",
+        () => storage.getDocument("get-doc"),
+        { iterations: 1000 },
+      );
+    });
+
+    it("writeDocumentMetadata + getDocumentMetadata", async () => {
+      const metadata = {
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        encrypted: false,
+      };
+      await bench(
+        "write+get metadata",
+        async () => {
+          await storage.writeDocumentMetadata("meta-doc", metadata);
+          await storage.getDocumentMetadata("meta-doc");
+        },
+        { iterations: 1000 },
+      );
+    });
+
+    it("many documents - create throughput", async () => {
+      const update = makeUpdate("document content here");
+      let docNum = 0;
+      await benchBatch(
+        "create 100 documents",
+        async () => {
+          for (let j = 0; j < 100; j++) {
+            await storage.handleUpdate(`batch-doc-${docNum++}`, update);
+          }
+        },
+        { batchSize: 100, iterations: 20 },
+      );
+    });
+  });
+
+  describe("VirtualStorage (write batching)", () => {
+    it("handleUpdate - buffered writes vs direct", async () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+
+      const inner = new MemoryDocumentStorage(false);
+      const virtual = new VirtualStorage(inner, {
+        batchMaxSize: 50,
+        batchWaitMs: 1,
+      });
+
+      const doc = new Y.Doc();
+      let i = 0;
+      await bench(
+        "VirtualStorage handleUpdate (buffered)",
+        async () => {
+          const update = makeIncrementalUpdate(doc, "x", i++ % 100);
+          await virtual.handleUpdate("virtual-doc", update);
+        },
+        { iterations: 200, warmup: 5 },
+      );
+
+      await new Promise((r) => setTimeout(r, 5));
+    });
+  });
+
+  describe("Y.js encoding overhead", () => {
+    it("encodeStateAsUpdateV2 - various sizes", async () => {
+      for (const size of [100, 1_000, 10_000, 50_000]) {
+        const doc = createLargeDoc(size);
+        await bench(
+          `encodeStateAsUpdateV2 (${size} chars)`,
+          () => { Y.encodeStateAsUpdateV2(doc); },
+          { iterations: size > 10_000 ? 50 : 200 },
+        );
+        const encoded = Y.encodeStateAsUpdateV2(doc);
+        console.log(`    encoded size: ${formatBytes(encoded.byteLength)}`);
+      }
+    });
+
+    it("mergeUpdatesV2", async () => {
+      const doc = new Y.Doc();
+      const updates: Uint8Array[] = [];
+      for (let i = 0; i < 100; i++) {
+        const sv = Y.encodeStateVector(doc);
+        doc.getText("content").insert(i, `char-${i}-`);
+        updates.push(Y.encodeStateAsUpdateV2(doc, sv));
+      }
+
+      await bench(
+        "mergeUpdatesV2 (100 updates)",
+        () => { Y.mergeUpdatesV2(updates); },
+        { iterations: 200 },
+      );
+    });
+
+    it("diffUpdateV2", async () => {
+      const doc = createLargeDoc(10_000);
+      const fullUpdate = Y.encodeStateAsUpdateV2(doc);
+      const partialDoc = createLargeDoc(5_000);
+      const sv = Y.encodeStateVector(partialDoc);
+
+      await bench(
+        "diffUpdateV2 (10K doc, 50% diff)",
+        () => { Y.diffUpdateV2(fullUpdate, sv); },
+        { iterations: 200 },
+      );
+    });
+
+    it("applyUpdateV2", async () => {
+      const sourceDoc = createLargeDoc(5_000);
+      const update = Y.encodeStateAsUpdateV2(sourceDoc);
+
+      await bench(
+        "applyUpdateV2 (5K chars)",
+        () => {
+          const doc = new Y.Doc();
+          Y.applyUpdateV2(doc, update);
+        },
+        { iterations: 200 },
+      );
+    });
+  });
+});

--- a/benchmarks/sync.bench.test.ts
+++ b/benchmarks/sync.bench.test.ts
@@ -1,0 +1,307 @@
+import { describe, it } from "bun:test";
+import * as Y from "yjs";
+import { Connection } from "../src/providers/connection";
+import { Provider } from "../src/providers/provider";
+import { createMemoryTransportPair } from "../src/providers/transports/memory";
+import { encodeContentEncryptedPayload } from "../src/lib/protocol/encryption/encoding";
+import { DocMessage, type UpdateV2, type SyncStep2UpdateV2 } from "teleportal";
+import { bench, benchBatch, createLargeDoc, formatBytes } from "./helpers";
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+function wrapV2(rawV2: Uint8Array): Uint8Array {
+  return encodeContentEncryptedPayload({
+    structureUpdate: rawV2,
+    encryptedSidecars: [],
+  });
+}
+
+async function createTestProvider(document = "bench-doc") {
+  const [clientTransport, serverTransport] = createMemoryTransportPair();
+  const clientConn = new Connection({
+    transports: [clientTransport],
+    connect: false,
+    batchIntervalMs: 0,
+  });
+  const serverConn = new Connection({
+    transports: [serverTransport],
+    connect: false,
+    batchIntervalMs: 0,
+  });
+
+  await Promise.all([clientConn.connect(), serverConn.connect()]);
+
+  const provider = new Provider({
+    connection: clientConn,
+    document,
+    encryptionKey: false,
+    enableOfflinePersistence: false,
+  });
+
+  return { provider, clientConn, serverConn, clientTransport, serverTransport };
+}
+
+async function sendSyncDone(serverConn: Connection, document: string) {
+  const syncDone = new DocMessage(document, { type: "sync-done" }, {}, false);
+  await serverConn.send(syncDone);
+  await flush();
+}
+
+describe("Sync & Provider Benchmarks", () => {
+  describe("Connection", () => {
+    it("send message through memory transport", async () => {
+      const [clientTransport] = createMemoryTransportPair();
+      const conn = new Connection({
+        transports: [clientTransport],
+        connect: false,
+        batchIntervalMs: 0,
+      });
+      await conn.connect();
+
+      const msg = new DocMessage("doc", { type: "sync-done" }, {}, false);
+      await bench(
+        "Connection.send (memory transport)",
+        () => conn.send(msg),
+        { iterations: 1000 },
+      );
+
+      conn.destroy();
+    });
+
+    it("connection setup + teardown", async () => {
+      await bench(
+        "Connection create + connect + destroy",
+        async () => {
+          const [clientTransport] = createMemoryTransportPair();
+          const conn = new Connection({
+            transports: [clientTransport],
+            connect: false,
+            batchIntervalMs: 0,
+          });
+          await conn.connect();
+          conn.destroy();
+        },
+        { iterations: 200 },
+      );
+    });
+  });
+
+  describe("Provider Lifecycle", () => {
+    it("create provider", async () => {
+      const providers: Provider[] = [];
+      await bench(
+        "Provider create (no encryption)",
+        async () => {
+          const [clientTransport] = createMemoryTransportPair();
+          const conn = new Connection({
+            transports: [clientTransport],
+            connect: false,
+            batchIntervalMs: 0,
+          });
+          await conn.connect();
+          const provider = new Provider({
+            connection: conn,
+            document: "bench-doc",
+            encryptionKey: false,
+            enableOfflinePersistence: false,
+          });
+          providers.push(provider);
+        },
+        { iterations: 200 },
+      );
+      for (const p of providers) p.destroy();
+    });
+  });
+
+  describe("Document Sync", () => {
+    it("initial sync (sync-step-1 exchange)", async () => {
+      const { provider, serverConn } = await createTestProvider();
+
+      await bench(
+        "initial sync handshake",
+        async () => {
+          await sendSyncDone(serverConn, "bench-doc");
+        },
+        { iterations: 200 },
+      );
+
+      provider.destroy();
+    });
+
+    it("send incremental updates via provider", async () => {
+      const { provider, serverConn } = await createTestProvider();
+      await sendSyncDone(serverConn, "bench-doc");
+
+      let i = 0;
+      await bench(
+        "provider incremental update",
+        async () => {
+          provider.doc.getText("content").insert(i++ % 100, "x");
+          await flush();
+        },
+        { iterations: 500 },
+      );
+
+      // Let in-flight messages drain before tearing down
+      await new Promise((r) => setTimeout(r, 10));
+      provider.destroy();
+    });
+
+    it("apply update from remote", async () => {
+      const { provider, serverConn } = await createTestProvider();
+      await sendSyncDone(serverConn, "bench-doc");
+
+      const remoteDoc = new Y.Doc();
+      let i = 0;
+
+      await bench(
+        "apply remote update",
+        async () => {
+          const sv = Y.encodeStateVector(remoteDoc);
+          remoteDoc.getText("content").insert(i++ % 100, "y");
+          const diff = Y.encodeStateAsUpdateV2(remoteDoc, sv);
+          const msg = new DocMessage(
+            "bench-doc",
+            {
+              type: "update",
+              update: { version: 2, data: wrapV2(diff) as UpdateV2 },
+            },
+            {},
+            false,
+          );
+          await serverConn.send(msg);
+          await flush();
+        },
+        { iterations: 500 },
+      );
+
+      provider.destroy();
+    });
+
+    it("large document initial load", async () => {
+      for (const size of [1_000, 10_000, 50_000]) {
+        const doc = createLargeDoc(size);
+        const rawUpdate = Y.encodeStateAsUpdateV2(doc);
+        const wrappedUpdate = wrapV2(rawUpdate);
+        console.log(`    ${size} chars → ${formatBytes(rawUpdate.byteLength)} (raw), ${formatBytes(wrappedUpdate.byteLength)} (wrapped)`);
+
+        const { provider, serverConn } = await createTestProvider(`large-${size}`);
+
+        await bench(
+          `initial load ${size} chars`,
+          async () => {
+            const msg = new DocMessage(
+              `large-${size}`,
+              {
+                type: "sync-step-2",
+                update: { version: 2, data: wrappedUpdate as SyncStep2UpdateV2 },
+              },
+              {},
+              false,
+            );
+            await serverConn.send(msg);
+            await flush();
+          },
+          { iterations: size > 10_000 ? 20 : 50 },
+        );
+
+        provider.destroy();
+      }
+    });
+  });
+
+  describe("Memory Transport Throughput", () => {
+    it("raw message throughput", async () => {
+      const [a, b] = createMemoryTransportPair();
+      const connA = new Connection({
+        transports: [a],
+        connect: false,
+        batchIntervalMs: 0,
+      });
+      const connB = new Connection({
+        transports: [b],
+        connect: false,
+        batchIntervalMs: 0,
+      });
+
+      await Promise.all([connA.connect(), connB.connect()]);
+
+      const msg = new DocMessage("doc", { type: "sync-done" }, {}, false);
+      const batchSize = 100;
+
+      await benchBatch(
+        `${batchSize} messages through memory transport`,
+        async () => {
+          for (let j = 0; j < batchSize; j++) {
+            await connA.send(msg);
+          }
+          await flush();
+        },
+        { batchSize, iterations: 20 },
+      );
+
+      connA.destroy();
+      connB.destroy();
+    });
+  });
+
+  describe("Multi-Provider Sync", () => {
+    it("two providers exchanging updates", async () => {
+      const [t1client, t1server] = createMemoryTransportPair();
+      const [t2client, t2server] = createMemoryTransportPair();
+
+      const conn1 = new Connection({ transports: [t1client], connect: false, batchIntervalMs: 0 });
+      const conn2 = new Connection({ transports: [t2client], connect: false, batchIntervalMs: 0 });
+
+      await Promise.all([conn1.connect(), conn2.connect()]);
+
+      const p1 = new Provider({
+        connection: conn1,
+        document: "shared-doc",
+        encryptionKey: false,
+        enableOfflinePersistence: false,
+      });
+
+      const p2 = new Provider({
+        connection: conn2,
+        document: "shared-doc",
+        encryptionKey: false,
+        enableOfflinePersistence: false,
+      });
+
+      const serverConn1 = new Connection({ transports: [t1server], connect: false, batchIntervalMs: 0 });
+      const serverConn2 = new Connection({ transports: [t2server], connect: false, batchIntervalMs: 0 });
+      await Promise.all([serverConn1.connect(), serverConn2.connect()]);
+
+      await sendSyncDone(serverConn1, "shared-doc");
+      await sendSyncDone(serverConn2, "shared-doc");
+
+      let i = 0;
+      await bench(
+        "p1 edit → relay → p2 apply",
+        async () => {
+          const sv = Y.encodeStateVector(p1.doc);
+          p1.doc.getText("content").insert(i++ % 100, "a");
+          const diff = Y.encodeStateAsUpdateV2(p1.doc, sv);
+          const msg = new DocMessage(
+            "shared-doc",
+            { type: "update", update: { version: 2, data: wrapV2(diff) as UpdateV2 } },
+            {},
+            false,
+          );
+          await serverConn2.send(msg);
+          await flush();
+        },
+        { iterations: 200 },
+      );
+
+      console.log(`    p1 doc length: ${p1.doc.getText("content").length}`);
+      console.log(`    p2 doc length: ${p2.doc.getText("content").length}`);
+
+      p1.destroy();
+      p2.destroy();
+    });
+  });
+});

--- a/benchmarks/sync.bench.test.ts
+++ b/benchmarks/sync.bench.test.ts
@@ -61,11 +61,7 @@ describe("Sync & Provider Benchmarks", () => {
       await conn.connect();
 
       const msg = new DocMessage("doc", { type: "sync-done" }, {}, false);
-      await bench(
-        "Connection.send (memory transport)",
-        () => conn.send(msg),
-        { iterations: 1000 },
-      );
+      await bench("Connection.send (memory transport)", () => conn.send(msg), { iterations: 1000 });
 
       conn.destroy();
     });
@@ -185,7 +181,9 @@ describe("Sync & Provider Benchmarks", () => {
         const doc = createLargeDoc(size);
         const rawUpdate = Y.encodeStateAsUpdateV2(doc);
         const wrappedUpdate = wrapV2(rawUpdate);
-        console.log(`    ${size} chars → ${formatBytes(rawUpdate.byteLength)} (raw), ${formatBytes(wrappedUpdate.byteLength)} (wrapped)`);
+        console.log(
+          `    ${size} chars → ${formatBytes(rawUpdate.byteLength)} (raw), ${formatBytes(wrappedUpdate.byteLength)} (wrapped)`,
+        );
 
         const { provider, serverConn } = await createTestProvider(`large-${size}`);
 
@@ -271,8 +269,16 @@ describe("Sync & Provider Benchmarks", () => {
         enableOfflinePersistence: false,
       });
 
-      const serverConn1 = new Connection({ transports: [t1server], connect: false, batchIntervalMs: 0 });
-      const serverConn2 = new Connection({ transports: [t2server], connect: false, batchIntervalMs: 0 });
+      const serverConn1 = new Connection({
+        transports: [t1server],
+        connect: false,
+        batchIntervalMs: 0,
+      });
+      const serverConn2 = new Connection({
+        transports: [t2server],
+        connect: false,
+        batchIntervalMs: 0,
+      });
       await Promise.all([serverConn1.connect(), serverConn2.connect()]);
 
       await sendSyncDone(serverConn1, "shared-doc");

--- a/benchmarks/tiered-storage.bench.test.ts
+++ b/benchmarks/tiered-storage.bench.test.ts
@@ -315,4 +315,129 @@ describe("Tiered Storage Benchmarks", () => {
       MemoryDocumentStorage.attributionMaps.clear();
     });
   });
+
+  describe("tiered overhead isolation — fast tier vs tiered delegation", () => {
+    it("handleUpdate: Memory direct vs Tiered (mem-only) overhead", async () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+
+      const memDirect = new MemoryDocumentStorage(false);
+      const doc = new Y.Doc();
+      for (let i = 0; i < 200; i++) {
+        doc.getText("content").insert(i, "x");
+      }
+      const fullUpdate = wrapUpdate(Y.encodeStateAsUpdateV2(doc));
+      await memDirect.handleUpdate("overhead-doc", fullUpdate);
+
+      let j = 0;
+      const baseResult = await bench(
+        "Memory direct (200-char base)",
+        () => {
+          const update = makeIncrementalUpdate(doc, "a", j++ % 100);
+          return memDirect.handleUpdate("overhead-doc", update);
+        },
+        { iterations: 300 },
+      );
+
+      // Same workload through tiered layer (mem fast, no slow involved)
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      const tieredStore = new TieredDocumentStorage(
+        new MemoryDocumentStorage(false),
+        new MemoryDocumentStorage(false),
+        { persistIntervalMs: 60_000 },
+      );
+      const doc2 = new Y.Doc();
+      for (let i = 0; i < 200; i++) {
+        doc2.getText("content").insert(i, "x");
+      }
+      await tieredStore.handleUpdate("overhead-doc", wrapUpdate(Y.encodeStateAsUpdateV2(doc2)));
+
+      j = 0;
+      const tieredResult = await bench(
+        "Tiered delegation (200-char base)",
+        () => {
+          const update = makeIncrementalUpdate(doc2, "a", j++ % 100);
+          return tieredStore.handleUpdate("overhead-doc", update);
+        },
+        { iterations: 300 },
+      );
+
+      const overhead = tieredResult.avgMs - baseResult.avgMs;
+      console.log(`    Tiered overhead: ${(overhead * 1000).toFixed(0)}μs per handleUpdate`);
+
+      await tieredStore[Symbol.asyncDispose]();
+    });
+
+    it("getDocument: Memory direct vs Tiered (warm) overhead", async () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+
+      const memDirect = new MemoryDocumentStorage(false);
+      const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(1_000)));
+      await memDirect.handleUpdate("read-doc", update);
+
+      const baseResult = await bench(
+        "Memory direct getDocument (1K)",
+        () => memDirect.getDocument("read-doc"),
+        { iterations: 1000 },
+      );
+
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      const tieredStore = new TieredDocumentStorage(
+        new MemoryDocumentStorage(false),
+        new MemoryDocumentStorage(false),
+        { persistIntervalMs: 60_000 },
+      );
+      await tieredStore.handleUpdate("read-doc", update);
+
+      const tieredResult = await bench(
+        "Tiered warm getDocument (1K)",
+        () => tieredStore.getDocument("read-doc"),
+        { iterations: 1000 },
+      );
+
+      const overhead = tieredResult.avgMs - baseResult.avgMs;
+      console.log(`    Tiered overhead: ${(overhead * 1000).toFixed(0)}μs per getDocument`);
+
+      await tieredStore[Symbol.asyncDispose]();
+    });
+
+    it("handleSyncStep1: Memory direct vs Tiered (warm) overhead", async () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+
+      const memDirect = new MemoryDocumentStorage(false);
+      const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(1_000)));
+      await memDirect.handleUpdate("sync-doc", update);
+      const sv = Y.encodeStateVector(new Y.Doc()) as StateVector;
+
+      const baseResult = await bench(
+        "Memory direct handleSyncStep1 (1K)",
+        () => memDirect.handleSyncStep1("sync-doc", sv),
+        { iterations: 500 },
+      );
+
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      const tieredStore = new TieredDocumentStorage(
+        new MemoryDocumentStorage(false),
+        new MemoryDocumentStorage(false),
+        { persistIntervalMs: 60_000 },
+      );
+      await tieredStore.handleUpdate("sync-doc", update);
+
+      const tieredResult = await bench(
+        "Tiered warm handleSyncStep1 (1K)",
+        () => tieredStore.handleSyncStep1("sync-doc", sv),
+        { iterations: 500 },
+      );
+
+      const overhead = tieredResult.avgMs - baseResult.avgMs;
+      console.log(`    Tiered overhead: ${(overhead * 1000).toFixed(0)}μs per handleSyncStep1`);
+
+      await tieredStore[Symbol.asyncDispose]();
+    });
+  });
 });

--- a/benchmarks/tiered-storage.bench.test.ts
+++ b/benchmarks/tiered-storage.bench.test.ts
@@ -1,0 +1,318 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from "bun:test";
+import * as Y from "yjs";
+import { createStorage, type Storage } from "unstorage";
+import fsDriver from "unstorage/drivers/fs";
+import { MemoryDocumentStorage } from "../src/storage/in-memory/document-storage";
+import { UnstorageDocumentStorage } from "../src/storage/unstorage/document-storage";
+import { TieredDocumentStorage } from "../src/storage/tiered/document-storage";
+import { encodeContentEncryptedPayload } from "../src/lib/protocol/encryption/encoding";
+import type { VersionedUpdate, Update, StateVector } from "teleportal";
+import { bench, createLargeDoc, formatBytes, formatDuration } from "./helpers";
+import type { AbstractDocumentStorage } from "../src/storage/document-storage";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function wrapUpdate(rawV2: Uint8Array): VersionedUpdate {
+  const payload = encodeContentEncryptedPayload({
+    structureUpdate: rawV2,
+    encryptedSidecars: [],
+  });
+  return { version: 2, data: payload as Update } as VersionedUpdate;
+}
+
+function makeUpdate(content: string): VersionedUpdate {
+  const doc = new Y.Doc();
+  doc.getText("content").insert(0, content);
+  return wrapUpdate(Y.encodeStateAsUpdateV2(doc));
+}
+
+function makeIncrementalUpdate(doc: Y.Doc, text: string, pos: number): VersionedUpdate {
+  const sv = Y.encodeStateVector(doc);
+  doc.getText("content").insert(pos, text);
+  return wrapUpdate(Y.encodeStateAsUpdateV2(doc, sv));
+}
+
+// ── Backend factories ────────────────────────────────────────────────────────
+
+type BackendSetup = {
+  name: string;
+  make: () => AbstractDocumentStorage;
+  cleanup: () => Promise<void>;
+};
+
+let tmpDir: string;
+const openStorages: Storage[] = [];
+
+function makeBackends(): BackendSetup[] {
+  return [
+    {
+      name: "Memory",
+      make: () => {
+        MemoryDocumentStorage.docs.clear();
+        MemoryDocumentStorage.attributionMaps.clear();
+        return new MemoryDocumentStorage(false);
+      },
+      cleanup: async () => {
+        MemoryDocumentStorage.docs.clear();
+        MemoryDocumentStorage.attributionMaps.clear();
+      },
+    },
+    {
+      name: "Unstorage (fs)",
+      make: () => {
+        const store = createStorage({ driver: fsDriver({ base: tmpDir }) });
+        openStorages.push(store);
+        return new UnstorageDocumentStorage(store, { encrypted: false });
+      },
+      cleanup: async () => {
+        await Promise.all(openStorages.splice(0).map((s) => s.dispose()));
+      },
+    },
+    {
+      name: "Tiered (mem+fs)",
+      make: () => {
+        MemoryDocumentStorage.docs.clear();
+        MemoryDocumentStorage.attributionMaps.clear();
+        const store = createStorage({ driver: fsDriver({ base: tmpDir }) });
+        openStorages.push(store);
+        return new TieredDocumentStorage(
+          new MemoryDocumentStorage(false),
+          new UnstorageDocumentStorage(store, { encrypted: false }),
+          { persistIntervalMs: 60_000 },
+        );
+      },
+      cleanup: async () => {
+        MemoryDocumentStorage.docs.clear();
+        MemoryDocumentStorage.attributionMaps.clear();
+        await Promise.all(openStorages.splice(0).map((s) => s.dispose()));
+      },
+    },
+  ];
+}
+
+// ── Benchmarks ───────────────────────────────────────────────────────────────
+
+describe("Tiered Storage Benchmarks", () => {
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "teleportal-bench-"));
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("handleUpdate — small update (new doc each time)", () => {
+    for (const backend of makeBackends()) {
+      it(backend.name, async () => {
+        const storage = backend.make();
+        const update = makeUpdate("hello world");
+        let i = 0;
+        await bench(
+          backend.name,
+          () => storage.handleUpdate(`doc-${i++}`, update),
+          { iterations: 500 },
+        );
+        await backend.cleanup();
+      });
+    }
+  });
+
+  describe("handleUpdate — incremental updates (same doc)", () => {
+    for (const backend of makeBackends()) {
+      it(backend.name, async () => {
+        const storage = backend.make();
+        const doc = new Y.Doc();
+        let i = 0;
+        await bench(
+          backend.name,
+          () => {
+            const update = makeIncrementalUpdate(doc, "x", i++ % 100);
+            return storage.handleUpdate("bench-doc", update);
+          },
+          { iterations: 300 },
+        );
+        await backend.cleanup();
+      });
+    }
+  });
+
+  describe("handleUpdate — large update (10K chars)", () => {
+    for (const backend of makeBackends()) {
+      it(backend.name, async () => {
+        const storage = backend.make();
+        const largeDoc = createLargeDoc(10_000);
+        const update = wrapUpdate(Y.encodeStateAsUpdateV2(largeDoc));
+        console.log(`    update size: ${formatBytes(update.data.byteLength)}`);
+        let i = 0;
+        await bench(
+          backend.name,
+          () => storage.handleUpdate(`doc-${i++}`, update),
+          { iterations: 100 },
+        );
+        await backend.cleanup();
+      });
+    }
+  });
+
+  describe("getDocument — 5K char doc", () => {
+    for (const backend of makeBackends()) {
+      it(backend.name, async () => {
+        const storage = backend.make();
+        const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(5_000)));
+        await storage.handleUpdate("get-doc", update);
+        await bench(
+          backend.name,
+          () => storage.getDocument("get-doc"),
+          { iterations: 500 },
+        );
+        await backend.cleanup();
+      });
+    }
+  });
+
+  describe("handleSyncStep1 — 1K char doc, empty client", () => {
+    for (const backend of makeBackends()) {
+      it(backend.name, async () => {
+        const storage = backend.make();
+        const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(1_000)));
+        await storage.handleUpdate("sync-doc", update);
+        const sv = Y.encodeStateVector(new Y.Doc()) as StateVector;
+        await bench(
+          backend.name,
+          () => storage.handleSyncStep1("sync-doc", sv),
+          { iterations: 500 },
+        );
+        await backend.cleanup();
+      });
+    }
+  });
+
+  describe("write-then-read cycle — simulating real usage", () => {
+    for (const backend of makeBackends()) {
+      it(backend.name, async () => {
+        const storage = backend.make();
+        const doc = new Y.Doc();
+        const sv = Y.encodeStateVector(new Y.Doc()) as StateVector;
+        let i = 0;
+        await bench(
+          backend.name,
+          async () => {
+            const update = makeIncrementalUpdate(doc, "x", i++ % 100);
+            await storage.handleUpdate("cycle-doc", update);
+            if (i % 10 === 0) {
+              await storage.handleSyncStep1("cycle-doc", sv);
+            }
+          },
+          { iterations: 300 },
+        );
+        await backend.cleanup();
+      });
+    }
+  });
+
+  describe("write burst then flush — tiered-specific", () => {
+    it("100 updates then flush", async () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      const store = createStorage({ driver: fsDriver({ base: tmpDir }) });
+
+      const fast = new MemoryDocumentStorage(false);
+      const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+      const tiered = new TieredDocumentStorage(fast, slow, {
+        persistIntervalMs: 60_000,
+      });
+
+      const doc = new Y.Doc();
+      let i = 0;
+
+      // Measure: 100 fast writes + 1 flush
+      await bench(
+        "100 writes + flush",
+        async () => {
+          const docId = `burst-${i++}`;
+          for (let j = 0; j < 100; j++) {
+            const update = makeIncrementalUpdate(doc, "x", j % 50);
+            await tiered.handleUpdate(docId, update);
+          }
+          await tiered.flush(docId);
+        },
+        { iterations: 20 },
+      );
+
+      // Compare: 100 direct writes to unstorage
+      MemoryDocumentStorage.docs.clear();
+      i = 0;
+      await bench(
+        "100 writes direct to unstorage (no tier)",
+        async () => {
+          const docId = `direct-${i++}`;
+          for (let j = 0; j < 100; j++) {
+            const update = makeIncrementalUpdate(doc, "x", j % 50);
+            await slow.handleUpdate(docId, update);
+          }
+        },
+        { iterations: 20 },
+      );
+
+      await tiered[Symbol.asyncDispose]();
+      await store.dispose();
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+    });
+  });
+
+  describe("cold read — loading from slow tier", () => {
+    it("Tiered cold read vs direct unstorage read", async () => {
+      const store = createStorage({ driver: fsDriver({ base: tmpDir }) });
+      openStorages.push(store);
+
+      const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+      const update = wrapUpdate(Y.encodeStateAsUpdateV2(createLargeDoc(5_000)));
+
+      // Pre-populate slow tier with multiple docs
+      for (let i = 0; i < 50; i++) {
+        await slow.handleUpdate(`cold-doc-${i}`, update);
+      }
+
+      // Benchmark: direct unstorage read
+      let idx = 0;
+      await bench(
+        "Unstorage direct getDocument",
+        () => slow.getDocument(`cold-doc-${idx++ % 50}`),
+        { iterations: 200 },
+      );
+
+      // Benchmark: tiered cold read (first access loads from slow)
+      idx = 0;
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      const tiered = new TieredDocumentStorage(
+        new MemoryDocumentStorage(false),
+        slow,
+        { persistIntervalMs: 60_000 },
+      );
+
+      await bench(
+        "Tiered cold getDocument (1st access)",
+        () => tiered.getDocument(`cold-doc-${idx++ % 50}`),
+        { iterations: 200 },
+      );
+
+      // Benchmark: tiered warm read (already loaded)
+      idx = 0;
+      await bench(
+        "Tiered warm getDocument (cached)",
+        () => tiered.getDocument(`cold-doc-${idx++ % 50}`),
+        { iterations: 200 },
+      );
+
+      await tiered[Symbol.asyncDispose]();
+      await Promise.all(openStorages.splice(0).map((s) => s.dispose()));
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+    });
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -24,11 +24,11 @@
         "msw": "2.14.6",
         "srvx": "0.11.16",
         "unstorage": "1.17.5",
-        "vite-plus": "0.1.24",
+        "vite-plus": "0.2.1",
       },
       "peerDependencies": {
         "@nats-io/transport-node": "^3.2.0",
-        "@standard-schema/spec": "",
+        "@standard-schema/spec": "1.1.0",
         "crossws": "^0.4.3",
         "ioredis": "^5.8.2",
         "unstorage": "^1.17.2",
@@ -165,6 +165,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@blazediff/core": ["@blazediff/core@1.9.1", "", {}, "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA=="],
 
     "@blocknote/core": ["@blocknote/core@0.51.4", "", { "dependencies": { "@emoji-mart/data": "^1.2.1", "@handlewithcare/prosemirror-inputrules": "^0.1.4", "@shikijs/types": "^4", "@tanstack/store": "^0.7.7", "@tiptap/core": "^3.13.0", "@tiptap/extension-bold": "^3.13.0", "@tiptap/extension-code": "^3.13.0", "@tiptap/extension-horizontal-rule": "^3.13.0", "@tiptap/extension-italic": "^3.13.0", "@tiptap/extension-paragraph": "^3.13.0", "@tiptap/extension-strike": "^3.13.0", "@tiptap/extension-text": "^3.13.0", "@tiptap/extension-underline": "^3.13.0", "@tiptap/extensions": "^3.13.0", "@tiptap/pm": "^3.13.0", "emoji-mart": "^5.6.0", "fast-deep-equal": "^3.1.3", "lib0": "^0.2.99", "prosemirror-highlight": "^0.15.1", "prosemirror-model": "^1.25.4", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.3", "prosemirror-transform": "^1.11.0", "prosemirror-view": "^1.41.4", "y-prosemirror": "^1.3.7", "y-protocols": "^1.0.6", "yjs": "^13.6.27" } }, "sha512-uR7/BlW6VVlCx/JzfGbkaLGz7O5uI3bu2tbNIdzGTfSloiEp8Qc14if36Dy7DDs+dVWfZgwds0jWiGfE3AzJiw=="],
 
@@ -422,47 +424,47 @@
 
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
-    "@oxc-project/runtime": ["@oxc-project/runtime@0.133.0", "", {}, "sha512-PkvjA1Lq5++V5S1E6Patr92ZVcieE6EalDr1VJTqv4BnjZdOUC4W3p8k1wMXSd5/2aFP4b/A6N5sg2Bkzcr9vQ=="],
+    "@oxc-project/runtime": ["@oxc-project/runtime@0.136.0", "", {}, "sha512-u0EutjK5y6NHJkl5jNJCs8zbup1z6A/UEWgajrYzqcEU3UX05HjqybhMQOLhSM0eKGISyM6WfSMMuklYSmH2wA=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.136.0", "", {}, "sha512-39Al/B3v9esnHCX7S8l9Se2+s2tb9b2jcMd+bZ2L659VG73kNyGPpPrL5Zi/p0ty7p4pTTU2/Dd+g27hv94XCg=="],
 
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.52.0", "", { "os": "android", "cpu": "arm" }, "sha512-17EMSJnQ9g+upVHrAUYDMfH5lvRKQ9Nvg8WtEoH72oDr1VpWz+7/o3tD97U1EToen2YAQ/68JmtDYkQUi20dfQ=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.55.0", "", { "os": "android", "cpu": "arm" }, "sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.52.0", "", { "os": "android", "cpu": "arm64" }, "sha512-A2G1IdwGEW2lLJkIxcvuirRH1CzSl/e0NX11zTlW1gvxJThfwbI/BEoaKrTNpm7M2FchvIf6guvIQU7d5iz+OQ=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.55.0", "", { "os": "android", "cpu": "arm64" }, "sha512-ctulLq8s3x8Zmvw6+iccB09TIKERAklRSmbJ10gk8mlAn05qZxoyo52dj3Hi9IJcmDSwF54fQaTVh2CbL6PInw=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.52.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-f9+bLvOYxy7NttCLFTvQ7afmqDOWY4wIP9xdvfj5trQ1qj6f2UFAGwZESlfsMjvJNTyRpXfIlOanCI9FOvoeQA=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.55.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xDQczLH9pw/RBk1h/GH0qcGMm8hQtmtVHBNLSH3lk1gEIR09hZ4L+mJQl4VqiVAvPK9VG9PYrWWuSQLt7xTbiA=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.52.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YSTB9sJ5nnQd/Q0ddHkgof0ZCHPAnWZT1IW2SJ8omz7CP7KluJhO1fNHrpqdxCtpztJwSs4hY1uAee35wKxxaw=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.55.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-JaNoFCkF2CJdGgpPSMbuO9HVyXyoNGIhMHPvp6NYAjeVKw9XEYc0HcUWJLPQa3Q69WV5wMa9m5jPMJPtbLtcRg=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.52.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-NIrRNTTPCs4UbmVs0bxLSCDlLCtIRMJIXklNKaXa5Oj2/K1UIMBvgE8+uPVo01Io3N9HF0+GAX+aAHjUgZS7vA=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.55.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-DNbszhpg6S2MIzax5azdHFTTBIVkR5xr8yyRZuA4yoDAwOkzIp3tmldgKZM2+VlT+hJIG0xUksA+elISzMEAfA=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-JXUCde8mn3GpgQouz2PXUokgy/uT1QrRJBL2s983VWcSQp62wTFYiNXgTKdeo1Jgbr0IgUnKKvzIk/YBlj/nVQ=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.55.0", "", { "os": "linux", "cpu": "arm" }, "sha512-2snoaoRfFFyGnbOcKUK36rREBYxe/Xgz3uHbiA5zbCB/s6R4DQj4mHqYAaWWhgizCUSDxV8cE9zAZ0XleNpKGw=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.52.0", "", { "os": "linux", "cpu": "arm" }, "sha512-psbUXaRZ+V8DaXz10Qf7LSHtdtdKAmC8fxXgeU608jjzrmWK4quamZMOpl6sf+dikoFHA85uE93Q0BqxrCdQrQ=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.55.0", "", { "os": "linux", "cpu": "arm" }, "sha512-q1aktHF/WRpSK81BX1dE/9vWrS2jGw1Nax2kb4DBLGAewubCLcoNyp4Zl/NSMgbv3vUS46Z33wIQkBVYOP3PYg=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jw7MgWUU9lcLCcy82updISP3EthTlfvAwR6gWNxPzqly7+fLvOi2gHQE9xXQjpqaVLm/8P+gOzlv9ODuoVlaaw=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.55.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-VD0y36aENezl/3tsclA/4G53Cc7iV+7Uoh7gz4yvcOTaEYBtJpQsE6PKDGTtUtOvGS4kv51ybfXY/nWZejO5IA=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-wZg6bLjDvh2KibyI3QFUYo8GTXneIFsd0JvehtvJiUmQ8WRPERgxd/VM4ctWb86U5FT1FkqgS8/wZKVB+AZScg=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.55.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.52.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-IngE8uxhNvxcMrLjZNDo9xNLY7rEK33AKnaMd2B46he1e/mz2CfcW6If/U1wUjdRZddm1QzQaciqZkuMkdh1FA=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.55.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-H3+DdFMv/efN3Efmhsv18jDrpiWWqKG7wsfAlQBqAt6z/E2Bx+TwEj2Nowe51CPOWB8/mFBC2dAMSgVFLvvowA=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.55.0", "", { "os": "linux", "cpu": "none" }, "sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-zji+1kb7lJKohSDjzC1IsS+K/cKRs1hdVf0ZH0VbdbiakmtLvN9twBoXo/k8VdjFax7kfo+DyPxS7vv52br1aw=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.55.0", "", { "os": "linux", "cpu": "none" }, "sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.52.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hcLBYedpCy7ToUvvBidWk7+11Yhg1oAZ4+6hKPic/mQI6NaqXJSXMps5nFlwUuX2ewhtLZZDPg63TI042qGKBg=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.55.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-IDO2loXK2OtTOhSPchU9MW25mWL2QCDGdJbjN8MXKZVS80qXe5gMTwQWu/gMJ3juoBHbkuUZNB2N1LHzNT7DoA=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.55.0", "", { "os": "linux", "cpu": "x64" }, "sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mAV2Hjn0SatJ+KoAzKUC3eJhdJ8wv+3m1KyuS0dTsbF0c5weq+QrCt/DRZZM+uj/XiKzCDEUKYsBF30e2qkcyw=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.55.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.52.0", "", { "os": "none", "cpu": "arm64" }, "sha512-vd4npaUIwChxp7XzkqmepBWTT9YMcSe/NBApVGPC30/lLyOVaV3dvma1SKo03t8O73BPRAG7EyJzGlN5cJM5hQ=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.55.0", "", { "os": "none", "cpu": "arm64" }, "sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.52.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-k2sz6gWQdMfh5HPpIS+Bw/0UEV/kaK2xuqJRrWL233sEHx9WLlsmvlPFM4HUNThkYbSN0U0vPW7LVKZWDS8hPQ=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.55.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-7p9FB5R32tw2KyyNX3wpQrR2WHwEHvMEiBlGXxeTCaRMCVNx3UtFMAUbaQ/pRNWIrEUZmYhJ6tcUH52uPTRYjQ=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.52.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-rhke69GTcArodLHpjMTfNnvjTEBryDeZcUCKK/VjXDMtfTULl6QRh0ymX5/hbCUv2WjYm9h/QbW++q2vE15gWQ=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.55.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-ZYqj3fDnOT1IaVGMP5kpmkQl4F3tQIm2ZyAxvqkJYmI0xgWWak4ss4XYwv3VDfM+TWXeC9K4uQ/wW5jm/5XABA=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.52.0", "", { "os": "win32", "cpu": "x64" }, "sha512-q5xL7oeXkZdEtNZWBdvehJcmt+GRu9l2bK40yJs1jJXlqq+r0Hygb1rTjq+FM2o/2xyt4cufH6KRplHp3Jjsvw=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.55.0", "", { "os": "win32", "cpu": "x64" }, "sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg=="],
 
     "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.23.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gOs9PVr2wEg4ox9z0aJo+RKhhImW86YL5N6yav8BK/rgPsIrwN/igSZ+pbRr723NFvUNKde9fgMhRA6JrXAOZw=="],
 
@@ -476,45 +478,45 @@
 
     "@oxlint-tsgolint/win32-x64": ["@oxlint-tsgolint/win32-x64@0.23.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5MyjFuqf+g8OUPJBSGWHJtmoWnzFJYyOg4To9WMQshZYEWig/vtu7JtJ03VWnzHv9LJkAUeApY0gVCOywFR/iQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.67.0", "", { "os": "android", "cpu": "arm" }, "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.70.0", "", { "os": "android", "cpu": "arm" }, "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.67.0", "", { "os": "android", "cpu": "arm64" }, "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.70.0", "", { "os": "android", "cpu": "arm64" }, "sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.67.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.70.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.67.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.70.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.67.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.70.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.70.0", "", { "os": "linux", "cpu": "arm" }, "sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.70.0", "", { "os": "linux", "cpu": "arm" }, "sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.70.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.70.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.67.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.70.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.70.0", "", { "os": "linux", "cpu": "none" }, "sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.70.0", "", { "os": "linux", "cpu": "none" }, "sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.67.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.70.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.70.0", "", { "os": "linux", "cpu": "x64" }, "sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.70.0", "", { "os": "linux", "cpu": "x64" }, "sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.67.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.70.0", "", { "os": "none", "cpu": "arm64" }, "sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.67.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.70.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.67.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.70.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.67.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.70.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g=="],
 
-    "@oxlint/plugins": ["@oxlint/plugins@1.61.0", "", {}, "sha512-nkOyZEF1vH527CkdQtOp1HMrVFEM4ResURvI2JFeGoup+h+43J/k/FgdOR9b9Isxg+Yae7qVDa7y3nssE8b3TQ=="],
+    "@oxlint/plugins": ["@oxlint/plugins@1.68.0", "", {}, "sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ=="],
 
     "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ=="],
 
@@ -686,6 +688,10 @@
 
     "@tanstack/store": ["@tanstack/store@0.7.7", "", {}, "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@tiptap/core": ["@tiptap/core@3.26.1", "", { "peerDependencies": { "@tiptap/pm": "3.26.1" } }, "sha512-TX9PyPqBoix0qDLjtok/bddtdSy54QhzLVha405C07V+WySOpH3s/pWYkywehZQY0SQtcrcY4MNSCeQjCbA28A=="],
 
     "@tiptap/extension-bold": ["@tiptap/extension-bold@3.26.1", "", { "peerDependencies": { "@tiptap/core": "3.26.1" } }, "sha512-VIlF2sAiV6K009pcIDotfY8mvsPaq90dxeG9Q0ZIqfMD958TUCqjHw4MGYZf0/FgP12xksBfmcR7W312xgUf9Q=="],
@@ -713,6 +719,8 @@
     "@tiptap/pm": ["@tiptap/pm@3.26.1", "", { "dependencies": { "prosemirror-changeset": "^2.3.0", "prosemirror-commands": "^1.6.2", "prosemirror-dropcursor": "^1.8.1", "prosemirror-gapcursor": "^1.3.2", "prosemirror-history": "^1.4.1", "prosemirror-inputrules": "^1.4.0", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.7", "prosemirror-schema-list": "^1.5.0", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.0", "prosemirror-transform": "^1.12.0", "prosemirror-view": "^1.41.8" } }, "sha512-48cJQRbvr9Ux0+IgM1BR5vOLU5hkC+n+uerdQy2JjrIRKpYE/huU8fQFm6PoRppoKYfilklzb29elsQ+n2TA+g=="],
 
     "@tiptap/react": ["@tiptap/react@3.26.1", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "fast-equals": "^5.3.3", "use-sync-external-store": "^1.4.0" }, "optionalDependencies": { "@tiptap/extension-bubble-menu": "^3.26.1", "@tiptap/extension-floating-menu": "^3.26.1" }, "peerDependencies": { "@tiptap/core": "3.26.1", "@tiptap/pm": "3.26.1", "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Gl7AhTJM7pjQ2WFwdIwD736oQeqUcw3GVaXYmCKtwTSO3F9PszLgeKEp6DvM+CmctTNYhu/apRfzkH3vU0h0uA=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -838,25 +846,41 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
-    "@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.24", "", { "dependencies": { "@oxc-project/runtime": "=0.133.0", "@oxc-project/types": "=0.133.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.1", "@tsdown/exe": "0.22.1", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-iXPGBABnQnrDMx89H6MOCGcTZp+QW+3rY4YMVKdE6ydchSvPk2O3MI2vgaRVfOtWJ2IjnxSnf1n2yjP67ZBRFQ=="],
+    "@vitest/browser": ["@vitest/browser@4.1.9", "", { "dependencies": { "@blazediff/core": "1.9.1", "@vitest/mocker": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pngjs": "^7.0.0", "sirv": "^3.0.2", "tinyrainbow": "^3.1.0", "ws": "^8.19.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg=="],
 
-    "@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.1.24", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Hpo9W9piSFlEsJzGkwzfDXhJGrnYByxHXF7NVQZ7g+SLOprddtlfTeM8t+gq9dxcuq0RzM8ddMAhDQP/K3fZQA=="],
+    "@vitest/browser-preview": ["@vitest/browser-preview@4.1.9", "", { "dependencies": { "@testing-library/dom": "^10.4.1", "@testing-library/user-event": "^14.6.1", "@vitest/browser": "4.1.9" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-a4/OrkMDb/WUnE4OOB/4FJbK3rYVO7YykqtUgcTKG4p2a0R3XcjPVu7SLRHFBs2+NIYhv5yxp1Lz3dbdGBjIow=="],
 
-    "@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.1.24", "", { "os": "darwin", "cpu": "x64" }, "sha512-SwnnnZrEFBiU5iKlh/CZAVwn0RFt/Udrvt3kFLtdRxMtN5bKaqTFVA2H8Y/FPCWp1QX9bs4V9ZIAeXAk06zLkw=="],
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
 
-    "@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.1.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-ImM3eqDki4DpRuHjW6dEh4St8zvbcfOMR7KQZJX42ArriCLQ/QdaYhDRRbcDi27XsOBqRxm2eqUUEymPrYIHpA=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
 
-    "@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.1.24", "", { "os": "linux", "cpu": "arm64" }, "sha512-gj4mzbob/ls8Zs7iTuF9Gr0EFFF7tdpDiPxDPBkH8tJP5OkHABlzWUwJhU+9xxcUbTaXqpHDw68Mil7jm5dpMg=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
 
-    "@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.1.24", "", { "os": "linux", "cpu": "x64" }, "sha512-x7IYK7lI+WuF1n3jSzEYU6FgJxPX/R0rDmTTsOutooGGCU7uShZvfZqIoiTXK0eFnJU5ij5BfBgenenUfsaT/A=="],
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
 
-    "@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.1.24", "", { "os": "linux", "cpu": "x64" }, "sha512-JCy2w0eSVUlWQlggK5T47MnL+j0o4EY7hLskINVI8gi+aixQF4xnYBDobz0lbxkqz3/IfiLyXUx6TcU3thcsGQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
 
-    "@voidzero-dev/vite-plus-test": ["@voidzero-dev/vite-plus-test@0.1.24", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.24", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-9NiG6UadG0iOaPL1AMsO5sDKkx6MADHw4/mMOmHWZUhhUwqzfVtnnptMK37vD71e6KyR7yAscx19FrtOWWtjvA=="],
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
 
-    "@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.1.24", "", { "os": "win32", "cpu": "arm64" }, "sha512-G+/lhLKVjyn3FmgXX8jeWgq7RcE5O1kdR7QyFayQOdlMX/ZRkvUwQD7bFaqhKzgJM6Oj3a1FH3HQPYk5QOYuCQ=="],
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
 
-    "@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.24", "", { "os": "win32", "cpu": "x64" }, "sha512-b0e5XohEV1w/RdzAtv8/Hm6tvHPXouPtBNsljjW/lDJZq3NCLND5s6lqe8H4IenrgmKSoqakHWtlqJqM36cFbw=="],
+    "@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.2.1", "", { "dependencies": { "@oxc-project/runtime": "=0.136.0", "@oxc-project/types": "=0.136.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.3", "@tsdown/exe": "0.22.3", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.8", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "unrun", "yaml"] }, "sha512-iWdtOlLezgYcDqIzxZx1yOUhY93vUB+ob+mRYBNr7/3Hf80uRyTQbqVD1WtsYaANbzeUi81SQ1ZoUraXHO+u8A=="],
+
+    "@voidzero-dev/vite-plus-darwin-arm64": ["@voidzero-dev/vite-plus-darwin-arm64@0.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9AfN/5LKRks8gbTaHPiQHT0L4yboy2xB6x6vvCRWxQMWxPS6/ZJLf5kUIZeE7I1z33AEyLKKkDscsZZVMgMLgg=="],
+
+    "@voidzero-dev/vite-plus-darwin-x64": ["@voidzero-dev/vite-plus-darwin-x64@0.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Q1vyimRbf4M82qIQSWRyr7NJaH9ag5G7vVEfGVVJlQHNprI+Q8zj2Phcs/PGf6QcyjcL8UclLznQTHU9NgnKZw=="],
+
+    "@voidzero-dev/vite-plus-linux-arm64-gnu": ["@voidzero-dev/vite-plus-linux-arm64-gnu@0.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WHW3DziqedRfhJ2upq6kC4y/pmdQWYt322DVB7+4Xb4oOa/CT9GtnSrWIiXVJ4PSO42v54+YsSTKPH2HC5RbtA=="],
+
+    "@voidzero-dev/vite-plus-linux-arm64-musl": ["@voidzero-dev/vite-plus-linux-arm64-musl@0.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-vUY7hYycZW0qEevpl7ImzZJFnOEKRYCaCOX4TBW0vk6MJZ+zj/xW7e0LOggzJcz2wbYAgLDqp5h+b8wV9dguDA=="],
+
+    "@voidzero-dev/vite-plus-linux-x64-gnu": ["@voidzero-dev/vite-plus-linux-x64-gnu@0.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tFxpToEaykBGxMQHp8M/qmr1yruRRED+c9gA1h9kmplqot04OxuqzRCWu/IiIvMJ0v3JFdOP3gqkyjXLLJhxIA=="],
+
+    "@voidzero-dev/vite-plus-linux-x64-musl": ["@voidzero-dev/vite-plus-linux-x64-musl@0.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-2scSS7wEbLO2758fqr1/bAULg7nLCFa5V8LO2b5w3g1CrTYdMTDt2WX1ghPesIi+70pYGydRbXo6iaaN43zfMg=="],
+
+    "@voidzero-dev/vite-plus-win32-arm64-msvc": ["@voidzero-dev/vite-plus-win32-arm64-msvc@0.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-3+5FJYhi9SqBszjngI2LBmvoiqEwxJWyQ5UsOUtNz6/d+yDrDw+tOgHLl4OKIh5aVNZeIGXzxvP6h24kcEqIyg=="],
+
+    "@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5sOEwEoU5PW7ObmJ5VCakU09Oh14rYCoLQJkFqvOph6PK30lN5iqWGk0KigEyfcd7Zv+fZg9EmcERDol/3Xl9w=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
@@ -925,6 +949,8 @@
     "canvas-roundrect-polyfill": ["canvas-roundrect-polyfill@0.0.1", "", {}, "sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "changelogen": ["changelogen@0.6.2", "", { "dependencies": { "c12": "^3.0.4", "confbox": "^0.2.2", "consola": "^3.4.2", "convert-gitmoji": "^0.1.5", "mri": "^1.2.0", "node-fetch-native": "^1.6.6", "ofetch": "^1.4.1", "open": "^10.1.2", "pathe": "^2.0.3", "pkg-types": "^2.2.0", "scule": "^1.3.0", "semver": "^7.7.2", "std-env": "^3.9.0" }, "bin": { "changelogen": "dist/cli.mjs" } }, "sha512-QtC7+r9BxoUm+XDAwhLbz3CgU134J1ytfE3iCpLpA4KFzX2P1e6s21RrWDwUBzfx66b1Rv+6lOA2nS2btprd+A=="],
 
@@ -1110,6 +1136,8 @@
 
     "docs": ["docs@workspace:docs"],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
@@ -1160,7 +1188,7 @@
 
     "estree-util-visit": ["estree-util-visit@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/unist": "^3.0.0" } }, "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -1169,6 +1197,8 @@
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
 
     "excalidraw": ["excalidraw@workspace:examples/excalidraw"],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "expressive-code": ["expressive-code@0.43.1", "", { "dependencies": { "@expressive-code/core": "^0.43.1", "@expressive-code/plugin-frames": "^0.43.1", "@expressive-code/plugin-shiki": "^0.43.1", "@expressive-code/plugin-text-markers": "^0.43.1" } }, "sha512-JdOzanoU825iNvslmk6Kg8Ro61eSHmDK2Zz7BynOxObVrpIXZNzrIZOwQO2uDQcGsjSYShL/8vTrXgeWYnq3NA=="],
 
@@ -1402,6 +1432,8 @@
 
     "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
@@ -1580,9 +1612,9 @@
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
-    "oxfmt": ["oxfmt@0.52.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.52.0", "@oxfmt/binding-android-arm64": "0.52.0", "@oxfmt/binding-darwin-arm64": "0.52.0", "@oxfmt/binding-darwin-x64": "0.52.0", "@oxfmt/binding-freebsd-x64": "0.52.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.52.0", "@oxfmt/binding-linux-arm-musleabihf": "0.52.0", "@oxfmt/binding-linux-arm64-gnu": "0.52.0", "@oxfmt/binding-linux-arm64-musl": "0.52.0", "@oxfmt/binding-linux-ppc64-gnu": "0.52.0", "@oxfmt/binding-linux-riscv64-gnu": "0.52.0", "@oxfmt/binding-linux-riscv64-musl": "0.52.0", "@oxfmt/binding-linux-s390x-gnu": "0.52.0", "@oxfmt/binding-linux-x64-gnu": "0.52.0", "@oxfmt/binding-linux-x64-musl": "0.52.0", "@oxfmt/binding-openharmony-arm64": "0.52.0", "@oxfmt/binding-win32-arm64-msvc": "0.52.0", "@oxfmt/binding-win32-ia32-msvc": "0.52.0", "@oxfmt/binding-win32-x64-msvc": "0.52.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-nJlYM35F64zTDMecCNhoHNkf+D/eHv7xcjj9XDSj+bFAVtN93m7v8DQMdHd6nDG6Akf/kEYYHmDUBs2Dz27Sug=="],
+    "oxfmt": ["oxfmt@0.55.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.55.0", "@oxfmt/binding-android-arm64": "0.55.0", "@oxfmt/binding-darwin-arm64": "0.55.0", "@oxfmt/binding-darwin-x64": "0.55.0", "@oxfmt/binding-freebsd-x64": "0.55.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.55.0", "@oxfmt/binding-linux-arm-musleabihf": "0.55.0", "@oxfmt/binding-linux-arm64-gnu": "0.55.0", "@oxfmt/binding-linux-arm64-musl": "0.55.0", "@oxfmt/binding-linux-ppc64-gnu": "0.55.0", "@oxfmt/binding-linux-riscv64-gnu": "0.55.0", "@oxfmt/binding-linux-riscv64-musl": "0.55.0", "@oxfmt/binding-linux-s390x-gnu": "0.55.0", "@oxfmt/binding-linux-x64-gnu": "0.55.0", "@oxfmt/binding-linux-x64-musl": "0.55.0", "@oxfmt/binding-openharmony-arm64": "0.55.0", "@oxfmt/binding-win32-arm64-msvc": "0.55.0", "@oxfmt/binding-win32-ia32-msvc": "0.55.0", "@oxfmt/binding-win32-x64-msvc": "0.55.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A=="],
 
-    "oxlint": ["oxlint@1.67.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.67.0", "@oxlint/binding-android-arm64": "1.67.0", "@oxlint/binding-darwin-arm64": "1.67.0", "@oxlint/binding-darwin-x64": "1.67.0", "@oxlint/binding-freebsd-x64": "1.67.0", "@oxlint/binding-linux-arm-gnueabihf": "1.67.0", "@oxlint/binding-linux-arm-musleabihf": "1.67.0", "@oxlint/binding-linux-arm64-gnu": "1.67.0", "@oxlint/binding-linux-arm64-musl": "1.67.0", "@oxlint/binding-linux-ppc64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-musl": "1.67.0", "@oxlint/binding-linux-s390x-gnu": "1.67.0", "@oxlint/binding-linux-x64-gnu": "1.67.0", "@oxlint/binding-linux-x64-musl": "1.67.0", "@oxlint/binding-openharmony-arm64": "1.67.0", "@oxlint/binding-win32-arm64-msvc": "1.67.0", "@oxlint/binding-win32-ia32-msvc": "1.67.0", "@oxlint/binding-win32-x64-msvc": "1.67.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ=="],
+    "oxlint": ["oxlint@1.70.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.70.0", "@oxlint/binding-android-arm64": "1.70.0", "@oxlint/binding-darwin-arm64": "1.70.0", "@oxlint/binding-darwin-x64": "1.70.0", "@oxlint/binding-freebsd-x64": "1.70.0", "@oxlint/binding-linux-arm-gnueabihf": "1.70.0", "@oxlint/binding-linux-arm-musleabihf": "1.70.0", "@oxlint/binding-linux-arm64-gnu": "1.70.0", "@oxlint/binding-linux-arm64-musl": "1.70.0", "@oxlint/binding-linux-ppc64-gnu": "1.70.0", "@oxlint/binding-linux-riscv64-gnu": "1.70.0", "@oxlint/binding-linux-riscv64-musl": "1.70.0", "@oxlint/binding-linux-s390x-gnu": "1.70.0", "@oxlint/binding-linux-x64-gnu": "1.70.0", "@oxlint/binding-linux-x64-musl": "1.70.0", "@oxlint/binding-openharmony-arm64": "1.70.0", "@oxlint/binding-win32-arm64-msvc": "1.70.0", "@oxlint/binding-win32-ia32-msvc": "1.70.0", "@oxlint/binding-win32-x64-msvc": "1.70.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g=="],
 
     "oxlint-tsgolint": ["oxlint-tsgolint@0.23.0", "", { "optionalDependencies": { "@oxlint-tsgolint/darwin-arm64": "0.23.0", "@oxlint-tsgolint/darwin-x64": "0.23.0", "@oxlint-tsgolint/linux-arm64": "0.23.0", "@oxlint-tsgolint/linux-x64": "0.23.0", "@oxlint-tsgolint/win32-arm64": "0.23.0", "@oxlint-tsgolint/win32-x64": "0.23.0" }, "bin": { "tsgolint": "bin/tsgolint.js" } }, "sha512-3mBv3CoPbh8dFbzfDGIWa2ytZjn2v+3EX4aKRXjIhsoGFzG8GCjfRirz3rwZf1wYbZzsNLTSgpw8VjQuWdp/jA=="],
 
@@ -1630,8 +1662,6 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
-    "pixelmatch": ["pixelmatch@7.2.0", "", { "dependencies": { "pngjs": "^7.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg=="],
-
     "pkg-types": ["pkg-types@2.3.1", "", { "dependencies": { "confbox": "^0.2.4", "exsolve": "^1.0.8", "pathe": "^2.0.3" } }, "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg=="],
 
     "playground": ["playground@workspace:playground"],
@@ -1653,6 +1683,8 @@
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
@@ -1701,6 +1733,8 @@
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "react-icons": ["react-icons@5.6.0", "", { "peerDependencies": { "react": "*" } }, "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-number-format": ["react-number-format@5.4.5", "", { "peerDependencies": { "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw=="],
 
@@ -1822,6 +1856,8 @@
 
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
@@ -1847,6 +1883,8 @@
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "srvx": ["srvx@0.11.16", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
@@ -1893,6 +1931,8 @@
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tldts": ["tldts@7.4.3", "", { "dependencies": { "tldts-core": "^7.4.3" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg=="],
 
@@ -1980,9 +2020,11 @@
 
     "vite": ["vite@7.3.5", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww=="],
 
-    "vite-plus": ["vite-plus@0.1.24", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@oxlint/plugins": "=1.61.0", "@voidzero-dev/vite-plus-core": "0.1.24", "@voidzero-dev/vite-plus-test": "0.1.24", "oxfmt": "=0.52.0", "oxlint": "=1.67.0", "oxlint-tsgolint": "=0.23.0" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.24", "@voidzero-dev/vite-plus-darwin-x64": "0.1.24", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.24", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.24", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.24", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.24", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.24", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.24" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-b3fr6WtCiEhetjuzW/4KcEMOAMuZxoxZATWaXKmPzOLf1upG+pzKJOFZTb94D6wiPBlwcjxoaUtF7C3uAN+VjQ=="],
+    "vite-plus": ["vite-plus@0.2.1", "", { "dependencies": { "@oxc-project/types": "=0.136.0", "@oxlint/plugins": "=1.68.0", "@vitest/browser": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "@voidzero-dev/vite-plus-core": "0.2.1", "oxfmt": "=0.55.0", "oxlint": "=1.70.0", "oxlint-tsgolint": "=0.23.0", "vitest": "4.1.9" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.2.1", "@voidzero-dev/vite-plus-darwin-x64": "0.2.1", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.2.1", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.2.1", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.2.1", "@voidzero-dev/vite-plus-linux-x64-musl": "0.2.1", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.2.1", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.2.1" }, "peerDependencies": { "@vitest/browser-playwright": "4.1.9", "@vitest/browser-webdriverio": "4.1.9" }, "optionalPeers": ["@vitest/browser-playwright", "@vitest/browser-webdriverio"], "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-q5q/Y38UkWFsNg1JO+RyRdPUqoewaSqIlMyK2p83GKNUvf4D38Ntb3PToRTDZbTRh7mWt+B+d0DQBv4nCDpMcQ=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
 
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
@@ -2005,6 +2047,8 @@
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -2062,8 +2106,6 @@
 
     "@excalidraw/mermaid-to-excalidraw/nanoid": ["nanoid@4.0.2", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="],
 
-    "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
     "@radix-ui/react-collection/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA=="],
@@ -2100,11 +2142,11 @@
 
     "@radix-ui/react-tabs/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.0.0", "", { "dependencies": { "@babel/runtime": "^7.13.10", "@radix-ui/react-use-callback-ref": "1.0.0" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0" } }, "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg=="],
 
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
     "@tiptap/react/@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
-
-    "@voidzero-dev/vite-plus-test/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
-
-    "@voidzero-dev/vite-plus-test/std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
@@ -2124,8 +2166,6 @@
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
-    "estree-util-build-jsx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
     "h3/crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
     "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
@@ -2140,6 +2180,8 @@
 
     "postcss/nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
     "roughjs/points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
     "sass/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
@@ -2149,6 +2191,8 @@
     "starlight-llms-txt/@astrojs/mdx": ["@astrojs/mdx@5.0.6", "", { "dependencies": { "@astrojs/markdown-remark": "7.1.2", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
+
+    "vitest/std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "teleportal",
       "dependencies": {
-        "@logtape/logtape": "2.1.5",
-        "@tanstack/devtools-event-client": "0.4.3",
+        "@logtape/logtape": "2.2.1",
+        "@tanstack/devtools-event-client": "0.5.0",
         "hookable": "6.1.1",
         "jose": "6.2.3",
         "lib0": "0.2.117",
@@ -22,7 +22,7 @@
         "eventsource": "4.1.0",
         "ioredis": "5.11.1",
         "msw": "2.14.6",
-        "srvx": "0.11.16",
+        "srvx": "0.11.17",
         "unstorage": "1.17.5",
         "vite-plus": "0.2.1",
       },
@@ -87,10 +87,10 @@
         "@blocknote/core": "0.51.4",
         "@blocknote/mantine": "0.51.4",
         "@blocknote/react": "0.51.4",
-        "@logtape/adaptor-pino": "2.1.5",
-        "@logtape/logtape": "2.1.5",
-        "@logtape/pretty": "2.1.5",
-        "@tanstack/react-devtools": "0.10.5",
+        "@logtape/adaptor-pino": "2.2.1",
+        "@logtape/logtape": "2.2.1",
+        "@logtape/pretty": "2.2.1",
+        "@tanstack/react-devtools": "0.10.8",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "bun-plugin-tailwind": "0.1.2",
@@ -99,7 +99,7 @@
         "pino": "10.3.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "srvx": "0.11.16",
+        "srvx": "0.11.17",
         "tailwindcss": "4.3.1",
         "y-prosemirror": "1.3.7",
       },
@@ -360,11 +360,11 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@logtape/adaptor-pino": ["@logtape/adaptor-pino@2.1.5", "", { "peerDependencies": { "@logtape/logtape": "^2.1.5", "pino": "^9.7.0" } }, "sha512-mCkspkeTFLfIZT2l9cf6TGMtFnAESlXUndThwvtwixaON2jpBb9XuXzuTnxiJipyWIlQNLd0yYCsjwmYWB+Nlg=="],
+    "@logtape/adaptor-pino": ["@logtape/adaptor-pino@2.2.1", "", { "peerDependencies": { "@logtape/logtape": "^2.2.1", "pino": "^9.7.0 || ^10.0.0" } }, "sha512-VAlXHnFD+K/uqWrUqde1cGcuLMGg+Op8f3JqOiN4fQS0puDjM28nm2Zn88q5QThTUb5kyjKJ2O+ZaBWfuvD4Ww=="],
 
-    "@logtape/logtape": ["@logtape/logtape@2.1.5", "", {}, "sha512-59fyskQ9hR5mYQP9YMznZDtwRS4gIN7VIJkoRe0SLTmU+BQGaSP1s+ve8r+Binj1m6jNpwlF7yu9fz2/asSFLw=="],
+    "@logtape/logtape": ["@logtape/logtape@2.2.1", "", {}, "sha512-SkRptJUEAbGuf+/blXDxDa8sSq8no+lxJlfwPTMzrHIULOMsNZRaqT2qF3H9tmGOsaLYc+uF3orRCQfoH0qKzA=="],
 
-    "@logtape/pretty": ["@logtape/pretty@2.1.5", "", { "peerDependencies": { "@logtape/logtape": "^2.1.5" } }, "sha512-oZskWBaNGK3KlO21XYaJ0OQd83t6o+FuJj5ONrNmV95dTOj1ZHnjvKVls21a+zAFuXOJGHnlSfvAtcGfKpzX5A=="],
+    "@logtape/pretty": ["@logtape/pretty@2.2.1", "", { "peerDependencies": { "@logtape/logtape": "^2.2.1" } }, "sha512-JWUFYP79t9MFDrcSsG6yYZ8M92b7PRcvUDV0FTZnTrycpk98UrzgFLJbWAFewYx5wEcbNRVnISsza46GksDDUw=="],
 
     "@mantine/core": ["@mantine/core@9.3.1", "", { "dependencies": { "@floating-ui/react": "^0.27.19", "clsx": "^2.1.1", "react-number-format": "^5.4.5", "react-remove-scroll": "^2.7.2", "type-fest": "^5.6.0" }, "peerDependencies": { "@mantine/hooks": "9.3.1", "react": "^19.2.0", "react-dom": "^19.2.0" } }, "sha512-4rBoHpggSohayE+Os7lKdbsHTw7m/uZRKYjk9DN6cKBhQIjdiULdcG+b4b5CMVZSqZDHPgT70uWGI7yqkn8Ufw=="],
 
@@ -672,17 +672,17 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@tanstack/devtools": ["@tanstack/devtools@0.12.2", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.6", "@tanstack/devtools-event-bus": "0.4.1", "@tanstack/devtools-ui": "0.5.2", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-Xdl8pLzoDUvXaclQ0poY36WAPx0jEHk8vqUFd8FYFUm1BMshtB7RnTgD1HE9jCAXODxqw9I0gXBiUZLK3o3+Bw=="],
+    "@tanstack/devtools": ["@tanstack/devtools@0.12.5", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.3", "@solid-primitives/keyboard": "^1.3.3", "@solid-primitives/resize-observer": "^2.1.3", "@tanstack/devtools-client": "0.0.8", "@tanstack/devtools-event-bus": "0.4.2", "@tanstack/devtools-ui": "0.6.0", "clsx": "^2.1.1", "goober": "^2.1.16", "solid-js": "^1.9.9" }, "bin": { "intent": "./bin/intent.js" } }, "sha512-JdxTSeVdjJheycgz4c7qbldNKDCEDWlWr1l9dZBhd9sOmRBT5Z70ka9Eb8mb+FUnalcOIB62IDSR/iSxAIUD8Q=="],
 
-    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.6", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" } }, "sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ=="],
+    "@tanstack/devtools-client": ["@tanstack/devtools-client@0.0.8", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.5.0" } }, "sha512-cG3iZkGWCwN330bLBKa8+9r4Of2AXNoz2zUqcsy/4XsD3105ghVBx78cGyvJj9fSclNomPxoqAnDGXXhg1WLvA=="],
 
-    "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.4.1", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-cNnJ89Q021Zf883rlbBTfsaxTfi2r73/qejGtyTa7ksErF3hyDyAq1aTbo5crK9dAL7zSHh9viKY1BtMls1QOA=="],
+    "@tanstack/devtools-event-bus": ["@tanstack/devtools-event-bus@0.4.2", "", { "dependencies": { "ws": "^8.18.3" } }, "sha512-2LHzhwBFlKHCcklsQrGe8TeyjHd4XAF8nuCO6wHmva5fePUkJUULbu6CsCNAlGlCi0KkEsMXZSvRdR4HgMq4yA=="],
 
-    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.3", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw=="],
+    "@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.5.0", "", { "bin": { "intent": "./bin/intent.js" } }, "sha512-H+OH3zC6Vhu/K0NaVfQKknEKawc/+2PT+D3SB3Ox0V8SiMlTo0abbmH2rH0721R2aNYbjdMXA1oENOd8E2UVoA=="],
 
-    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.5.2", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-GtaMk8kaGZ9ZdR8Pu5RAfcse/ZrxzH/xsAIFtHMapLs2VMqSPFfb1NvIDO1MAAfUcub8Ix8XKQEP0uYSPzoFKw=="],
+    "@tanstack/devtools-ui": ["@tanstack/devtools-ui@0.6.0", "", { "dependencies": { "clsx": "^2.1.1", "dayjs": "^1.11.19", "goober": "^2.1.16", "solid-js": "^1.9.9" } }, "sha512-CVaM6rT6Nl5ijo83vJYFa2SjofvpuOl/uOvbYGhBrRgUhhelNHhx8zZX+hnZCHmIr0/lzM65hsocnZ72592Rvg=="],
 
-    "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.5", "", { "dependencies": { "@tanstack/devtools": "0.12.2" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-orVsRJ7oAXFb7oyafQCgx9YuK44jpILh5T/ddYuxAsolNfN5DZBr5/NLrWErD7HCGIzvYzg1TZI4sPxmiKvtvA=="],
+    "@tanstack/react-devtools": ["@tanstack/react-devtools@0.10.8", "", { "dependencies": { "@tanstack/devtools": "0.12.5" }, "peerDependencies": { "@types/react": ">=16.8", "@types/react-dom": ">=16.8", "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-YJV6YttQf9lhhPbPBLULgy1eScEvJUMsCS26mjg9hfBKgAJQA5sF9zvzorDzW9Ob6o/asoXikO81JnRUVuFX0Q=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.7.7", "", { "dependencies": { "@tanstack/store": "0.7.7", "use-sync-external-store": "^1.5.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg=="],
 
@@ -1882,7 +1882,7 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
-    "srvx": ["srvx@0.11.16", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw=="],
+    "srvx": ["srvx@0.11.17", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 

--- a/guides/10-rate-limiting/server.ts
+++ b/guides/10-rate-limiting/server.ts
@@ -36,16 +36,8 @@ const server = new Server({
     ],
     // rate-limiting tracking is single-node by default, if using multiple nodes, they need an external store
     rateLimitStorage: new UnstorageRateLimitStorage(storage),
-    // callback when a rate limit is exceeded, user will be disconnected automatically
-    onRateLimitExceeded: (details) => {
-      console.warn("Rate limit exceeded", details);
-    },
     // track message sizes for abuse
     maxMessageSize: 10 * 1024 * 1024, // 10MB as the max acceptable message size
-    // callback when a message size limit is exceeded, user is disconnected automatically
-    onMessageSizeExceeded: (details) => {
-      console.warn("Message size exceeded", details);
-    },
   },
 });
 

--- a/guides/11-kitchen-sink/server.ts
+++ b/guides/11-kitchen-sink/server.ts
@@ -87,16 +87,8 @@ const server = new Server({
     ],
     // rate-limiting tracking is single-node by default, if using multiple nodes, they need an external store
     rateLimitStorage: new UnstorageRateLimitStorage(backingStorage),
-    // callback when a rate limit is exceeded, user will be disconnected automatically
-    onRateLimitExceeded: (details) => {
-      console.warn("Rate limit exceeded", details);
-    },
     // track message sizes for abuse
     maxMessageSize: 10 * 1024 * 1024, // 10MB as the max acceptable message size
-    // callback when a message size limit is exceeded, user is disconnected automatically
-    onMessageSizeExceeded: (details) => {
-      console.warn("Message size exceeded", details);
-    },
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "msw": "2.14.6",
     "srvx": "0.11.16",
     "unstorage": "1.17.5",
-    "vite-plus": "0.1.24"
+    "vite-plus": "0.2.1"
   },
   "peerDependencies": {
     "@nats-io/transport-node": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -68,11 +68,17 @@
     "dev:encrypted": "PORT=1234 bun run --watch ./playground/bun/encrypted-server.ts",
     "release": "bun run test && changelogen --release && npm publish && git push --follow-tags",
     "test": "bun run test:types && bun test --dots",
-    "test:types": "vp check --no-fmt"
+    "test:types": "vp check --no-fmt",
+    "bench": "bun test ./benchmarks/ --timeout 60000",
+    "bench:storage": "bun test ./benchmarks/storage.bench.test.ts --timeout 60000",
+    "bench:server": "bun test ./benchmarks/server.bench.test.ts --timeout 60000",
+    "bench:sync": "bun test ./benchmarks/sync.bench.test.ts --timeout 60000",
+    "bench:protocol": "bun test ./benchmarks/protocol.bench.test.ts --timeout 60000",
+    "bench:file": "bun test ./benchmarks/file.bench.test.ts --timeout 60000"
   },
   "dependencies": {
-    "@logtape/logtape": "2.1.5",
-    "@tanstack/devtools-event-client": "0.4.3",
+    "@logtape/logtape": "2.2.1",
+    "@tanstack/devtools-event-client": "0.5.0",
     "hookable": "6.1.1",
     "jose": "6.2.3",
     "lib0": "0.2.117",
@@ -88,7 +94,7 @@
     "eventsource": "4.1.0",
     "ioredis": "5.11.1",
     "msw": "2.14.6",
-    "srvx": "0.11.16",
+    "srvx": "0.11.17",
     "unstorage": "1.17.5",
     "vite-plus": "0.2.1"
   },

--- a/playground/bun/server.ts
+++ b/playground/bun/server.ts
@@ -19,7 +19,7 @@ import {
   UnstorageTemporaryUploadStorage,
 } from "teleportal/storage";
 import { createTokenManager, TokenPayload } from "teleportal/token";
-import type { RateLimitRule } from "teleportal/transports/rate-limiter";
+import { defaultRateLimitRules } from "teleportal/transports/rate-limiter";
 import { tokenAuthenticatedWebsocketHandler } from "teleportal/websocket-server";
 
 import "../src/backend/logger";
@@ -74,21 +74,7 @@ const tokenManager = createTokenManager({
   issuer: "my-collaborative-app",
 });
 
-// Configure rate limit rules
-const rateLimitRules: RateLimitRule<TokenPayload & { clientId: string }>[] = [
-  {
-    id: "per-user",
-    maxMessages: 100, // 100 messages per window
-    windowMs: 1000, // 1 second window
-    trackBy: "user",
-  },
-  {
-    id: "per-document",
-    maxMessages: 500, // 500 messages per window per document
-    windowMs: 10000, // 10 second window
-    trackBy: "document",
-  },
-];
+const rateLimitRules = defaultRateLimitRules<TokenPayload & { clientId: string }>();
 
 const server = new Server<TokenPayload & { clientId: string }>({
   storage: async (ctx) => {
@@ -113,12 +99,6 @@ const server = new Server<TokenPayload & { clientId: string }>({
     maxMessageSize: 10 * 1024 * 1024, // 10MB
     getUserId: (message) => message.context?.userId,
     getDocumentId: (message) => message.document,
-    onRateLimitExceeded: (details) => {
-      console.warn("Rate limit exceeded", details);
-    },
-    onMessageSizeExceeded: (details) => {
-      console.warn("Message size exceeded", details);
-    },
   },
 });
 

--- a/playground/package.json
+++ b/playground/package.json
@@ -18,10 +18,10 @@
     "@blocknote/core": "0.51.4",
     "@blocknote/mantine": "0.51.4",
     "@blocknote/react": "0.51.4",
-    "@logtape/adaptor-pino": "2.1.5",
-    "@logtape/logtape": "2.1.5",
-    "@logtape/pretty": "2.1.5",
-    "@tanstack/react-devtools": "0.10.5",
+    "@logtape/adaptor-pino": "2.2.1",
+    "@logtape/logtape": "2.2.1",
+    "@logtape/pretty": "2.2.1",
+    "@tanstack/react-devtools": "0.10.8",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "bun-plugin-tailwind": "0.1.2",
@@ -30,7 +30,7 @@
     "pino": "10.3.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "srvx": "0.11.16",
+    "srvx": "0.11.17",
     "tailwindcss": "4.3.1",
     "y-prosemirror": "1.3.7"
   }

--- a/playground/src/components/documentEditor.tsx
+++ b/playground/src/components/documentEditor.tsx
@@ -67,43 +67,42 @@ export function DocumentEditor({ documentId, isSidebarOpen, toggleSidebar }: Doc
     <div className="flex-1 flex flex-col h-full overflow-hidden">
       {/* Document Header */}
       <div className="border-b h-auto min-h-[60px] md:h-20 border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 px-4 md:px-6 py-3 md:py-4 shrink-0">
-        <div className="flex flex-col gap-2">
-          {/* Top row: Hamburger, Title, Versions button */}
-          <div className="flex items-center gap-2 md:gap-4 flex-nowrap min-w-0">
-            {/* Hamburger button for mobile */}
-            {toggleSidebar && (
-              <button
-                onClick={toggleSidebar}
-                className="md:hidden p-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shrink-0"
-                aria-label="Toggle sidebar"
-                type="button"
+        <div className="flex items-center gap-2 md:gap-4 flex-nowrap min-w-0">
+          {/* Hamburger button for mobile */}
+          {toggleSidebar && (
+            <button
+              onClick={toggleSidebar}
+              className="md:hidden p-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors shrink-0"
+              aria-label="Toggle sidebar"
+              type="button"
+            >
+              <svg
+                className="w-6 h-6 text-gray-600 dark:text-gray-300"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
               >
-                <svg
-                  className="w-6 h-6 text-gray-600 dark:text-gray-300"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  {isSidebarOpen ? (
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  ) : (
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 6h16M4 12h16M4 18h16"
-                    />
-                  )}
-                </svg>
-              </button>
-            )}
-            {/* Title and icon */}
-            <div className="flex items-center gap-2 min-w-0 shrink">
+                {isSidebarOpen ? (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                ) : (
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                )}
+              </svg>
+            </button>
+          )}
+          {/* Title, icon, and date */}
+          <div className="min-w-0 shrink">
+            <div className="flex items-center gap-2">
               <h1 className="text-lg md:text-xl font-semibold text-gray-900 dark:text-white truncate">
                 {document.name}
               </h1>
@@ -123,59 +122,58 @@ export function DocumentEditor({ documentId, isSidebarOpen, toggleSidebar }: Doc
                 </svg>
               )}
             </div>
-            {/* Versions + Authorship buttons - pushed to the right */}
-            <div className="flex items-center ml-auto shrink-0 gap-2">
-              <button
-                onClick={() => setIsAttributionPanelOpen((v) => !v)}
-                className={`px-3 py-2 text-sm font-medium border rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap ${
-                  isAttributionPanelOpen
-                    ? "text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700"
-                    : "text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
-                }`}
-                title="See who wrote what"
-              >
-                <svg
-                  className="w-4 h-4 shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-1.13a4 4 0 10-4-4 4 4 0 004 4zm6 0a4 4 0 10-3-6.65"
-                  />
-                </svg>
-                <span className="hidden md:inline">Authorship</span>
-              </button>
-              <button
-                onClick={() => setIsMilestonePanelOpen(true)}
-                className="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"
-                title="View document versions"
-              >
-                <svg
-                  className="w-4 h-4 shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                  />
-                </svg>
-                <span className="hidden md:inline">Versions</span>
-              </button>
-            </div>
+            <p className="hidden md:block text-sm text-gray-500 dark:text-gray-400">
+              Created {new Date(document.createdAt).toLocaleDateString()} • Last updated{" "}
+              {new Date(document.updatedAt).toLocaleDateString()}
+            </p>
           </div>
-          {/* Bottom row: Date text */}
-          <p className="hidden md:block text-sm text-gray-500 dark:text-gray-400">
-            Created {new Date(document.createdAt).toLocaleDateString()} • Last updated{" "}
-            {new Date(document.updatedAt).toLocaleDateString()}
-          </p>
+          {/* Versions + Authorship buttons - pushed to the right */}
+          <div className="flex items-center ml-auto shrink-0 gap-2">
+            <button
+              onClick={() => setIsAttributionPanelOpen((v) => !v)}
+              className={`px-3 py-2 text-sm font-medium border rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap ${
+                isAttributionPanelOpen
+                  ? "text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-700"
+                  : "text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700"
+              }`}
+              title="See who wrote what"
+            >
+              <svg
+                className="w-4 h-4 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-1.13a4 4 0 10-4-4 4 4 0 004 4zm6 0a4 4 0 10-3-6.65"
+                />
+              </svg>
+              <span className="hidden md:inline">Authorship</span>
+            </button>
+            <button
+              onClick={() => setIsMilestonePanelOpen(true)}
+              className="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap"
+              title="View document versions"
+            >
+              <svg
+                className="w-4 h-4 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                />
+              </svg>
+              <span className="hidden md:inline">Versions</span>
+            </button>
+          </div>
         </div>
       </div>
 

--- a/playground/src/components/editor.tsx
+++ b/playground/src/components/editor.tsx
@@ -38,8 +38,8 @@ export function Editor({ provider, user, selectedMilestone }: EditorProps) {
       : undefined,
     domAttributes: {
       editor: {
-        class: "flex-1 w-full min-h-full",
-        style: "min-height: calc(100vh - 200px);",
+        class: "w-full",
+        style: "",
       },
     },
     async uploadFile(file, blockId) {
@@ -110,7 +110,7 @@ export function Editor({ provider, user, selectedMilestone }: EditorProps) {
 
   return (
     <div className="h-full w-full flex flex-col touch-manipulation">
-      <BlockNoteView editor={editor} className="h-full w-full flex flex-col" />
+      <BlockNoteView editor={editor} className="h-full w-full" />
     </div>
   );
 }

--- a/playground/src/components/editor.tsx
+++ b/playground/src/components/editor.tsx
@@ -44,7 +44,7 @@ export function Editor({ provider, user, selectedMilestone }: EditorProps) {
     },
     async uploadFile(file, blockId) {
       try {
-        const fileId = await provider.rpc.files.upload(file, blockId);
+        const fileId = await provider.rpc.files.upload(file, { fileId: blockId });
 
         return `teleportal://${fileId}`;
       } catch (error) {

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -103,6 +103,20 @@ select:focus-visible {
   background: #718096;
 }
 
+/* Make the editor fill available vertical space */
+.bn-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.bn-container > .bn-editor {
+  flex: 1;
+}
+
+.bn-container > .bn-root {
+  height: auto;
+}
+
 /* Safe area insets for mobile devices with notches */
 @supports (padding: max(0px)) {
   body {

--- a/playground/src/utils/providers.tsx
+++ b/playground/src/utils/providers.tsx
@@ -10,8 +10,11 @@ import { createTokenManager, DocumentAccessBuilder } from "teleportal/token";
 import { createMilestoneRpc } from "teleportal/protocols/milestone";
 import { createAttributionRpc } from "teleportal/protocols/attribution";
 import { createFileRpc } from "teleportal/protocols/file";
+import { IdbFileCache } from "teleportal/storage";
 
 import { getEncryptedTransport } from "./encrypted";
+
+const fileCache = new IdbFileCache();
 import { ClientContext, Transport } from "teleportal";
 import { EncryptionClient } from "../../../src/transports/encrypted/client";
 import { getIdentity } from "./identity";
@@ -93,7 +96,7 @@ class ProviderManager {
         rpc: {
           milestones: createMilestoneRpc,
           attribution: createAttributionRpc,
-          files: () => createFileRpc({ encryptionKey: key }),
+          files: () => createFileRpc({ encryptionKey: key, cache: fileCache }),
         },
         getTransport: ({ document, ydoc, awareness, getDefaultTransport }) => {
           const baseTransport = key
@@ -113,7 +116,7 @@ class ProviderManager {
         rpc: {
           milestones: createMilestoneRpc,
           attribution: createAttributionRpc,
-          files: () => createFileRpc({ encryptionKey: key }),
+          files: () => createFileRpc({ encryptionKey: key, cache: fileCache }),
         },
         getTransport: ({ document, ydoc, awareness, getDefaultTransport }) => {
           const baseTransport = key

--- a/src/encryption-key/index.ts
+++ b/src/encryption-key/index.ts
@@ -152,3 +152,6 @@ export async function decryptUpdate(
     throw new Error(`Decryption failed: ${error}`);
   }
 }
+
+export * from "./key-wrapping";
+export * from "./key-resolver";

--- a/src/encryption-key/key-resolver.test.ts
+++ b/src/encryption-key/key-resolver.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { encryptUpdate, decryptUpdate } from "./index";
+import { passwordKey } from "./key-resolver";
+
+describe("passwordKey", () => {
+  it("should derive a consistent key for the same passphrase + document", async () => {
+    const resolver1 = passwordKey("my-secret");
+    const resolver2 = passwordKey("my-secret");
+
+    const key1 = await resolver1.resolve({ document: "doc-1", connection: {} as any });
+    const key2 = await resolver2.resolve({ document: "doc-1", connection: {} as any });
+
+    const exported1 = await crypto.subtle.exportKey("jwk", key1);
+    const exported2 = await crypto.subtle.exportKey("jwk", key2);
+    expect(exported1.k).toBe(exported2.k);
+  });
+
+  it("should derive different keys for different documents", async () => {
+    const resolver = passwordKey("my-secret");
+
+    const key1 = await resolver.resolve({ document: "doc-1", connection: {} as any });
+    const key2 = await resolver.resolve({ document: "doc-2", connection: {} as any });
+
+    const exported1 = await crypto.subtle.exportKey("jwk", key1);
+    const exported2 = await crypto.subtle.exportKey("jwk", key2);
+    expect(exported1.k).not.toBe(exported2.k);
+  });
+
+  it("should derive different keys for different passphrases", async () => {
+    const resolver1 = passwordKey("password-a");
+    const resolver2 = passwordKey("password-b");
+
+    const key1 = await resolver1.resolve({ document: "doc-1", connection: {} as any });
+    const key2 = await resolver2.resolve({ document: "doc-1", connection: {} as any });
+
+    const exported1 = await crypto.subtle.exportKey("jwk", key1);
+    const exported2 = await crypto.subtle.exportKey("jwk", key2);
+    expect(exported1.k).not.toBe(exported2.k);
+  });
+
+  it("should cache the derived key for repeated resolves", async () => {
+    const resolver = passwordKey("my-secret");
+
+    const key1 = await resolver.resolve({ document: "doc-1", connection: {} as any });
+    const key2 = await resolver.resolve({ document: "doc-1", connection: {} as any });
+
+    expect(key1).toBe(key2);
+  });
+
+  it("should produce a usable AES-GCM key", async () => {
+    const resolver = passwordKey("my-secret");
+    const key = await resolver.resolve({ document: "doc-1", connection: {} as any });
+
+    expect(key.algorithm).toEqual({ name: "AES-GCM", length: 256 });
+
+    const plaintext = new Uint8Array([10, 20, 30]);
+    const encrypted = await encryptUpdate(key, plaintext);
+    const decrypted = await decryptUpdate(key, encrypted);
+    expect(decrypted).toEqual(plaintext);
+  });
+});

--- a/src/encryption-key/key-resolver.ts
+++ b/src/encryption-key/key-resolver.ts
@@ -1,0 +1,58 @@
+import type { Connection } from "teleportal/providers";
+
+const encoder = new TextEncoder();
+
+export type KeyResolverContext = {
+  document: string;
+  connection: Connection;
+};
+
+/**
+ * A `KeyResolver` asynchronously resolves an encryption key for a document.
+ *
+ * Pass as the `encryptionKey` option to `Provider.create` — the key will be
+ * resolved after the connection is ready but before the Provider is constructed.
+ */
+export type KeyResolver = {
+  resolve(ctx: KeyResolverContext): Promise<CryptoKey>;
+  onInvalidate?(callback: (document: string) => void): void;
+};
+
+/**
+ * Derive a per-document encryption key from a shared passphrase via PBKDF2.
+ *
+ * All users with the same passphrase derive the same key independently —
+ * no server involvement, no key registry. Good for "share a link with a
+ * password" use cases. The trade-off: no per-user revocation.
+ */
+export function passwordKey(passphrase: string): KeyResolver {
+  const cache = new Map<string, CryptoKey>();
+  return {
+    async resolve({ document }) {
+      let key = cache.get(document);
+      if (!key) {
+        const keyMaterial = await crypto.subtle.importKey(
+          "raw",
+          encoder.encode(passphrase),
+          "PBKDF2",
+          false,
+          ["deriveKey"],
+        );
+        key = await crypto.subtle.deriveKey(
+          {
+            name: "PBKDF2",
+            salt: encoder.encode(`teleportal-pwd:${document}`),
+            iterations: 600_000,
+            hash: "SHA-256",
+          },
+          keyMaterial,
+          { name: "AES-GCM", length: 256 },
+          true,
+          ["encrypt", "decrypt"],
+        );
+        cache.set(document, key);
+      }
+      return key;
+    },
+  };
+}

--- a/src/encryption-key/key-wrapping.test.ts
+++ b/src/encryption-key/key-wrapping.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "bun:test";
+import { createEncryptionKey, encryptUpdate, decryptUpdate } from "./index";
+import {
+  deriveWrappingKey,
+  wrapDocumentKey,
+  unwrapDocumentKey,
+  exportWrappingKey,
+  importWrappingKey,
+} from "./key-wrapping";
+
+const MASTER_SECRET = crypto.getRandomValues(new Uint8Array(32));
+
+describe("Key Wrapping", () => {
+  describe("deriveWrappingKey", () => {
+    it("should derive a deterministic wrapping key from masterSecret + userId", async () => {
+      const key1 = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const key2 = await deriveWrappingKey(MASTER_SECRET, "alice");
+
+      const exported1 = await exportWrappingKey(key1);
+      const exported2 = await exportWrappingKey(key2);
+      expect(exported1).toBe(exported2);
+    });
+
+    it("should derive different keys for different userIds (domain separation)", async () => {
+      const keyAlice = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const keyBob = await deriveWrappingKey(MASTER_SECRET, "bob");
+
+      const exportedAlice = await exportWrappingKey(keyAlice);
+      const exportedBob = await exportWrappingKey(keyBob);
+      expect(exportedAlice).not.toBe(exportedBob);
+    });
+
+    it("should derive different keys for different master secrets", async () => {
+      const otherSecret = crypto.getRandomValues(new Uint8Array(32));
+      const key1 = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const key2 = await deriveWrappingKey(otherSecret, "alice");
+
+      const exported1 = await exportWrappingKey(key1);
+      const exported2 = await exportWrappingKey(key2);
+      expect(exported1).not.toBe(exported2);
+    });
+
+    it("should produce an AES-KW key with wrapKey/unwrapKey usages", async () => {
+      const key = await deriveWrappingKey(MASTER_SECRET, "alice");
+      expect(key.algorithm).toEqual({ name: "AES-KW", length: 256 });
+      expect(key.usages).toContain("wrapKey");
+      expect(key.usages).toContain("unwrapKey");
+    });
+  });
+
+  describe("wrapDocumentKey / unwrapDocumentKey", () => {
+    it("should round-trip a document key through wrap → unwrap", async () => {
+      const wrappingKey = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const documentKey = await createEncryptionKey();
+
+      const wrapped = await wrapDocumentKey(wrappingKey, documentKey);
+      const unwrapped = await unwrapDocumentKey(wrappingKey, wrapped);
+
+      const originalExported = await crypto.subtle.exportKey("jwk", documentKey);
+      const unwrappedExported = await crypto.subtle.exportKey("jwk", unwrapped);
+      expect(unwrappedExported.k).toBe(originalExported.k);
+    });
+
+    it("should produce an opaque blob different from the raw key", async () => {
+      const wrappingKey = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const documentKey = await createEncryptionKey();
+
+      const wrapped = await wrapDocumentKey(wrappingKey, documentKey);
+      const rawKey = await crypto.subtle.exportKey("raw", documentKey);
+
+      expect(wrapped.byteLength).toBeGreaterThan(0);
+      expect(wrapped).not.toEqual(new Uint8Array(rawKey));
+    });
+
+    it("should fail to unwrap with a different wrapping key", async () => {
+      const wrappingKeyAlice = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const wrappingKeyBob = await deriveWrappingKey(MASTER_SECRET, "bob");
+      const documentKey = await createEncryptionKey();
+
+      const wrapped = await wrapDocumentKey(wrappingKeyAlice, documentKey);
+
+      await expect(unwrapDocumentKey(wrappingKeyBob, wrapped)).rejects.toThrow();
+    });
+
+    it("should produce an unwrapped key that works for encrypt/decrypt", async () => {
+      const wrappingKey = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const documentKey = await createEncryptionKey();
+
+      const wrapped = await wrapDocumentKey(wrappingKey, documentKey);
+      const unwrapped = await unwrapDocumentKey(wrappingKey, wrapped);
+
+      const plaintext = new Uint8Array([1, 2, 3, 4, 5]);
+      const encrypted = await encryptUpdate(unwrapped, plaintext);
+      const decrypted = await decryptUpdate(unwrapped, encrypted);
+      expect(decrypted).toEqual(plaintext);
+    });
+  });
+
+  describe("exportWrappingKey / importWrappingKey", () => {
+    it("should round-trip a wrapping key through export → import", async () => {
+      const original = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const exported = await exportWrappingKey(original);
+      const imported = await importWrappingKey(exported);
+
+      const reExported = await exportWrappingKey(imported);
+      expect(reExported).toBe(exported);
+    });
+
+    it("should produce a string suitable for JWT claims", async () => {
+      const key = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const exported = await exportWrappingKey(key);
+
+      expect(typeof exported).toBe("string");
+      expect(exported.length).toBeGreaterThan(0);
+    });
+
+    it("should import a key that can unwrap document keys", async () => {
+      const original = await deriveWrappingKey(MASTER_SECRET, "alice");
+      const exported = await exportWrappingKey(original);
+      const imported = await importWrappingKey(exported);
+
+      const documentKey = await createEncryptionKey();
+      const wrapped = await wrapDocumentKey(original, documentKey);
+      const unwrapped = await unwrapDocumentKey(imported, wrapped);
+
+      const docExported = await crypto.subtle.exportKey("jwk", documentKey);
+      const unwrappedExported = await crypto.subtle.exportKey("jwk", unwrapped);
+      expect(unwrappedExported.k).toBe(docExported.k);
+    });
+  });
+});

--- a/src/encryption-key/key-wrapping.ts
+++ b/src/encryption-key/key-wrapping.ts
@@ -1,0 +1,80 @@
+const encoder = new TextEncoder();
+
+/**
+ * Derive a per-user wrapping key from the app's master secret via HKDF-SHA256.
+ *
+ * The info string is domain-separated: `"teleportal-kwk:{userId}"` so that
+ * a leaked wrapping key for one user cannot be used to derive another's.
+ */
+export async function deriveWrappingKey(
+  masterSecret: Uint8Array,
+  userId: string,
+): Promise<CryptoKey> {
+  const keyMaterial = await crypto.subtle.importKey("raw", masterSecret, "HKDF", false, [
+    "deriveKey",
+  ]);
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(0),
+      info: encoder.encode(`teleportal-kwk:${userId}`),
+    },
+    keyMaterial,
+    { name: "AES-KW", length: 256 },
+    true,
+    ["wrapKey", "unwrapKey"],
+  );
+}
+
+/**
+ * Wrap a document encryption key (AES-256-GCM) using AES-KW (RFC 3394).
+ * Returns the wrapped key blob for storage.
+ */
+export async function wrapDocumentKey(
+  wrappingKey: CryptoKey,
+  documentKey: CryptoKey,
+): Promise<Uint8Array> {
+  const wrapped = await crypto.subtle.wrapKey("raw", documentKey, wrappingKey, "AES-KW");
+  return new Uint8Array(wrapped);
+}
+
+/**
+ * Unwrap a document encryption key from a stored blob.
+ * Returns a usable AES-256-GCM CryptoKey.
+ */
+export async function unwrapDocumentKey(
+  wrappingKey: CryptoKey,
+  wrappedKey: Uint8Array,
+): Promise<CryptoKey> {
+  return crypto.subtle.unwrapKey(
+    "raw",
+    wrappedKey,
+    wrappingKey,
+    "AES-KW",
+    { name: "AES-GCM", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/**
+ * Export a wrapping key to a string suitable for embedding in a JWT claim.
+ */
+export async function exportWrappingKey(key: CryptoKey): Promise<string> {
+  const exported = await crypto.subtle.exportKey("jwk", key);
+  return exported.k!;
+}
+
+/**
+ * Import a wrapping key from a string (e.g. extracted from a JWT claim).
+ */
+export async function importWrappingKey(keyString: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "jwk",
+    { k: keyString, alg: "A256KW", ext: true, key_ops: ["wrapKey", "unwrapKey"], kty: "oct" },
+    { name: "AES-KW", length: 256 },
+    true,
+    ["wrapKey", "unwrapKey"],
+  );
+}

--- a/src/http/handlers.ts
+++ b/src/http/handlers.ts
@@ -10,6 +10,7 @@ import {
   getPubSubSink,
   getPubSubSource,
   getSSESink,
+  withAckSink,
   withAckTrackingSink,
 } from "teleportal/transports";
 import { emitWideEvent } from "teleportal/server";
@@ -71,7 +72,12 @@ export function getSSEReaderEndpoint<Context extends ServerContext>({
         ...(await getContext(req)),
       } as Context;
 
-      const sseSink = getSSESink({ context });
+      const sseSink = withAckSink(getSSESink({ context }), {
+        pubSub: server.pubSub,
+        ackTopic: `ack/${context.clientId}`,
+        sourceId: "sse-" + context.clientId,
+        context,
+      });
 
       const sseTransport = compose(
         getPubSubSource({

--- a/src/http/utils.ts
+++ b/src/http/utils.ts
@@ -59,9 +59,7 @@ export function getDocumentsFromQueryParams(
  * Decodes a {@link Response} containing a {@link ReadableStream} of {@link MessageArray}s
  * into a batched async iterable of {@link Message}s.
  */
-export function decodeHTTPRequest(
-  response: Response,
-): AsyncIterable<Message<ClientContext>[]> {
+export function decodeHTTPRequest(response: Response): AsyncIterable<Message<ClientContext>[]> {
   const transform = fromMessageArrayTransform({
     clientId: response.headers.get("x-teleportal-client-id")!,
   });

--- a/src/lib/protocol/file-transfer.ts
+++ b/src/lib/protocol/file-transfer.ts
@@ -1,10 +1,6 @@
 import { toBase64 } from "lib0/buffer";
 import { uuidv4 } from "lib0/random";
-import {
-  CHUNK_SIZE,
-  chunkFile,
-  ENCRYPTED_CHUNK_SIZE,
-} from "teleportal/merkle-tree";
+import { CHUNK_SIZE, chunkFile, ENCRYPTED_CHUNK_SIZE } from "teleportal/merkle-tree";
 import { AckMessage, type Message } from "./message-types";
 import { decryptUpdate, encryptUpdate } from "teleportal/encryption-key";
 import { RpcMessage } from "teleportal/protocol";
@@ -283,6 +279,12 @@ export namespace FileTransferProtocol {
         return;
       }
 
+      if (handler.chunks.has(payload.chunkIndex)) return;
+
+      const decryptPromise = handler.encryptionKey
+        ? decryptUpdate(handler.encryptionKey, payload.chunkData)
+        : null;
+
       const isValid = this.verifyChunk(payload, handler.fileId);
       if (!isValid) {
         handler.reject(new Error(`Chunk ${payload.chunkIndex} failed merkle proof verification`));
@@ -290,13 +292,11 @@ export namespace FileTransferProtocol {
         return;
       }
 
-      if (!handler.chunks.has(payload.chunkIndex)) {
-        if (handler.encryptionKey) {
-          payload.chunkData = await decryptUpdate(handler.encryptionKey, payload.chunkData);
-        }
-        handler.chunks.set(payload.chunkIndex, payload.chunkData);
-        await this.checkDownloadCompletion(handler);
-      }
+      handler.chunks.set(
+        payload.chunkIndex,
+        decryptPromise ? await decryptPromise : payload.chunkData,
+      );
+      await this.checkDownloadCompletion(handler);
     }
 
     private async checkDownloadCompletion(handler: DownloadState) {
@@ -308,17 +308,15 @@ export namespace FileTransferProtocol {
         handler.fileMetadata.size === 0 ? 1 : Math.ceil(handler.fileMetadata.size / chunkSize);
       if (handler.chunks.size >= expectedChunks) {
         try {
-          const fileData = new Uint8Array(expectedChunks * CHUNK_SIZE);
-          let offset = 0;
+          const parts: Uint8Array[] = [];
           for (let i = 0; i < expectedChunks; i++) {
             const chunk = handler.chunks.get(i);
             if (!chunk) {
               throw new Error(`Missing chunk ${i}`);
             }
-            fileData.set(chunk, offset);
-            offset += chunk.length;
+            parts.push(chunk);
           }
-          const file = new File([fileData.slice(0, offset)], handler.fileMetadata.filename, {
+          const file = new File(parts as BlobPart[], handler.fileMetadata.filename, {
             type: handler.fileMetadata.mimeType,
           });
           await this.onDownloadComplete(handler, file);

--- a/src/lib/protocol/file-transfer.ts
+++ b/src/lib/protocol/file-transfer.ts
@@ -2,7 +2,7 @@ import { toBase64 } from "lib0/buffer";
 import { uuidv4 } from "lib0/random";
 import {
   CHUNK_SIZE,
-  createMerkleTreeTransformStream,
+  chunkFile,
   ENCRYPTED_CHUNK_SIZE,
 } from "teleportal/merkle-tree";
 import { AckMessage, type Message } from "./message-types";
@@ -236,49 +236,43 @@ export namespace FileTransferProtocol {
       context?: Context,
       originalRequestId?: string,
     ) {
-      const transformStream = createMerkleTreeTransformStream(
+      const parts = chunkFile(
+        uploadState.file.stream(),
         uploadState.file.size,
         uploadState.encryptionKey
           ? (chunk: Uint8Array) => encryptUpdate(uploadState.encryptionKey!, chunk)
           : undefined,
       );
 
-      return uploadState.file
-        .stream()
-        .pipeThrough(transformStream)
-        .pipeTo(
-          new WritableStream({
-            write: async (chunk) => {
-              if (chunk.rootHash.length > 0 && !uploadState.fileId) {
-                uploadState.fileId = toBase64(chunk.rootHash);
-              }
+      for await (const chunk of parts) {
+        if (chunk.rootHash.length > 0 && !uploadState.fileId) {
+          uploadState.fileId = toBase64(chunk.rootHash);
+        }
 
-              const filePart: FilePartStream = {
-                fileId: uploadState.uploadId,
-                chunkIndex: chunk.chunkIndex,
-                chunkData: chunk.chunkData,
-                merkleProof: chunk.merkleProof,
-                totalChunks: chunk.totalChunks,
-                bytesUploaded: chunk.bytesProcessed,
-                encrypted: chunk.encrypted,
-              };
+        const filePart: FilePartStream = {
+          fileId: uploadState.uploadId,
+          chunkIndex: chunk.chunkIndex,
+          chunkData: chunk.chunkData,
+          merkleProof: chunk.merkleProof,
+          totalChunks: chunk.totalChunks,
+          bytesUploaded: chunk.bytesProcessed,
+          encrypted: chunk.encrypted,
+        };
 
-              const message = new RpcMessage<Context>(
-                uploadState.document,
-                { type: "success", payload: filePart },
-                "fileUpload",
-                "stream",
-                originalRequestId ?? uploadState.uploadId,
-                context ?? ({} as Context),
-                chunk.encrypted,
-              );
-
-              uploadState.sentChunks.add(message.id);
-
-              this.sendMessage(message);
-            },
-          }),
+        const message = new RpcMessage<Context>(
+          uploadState.document,
+          { type: "success", payload: filePart },
+          "fileUpload",
+          "stream",
+          originalRequestId ?? uploadState.uploadId,
+          context ?? ({} as Context),
+          chunk.encrypted,
         );
+
+        uploadState.sentChunks.add(message.id);
+
+        this.sendMessage(message);
+      }
     }
 
     protected abstract verifyChunk(chunk: FilePartStream, fileId: string): boolean;

--- a/src/lib/protocol/types.ts
+++ b/src/lib/protocol/types.ts
@@ -133,6 +133,12 @@ export type DecodedAckMessage = {
    * The id of the message that was acknowledged.
    */
   messageId: string;
+  /**
+   * When set, indicates the message was rejected due to rate limiting.
+   * The value is the number of milliseconds the client should wait
+   * before retransmitting.
+   */
+  retryAfter?: number;
 };
 
 /**

--- a/src/lib/rpc/README.md
+++ b/src/lib/rpc/README.md
@@ -45,26 +45,34 @@ import { createHandlers, ok, err } from "teleportal/rpc";
 import { commentProtocol } from "./methods";
 
 export function getCommentRpcHandlers(db: CommentDB) {
-  return createHandlers(commentProtocol, { db }, {
-    list: ({ db }) => async (payload, ctx) => {
-      const result = await db.comments.find({
-        documentId: ctx.documentId,
-        cursor: payload.cursor,
-        limit: payload.limit ?? 50,
-      });
-      return ok({ comments: result.items, nextCursor: result.nextCursor });
-    },
+  return createHandlers(
+    commentProtocol,
+    { db },
+    {
+      list:
+        ({ db }) =>
+        async (payload, ctx) => {
+          const result = await db.comments.find({
+            documentId: ctx.documentId,
+            cursor: payload.cursor,
+            limit: payload.limit ?? 50,
+          });
+          return ok({ comments: result.items, nextCursor: result.nextCursor });
+        },
 
-    create: ({ db }) => async (payload, ctx) => {
-      if (!ctx.userId) return err(401, "Authentication required");
-      const comment = await db.comments.insert({
-        documentId: ctx.documentId,
-        text: payload.text,
-        userId: ctx.userId,
-      });
-      return ok({ comment });
+      create:
+        ({ db }) =>
+        async (payload, ctx) => {
+          if (!ctx.userId) return err(401, "Authentication required");
+          const comment = await db.comments.insert({
+            documentId: ctx.documentId,
+            text: payload.text,
+            userId: ctx.userId,
+          });
+          return ok({ comment });
+        },
     },
-  });
+  );
 }
 ```
 
@@ -178,9 +186,9 @@ try {
   await provider.rpc.comments.create({ text: "" });
 } catch (error) {
   if (error instanceof RpcOperationError) {
-    error.protocol;  // "comments"
+    error.protocol; // "comments"
     error.operation; // "create"
-    error.cause;     // underlying RPC error
+    error.cause; // underlying RPC error
   }
 }
 ```

--- a/src/merkle-tree/merkle-tree.ts
+++ b/src/merkle-tree/merkle-tree.ts
@@ -323,6 +323,12 @@ export function deserializeMerkleTree(data: Uint8Array, chunkCount: number): Mer
       }
     }
   }
+  // Odd-level nodes duplicate left as right in buildMerkleTree
+  for (const node of nodes) {
+    if (node.left !== undefined && node.right === undefined) {
+      node.right = node.left;
+    }
+  }
 
   return {
     nodes,
@@ -527,9 +533,7 @@ export async function* chunkFile(
       pendingChunks.delete(index);
       const proof = tree.generateProof(index);
       const rootHash =
-        index === totalChunks - 1
-          ? (tree.getRootHash() ?? new Uint8Array(0))
-          : new Uint8Array(0);
+        index === totalChunks - 1 ? (tree.getRootHash() ?? new Uint8Array(0)) : new Uint8Array(0);
       bytesProcessed += data.length;
       yield {
         chunkData: data,

--- a/src/merkle-tree/merkle-tree.ts
+++ b/src/merkle-tree/merkle-tree.ts
@@ -493,22 +493,21 @@ class StableIncrementalMerkleTree {
 }
 
 /**
- * TransformStream that processes a file stream and outputs file parts with merkle proofs.
+ * Chunk a file stream into {@link FilePart} objects with merkle proofs.
  *
- * This stream:
- * 1. Chunks the input data into CHUNK_SIZE pieces
- * 2. Builds a merkle tree incrementally knowing the complete tree structure
- * 3. Outputs each chunk once its proof becomes stable
- * 4. The root hash is only set in the last chunk
+ * Reads from a {@link ReadableStream}, splits into CHUNK_SIZE pieces, builds
+ * a merkle tree incrementally, and yields each part once its proof is stable.
+ * The root hash is only set on the last part.
  *
- * @param fileSize - Total size of the file (used to determine total chunks)
- * @returns A TransformStream that transforms Uint8Array chunks into FilePart objects
+ * @param source - ReadableStream of raw file bytes (e.g. from `File.stream()`)
+ * @param fileSize - Total file size in bytes
+ * @param encryptChunk - Optional per-chunk encryption function
  */
-export function createMerkleTreeTransformStream(
+export async function* chunkFile(
+  source: ReadableStream<Uint8Array>,
   fileSize: number,
   encryptChunk?: (chunk: Uint8Array) => Promise<Uint8Array> | Uint8Array,
-): TransformStream<Uint8Array, FilePart> {
-  // 12 bytes for the encryption initialization vector
+): AsyncGenerator<FilePart> {
   const chunkSize = encryptChunk ? ENCRYPTED_CHUNK_SIZE : CHUNK_SIZE;
   const totalChunks = fileSize === 0 ? 1 : Math.ceil(fileSize / chunkSize);
   const tree = new StableIncrementalMerkleTree(totalChunks);
@@ -516,87 +515,59 @@ export function createMerkleTreeTransformStream(
   let bytesProcessed = 0;
   const pendingChunks = new Map<number, Uint8Array>();
 
-  const emitChunk = (
-    index: number,
-    data: Uint8Array,
-    controller: TransformStreamDefaultController<FilePart>,
-  ) => {
-    const proof = tree.generateProof(index);
-    const rootHash =
-      index === totalChunks - 1 ? (tree.getRootHash() ?? new Uint8Array(0)) : new Uint8Array(0);
-    bytesProcessed += data.length;
-
-    controller.enqueue({
-      chunkData: data,
-      chunkIndex: index,
-      merkleProof: proof,
-      totalChunks,
-      bytesProcessed,
-      rootHash,
-      encrypted: !!encryptChunk,
-    });
-  };
-
-  const flushReadyChunks = (controller: TransformStreamDefaultController<FilePart>) => {
+  function* flushReady(): Generator<FilePart> {
     const readyIndexes: number[] = [];
     for (const [index] of pendingChunks) {
       if (tree.canGenerateProof(index)) {
         readyIndexes.push(index);
       }
     }
-
     for (const index of readyIndexes) {
       const data = pendingChunks.get(index)!;
       pendingChunks.delete(index);
-      emitChunk(index, data, controller);
+      const proof = tree.generateProof(index);
+      const rootHash =
+        index === totalChunks - 1
+          ? (tree.getRootHash() ?? new Uint8Array(0))
+          : new Uint8Array(0);
+      bytesProcessed += data.length;
+      yield {
+        chunkData: data,
+        chunkIndex: index,
+        merkleProof: proof,
+        totalChunks,
+        bytesProcessed,
+        rootHash,
+        encrypted: !!encryptChunk,
+      };
     }
-  };
+  }
 
-  const encodeChunk = async (chunk: Uint8Array): Promise<Uint8Array> => {
-    if (!encryptChunk) {
-      return chunk;
+  async function processChunk(raw: Uint8Array) {
+    const encoded = encryptChunk ? await encryptChunk(raw) : raw;
+    const chunkIndex = tree.addChunk(encoded);
+    pendingChunks.set(chunkIndex, encoded);
+  }
+
+  for await (const incoming of source) {
+    const newBuffer = new Uint8Array(buffer.length + incoming.length);
+    newBuffer.set(buffer, 0);
+    newBuffer.set(incoming, buffer.length);
+    buffer = newBuffer;
+
+    while (buffer.length >= chunkSize) {
+      await processChunk(buffer.slice(0, chunkSize));
+      buffer = buffer.slice(chunkSize);
+      yield* flushReady();
     }
-    return await encryptChunk(chunk);
-  };
+  }
 
-  const processChunk = async (
-    chunk: Uint8Array,
-    controller: TransformStreamDefaultController<FilePart>,
-  ) => {
-    const encodedChunk = await encodeChunk(chunk);
-    const chunkIndex = tree.addChunk(encodedChunk);
-    pendingChunks.set(chunkIndex, encodedChunk);
-    flushReadyChunks(controller);
-  };
+  if (buffer.length > 0) {
+    await processChunk(buffer);
+  } else if (totalChunks === 1 && pendingChunks.size === 0) {
+    await processChunk(new Uint8Array(0));
+  }
 
-  return new TransformStream<Uint8Array, FilePart>({
-    async transform(chunk, controller) {
-      const newBuffer = new Uint8Array(buffer.length + chunk.length);
-      newBuffer.set(buffer, 0);
-      newBuffer.set(chunk, buffer.length);
-      buffer = newBuffer;
-
-      while (buffer.length >= chunkSize) {
-        const completeChunk = buffer.slice(0, chunkSize);
-        buffer = buffer.slice(chunkSize);
-
-        await processChunk(completeChunk, controller);
-      }
-    },
-
-    async flush(controller) {
-      if (buffer.length > 0) {
-        await processChunk(buffer, controller);
-        buffer = new Uint8Array(0);
-      } else if (tree.getTotalChunks() === 0) {
-        await processChunk(new Uint8Array(0), controller);
-      }
-
-      flushReadyChunks(controller);
-
-      if (pendingChunks.size > 0) {
-        flushReadyChunks(controller);
-      }
-    },
-  });
+  yield* flushReady();
+  yield* flushReady();
 }

--- a/src/protocols/file/README.md
+++ b/src/protocols/file/README.md
@@ -112,7 +112,7 @@ try {
   await provider.rpc.file.upload(myFile);
 } catch (error) {
   if (error instanceof RpcOperationError) {
-    console.log(error.protocol);  // "file"
+    console.log(error.protocol); // "file"
     console.log(error.operation); // "upload"
   }
 }

--- a/src/protocols/file/client.ts
+++ b/src/protocols/file/client.ts
@@ -1,6 +1,7 @@
 import type { AckMessage, RpcMessage } from "teleportal/protocol";
 import { RpcOperationError, type RpcExtension, type RpcExtensionContext } from "teleportal/rpc";
 import { getFileClientHandlers, type FileClientHandlerOptions } from "./transfer";
+import type { FileCache } from "../../storage/idb/file-cache";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -8,11 +9,24 @@ import { getFileClientHandlers, type FileClientHandlerOptions } from "./transfer
 
 export interface FileRpcOptions {
   encryptionKey?: CryptoKey;
+  cache?: FileCache;
+}
+
+export interface FileUploadOptions {
+  fileId?: string;
+  encryptionKey?: CryptoKey;
+  cache?: boolean;
+}
+
+export interface FileDownloadOptions {
+  encryptionKey?: CryptoKey;
+  timeout?: number;
+  cache?: boolean;
 }
 
 export interface FileRpc {
-  upload(file: File, fileId?: string, encryptionKey?: CryptoKey): Promise<string>;
-  download(fileId: string, encryptionKey?: CryptoKey, timeout?: number): Promise<File>;
+  upload(file: File, options?: FileUploadOptions): Promise<string>;
+  download(fileId: string, options?: FileDownloadOptions): Promise<File>;
 }
 
 // ---------------------------------------------------------------------------
@@ -30,15 +44,17 @@ export interface FileRpc {
  * ```ts
  * import { createFileRpc } from "teleportal/protocols/file";
  * import { createEncryptionKey } from "teleportal/encryption-key";
+ * import { IdbFileCache } from "teleportal/storage";
  *
  * const encryptionKey = await createEncryptionKey();
+ * const cache = new IdbFileCache();
  *
  * const provider = await Provider.create({
  *   url: "wss://...",
  *   document: "my-doc",
  *   encryptionKey,
  *   rpc: {
- *     file: () => createFileRpc({ encryptionKey }),
+ *     file: () => createFileRpc({ encryptionKey, cache }),
  *   },
  * });
  *
@@ -49,6 +65,7 @@ export interface FileRpc {
 export function createFileRpc(options?: FileRpcOptions): RpcExtension<FileRpc> {
   const handlerOptions: FileClientHandlerOptions = {
     encryptionKey: options?.encryptionKey,
+    cache: options?.cache,
   };
   const handlers = getFileClientHandlers(handlerOptions);
   const handler = handlers.fileUpload as any;
@@ -64,26 +81,28 @@ export function createFileRpc(options?: FileRpcOptions): RpcExtension<FileRpc> {
       });
 
       return {
-        async upload(file: File, fileId?: string, encryptionKey?: CryptoKey): Promise<string> {
+        async upload(file: File, opts?: FileUploadOptions): Promise<string> {
           try {
             return await handler.uploadFile(
               file,
               document,
-              fileId,
-              encryptionKey ?? ctx.encryptionKey,
+              opts?.fileId,
+              opts?.encryptionKey ?? ctx.encryptionKey,
+              opts?.cache === false ? true : undefined,
             );
           } catch (error) {
             throw new RpcOperationError("file", "upload", error);
           }
         },
 
-        async download(fileId: string, encryptionKey?: CryptoKey, timeout?: number): Promise<File> {
+        async download(fileId: string, opts?: FileDownloadOptions): Promise<File> {
           try {
             return await handler.downloadFile(
               fileId,
               document,
-              encryptionKey ?? ctx.encryptionKey,
-              timeout,
+              opts?.encryptionKey ?? ctx.encryptionKey,
+              opts?.timeout,
+              opts?.cache === false ? true : undefined,
             );
           } catch (error) {
             throw new RpcOperationError("file", "download", error);

--- a/src/protocols/file/file-cache.test.ts
+++ b/src/protocols/file/file-cache.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, it, beforeEach } from "bun:test";
+import { toBase64 } from "lib0/buffer";
+import { AckMessage, type Message } from "teleportal";
+import { RpcMessage } from "teleportal/protocol";
+import { buildMerkleTree, CHUNK_SIZE, generateMerkleProof } from "teleportal/merkle-tree";
+import type { CachedFileMetadata, FileCache } from "../../storage/idb/file-cache";
+import { getFileClientHandlers } from "./transfer";
+
+// ---------------------------------------------------------------------------
+// In-memory FileCache for testing
+// ---------------------------------------------------------------------------
+
+class InMemoryFileCache implements FileCache {
+  metadata = new Map<string, CachedFileMetadata>();
+  chunks = new Map<string, Uint8Array>();
+
+  async getMetadata(fileId: string) {
+    return this.metadata.get(fileId) ?? null;
+  }
+  async getChunk(fileId: string, chunkIndex: number) {
+    return this.chunks.get(`${fileId}:${chunkIndex}`) ?? null;
+  }
+  async putMetadata(fileId: string, meta: CachedFileMetadata) {
+    this.metadata.set(fileId, meta);
+  }
+  async putChunk(fileId: string, chunkIndex: number, data: Uint8Array) {
+    this.chunks.set(`${fileId}:${chunkIndex}`, data);
+  }
+  async delete(fileId: string) {
+    const meta = this.metadata.get(fileId);
+    if (meta) {
+      for (let i = 0; i < meta.totalChunks; i++) {
+        this.chunks.delete(`${fileId}:${i}`);
+      }
+      this.metadata.delete(fileId);
+    }
+  }
+  async has(fileId: string) {
+    return this.metadata.has(fileId);
+  }
+  async clear() {
+    this.metadata.clear();
+    this.chunks.clear();
+  }
+  close() {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFileData(size: number, fill: number = 0xab): Uint8Array {
+  const data = new Uint8Array(size);
+  data.fill(fill);
+  return data;
+}
+
+function makeContentAddressedFile(data: Uint8Array) {
+  const totalChunks = data.length === 0 ? 1 : Math.ceil(data.length / CHUNK_SIZE);
+  const chunks: Uint8Array[] = [];
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * CHUNK_SIZE;
+    const end = Math.min(start + CHUNK_SIZE, data.length);
+    chunks.push(data.slice(start, end));
+  }
+  if (chunks.length === 0) chunks.push(new Uint8Array(0));
+
+  const tree = buildMerkleTree(chunks);
+  const root = tree.nodes.at(-1)!.hash!;
+  const fileId = toBase64(root);
+
+  return { fileId, chunks, tree, root, totalChunks };
+}
+
+/**
+ * Simulate a full upload through the FileClientHandler:
+ * 1. Call uploadFile()
+ * 2. Feed the handleResponse (upload accepted)
+ * 3. Capture the stream messages, ACK them all
+ */
+async function simulateUpload(
+  handler: any,
+  file: File,
+  document: string,
+  encryptionKey?: CryptoKey,
+) {
+  const sentMessages: RpcMessage<any>[] = [];
+
+  handler.setRpcClient(
+    {
+      sendRequest: async (_doc: string, _method: string, _payload: any, _opts: any) => {
+        // no-op — the response is fed via handleResponse
+      },
+      sendStream: async (msg: RpcMessage<any>) => {
+        sentMessages.push(msg);
+      },
+    },
+    async (msg: Message<any>) => {
+      sentMessages.push(msg as RpcMessage<any>);
+    },
+  );
+
+  const uploadPromise = handler.uploadFile(file, document, undefined, encryptionKey);
+
+  // Wait a tick for the request to be sent
+  await new Promise((r) => setTimeout(r, 0));
+
+  // Find the uploadId from the active uploads
+  const uploadId = [...handler.activeUploads.keys()][0];
+
+  // Simulate server accepting the upload
+  handler.handleResponse(
+    new RpcMessage<any>(
+      document,
+      { type: "success", payload: { fileId: uploadId } },
+      "fileUpload",
+      "response",
+      uploadId,
+    ),
+  );
+
+  // Wait for all chunks to be sent
+  await new Promise((r) => setTimeout(r, 0));
+  // May need more ticks for async generators
+  for (let i = 0; i < 10; i++) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+
+  // ACK all sent stream messages
+  for (const msg of sentMessages) {
+    if (msg.requestType === "stream") {
+      handler.handleAck(new AckMessage({ type: "ack", messageId: msg.id }));
+    }
+  }
+
+  const fileId = await uploadPromise;
+  return { fileId, sentMessages };
+}
+
+/**
+ * Simulate a download: feed the handler response + stream parts for a known file.
+ */
+async function simulateDownload(
+  handler: any,
+  fileId: string,
+  fileData: { chunks: Uint8Array[]; tree: ReturnType<typeof buildMerkleTree> },
+  metadata: { filename: string; size: number; mimeType: string },
+  document: string,
+  skipCache?: boolean,
+) {
+  handler.setRpcClient(
+    {
+      sendRequest: async (_doc: string, _method: string, _payload: any, _opts: any) => {
+        // no-op
+      },
+      sendStream: async () => {},
+    },
+    async () => {},
+  );
+
+  const downloadPromise = handler.downloadFile(fileId, document, undefined, undefined, skipCache);
+
+  await new Promise((r) => setTimeout(r, 0));
+
+  // Send download response with metadata
+  handler.handleResponse(
+    new RpcMessage<any>(
+      document,
+      {
+        type: "success",
+        payload: {
+          fileId,
+          filename: metadata.filename,
+          size: metadata.size,
+          mimeType: metadata.mimeType,
+        },
+      },
+      "fileDownload",
+      "response",
+      fileId,
+    ),
+  );
+
+  // Send file chunks as stream messages
+  for (let i = 0; i < fileData.chunks.length; i++) {
+    const proof = generateMerkleProof(fileData.tree, i);
+    let bytesSoFar = 0;
+    for (let j = 0; j <= i; j++) bytesSoFar += fileData.chunks[j].length;
+
+    handler.handleStream(
+      new RpcMessage<any>(
+        document,
+        {
+          type: "success",
+          payload: {
+            fileId,
+            chunkIndex: i,
+            chunkData: fileData.chunks[i],
+            merkleProof: proof,
+            totalChunks: fileData.chunks.length,
+            bytesUploaded: bytesSoFar,
+            encrypted: false,
+          },
+        },
+        "fileDownload",
+        "stream",
+        fileId,
+      ),
+    );
+  }
+
+  return downloadPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FileClientHandler cache integration", () => {
+  let cache: InMemoryFileCache;
+
+  beforeEach(() => {
+    cache = new InMemoryFileCache();
+  });
+
+  it("upload populates the cache with encrypted chunks", async () => {
+    const handlers = getFileClientHandlers({ cache });
+    const handler = handlers.fileUpload as any;
+
+    const data = makeFileData(100);
+    const file = new File([data] as BlobPart[], "test.bin", { type: "application/octet-stream" });
+
+    const { fileId } = await simulateUpload(handler, file, "doc-1");
+
+    // Cache should have metadata + chunks
+    expect(await cache.has(fileId)).toBe(true);
+    const meta = await cache.getMetadata(fileId);
+    expect(meta).not.toBeNull();
+    expect(meta!.filename).toBe("test.bin");
+    expect(meta!.totalChunks).toBe(1);
+    expect(meta!.mimeType).toBe("application/octet-stream");
+
+    const chunk = await cache.getChunk(fileId, 0);
+    expect(chunk).not.toBeNull();
+    expect(chunk!.length).toBe(100);
+  });
+
+  it("download serves from cache without server round-trip", async () => {
+    const handlers = getFileClientHandlers({ cache });
+    const handler = handlers.fileUpload as any;
+
+    // Pre-populate cache with a known file
+    const data = makeFileData(50, 0xcd);
+    const { fileId, chunks } = makeContentAddressedFile(data);
+
+    await cache.putMetadata(fileId, {
+      filename: "cached.bin",
+      size: 50,
+      mimeType: "application/octet-stream",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: Date.now(),
+    });
+    await cache.putChunk(fileId, 0, chunks[0]);
+
+    // Set up handler with a mock RPC client that will reject if called
+    let serverCalled = false;
+    handler.setRpcClient(
+      {
+        sendRequest: async () => {
+          serverCalled = true;
+          throw new Error("Should not call server when cache hit");
+        },
+        sendStream: async () => {},
+      },
+      async () => {},
+    );
+
+    const file = await handler.downloadFile(fileId, "doc-1");
+
+    expect(serverCalled).toBe(false);
+    expect(file.name).toBe("cached.bin");
+    expect(file.size).toBe(50);
+
+    // Verify the content matches
+    const buf = new Uint8Array(await file.arrayBuffer());
+    expect(buf.every((b) => b === 0xcd)).toBe(true);
+  });
+
+  it("download from server populates the cache", async () => {
+    const handlers = getFileClientHandlers({ cache });
+    const handler = handlers.fileUpload as any;
+
+    const data = makeFileData(200, 0xef);
+    const { fileId, chunks, tree } = makeContentAddressedFile(data);
+
+    const file = await simulateDownload(
+      handler,
+      fileId,
+      { chunks, tree },
+      { filename: "from-server.bin", size: 200, mimeType: "application/octet-stream" },
+      "doc-1",
+    );
+
+    expect(file.name).toBe("from-server.bin");
+    expect(file.size).toBe(200);
+
+    // Wait for fire-and-forget cache writes
+    await new Promise((r) => setTimeout(r, 1));
+
+    // Cache should now be populated
+    expect(await cache.has(fileId)).toBe(true);
+    const meta = await cache.getMetadata(fileId);
+    expect(meta!.filename).toBe("from-server.bin");
+    expect(meta!.totalChunks).toBe(1);
+
+    const cachedChunk = await cache.getChunk(fileId, 0);
+    expect(cachedChunk).not.toBeNull();
+    expect(cachedChunk!.length).toBe(200);
+  });
+
+  it("multi-chunk file round-trips through cache", async () => {
+    const handlers = getFileClientHandlers({ cache });
+    const handler = handlers.fileUpload as any;
+
+    // Create a file larger than CHUNK_SIZE to get multiple chunks
+    const data = makeFileData(CHUNK_SIZE + 100, 0x42);
+    const file = new File([data] as BlobPart[], "big.bin", { type: "application/octet-stream" });
+
+    const { fileId } = await simulateUpload(handler, file, "doc-1");
+
+    // Verify cache has 2 chunks
+    const meta = await cache.getMetadata(fileId);
+    expect(meta!.totalChunks).toBe(2);
+    expect(await cache.getChunk(fileId, 0)).not.toBeNull();
+    expect(await cache.getChunk(fileId, 1)).not.toBeNull();
+
+    // Now download from cache (fresh handler with same cache)
+    const handlers2 = getFileClientHandlers({ cache });
+    const handler2 = handlers2.fileUpload as any;
+
+    let serverCalled = false;
+    handler2.setRpcClient(
+      {
+        sendRequest: async () => {
+          serverCalled = true;
+          throw new Error("Should not call server");
+        },
+        sendStream: async () => {},
+      },
+      async () => {},
+    );
+
+    const downloaded = await handler2.downloadFile(fileId, "doc-1");
+    expect(serverCalled).toBe(false);
+    expect(downloaded.name).toBe("big.bin");
+    expect(downloaded.size).toBe(CHUNK_SIZE + 100);
+
+    const buf = new Uint8Array(await downloaded.arrayBuffer());
+    expect(buf.every((b) => b === 0x42)).toBe(true);
+  });
+
+  it("skipCache=true bypasses cache on download", async () => {
+    const handlers = getFileClientHandlers({ cache });
+    const handler = handlers.fileUpload as any;
+
+    // Pre-populate cache
+    const data = makeFileData(50);
+    const { fileId, chunks } = makeContentAddressedFile(data);
+    await cache.putMetadata(fileId, {
+      filename: "cached.bin",
+      size: 50,
+      mimeType: "application/octet-stream",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: Date.now(),
+    });
+    await cache.putChunk(fileId, 0, chunks[0]);
+
+    // Download with skipCache=true — should hit the server (which we simulate)
+    const { tree } = makeContentAddressedFile(data);
+    const file = await simulateDownload(
+      handler,
+      fileId,
+      { chunks, tree },
+      { filename: "from-server.bin", size: 50, mimeType: "application/octet-stream" },
+      "doc-1",
+      true,
+    );
+
+    // Gets the server version, not the cached version
+    expect(file.name).toBe("from-server.bin");
+  });
+
+  it("incomplete cache falls through to server", async () => {
+    const handlers = getFileClientHandlers({ cache });
+    const handler = handlers.fileUpload as any;
+
+    // Put metadata but no chunks — simulates an incomplete cache entry
+    const data = makeFileData(50, 0xbb);
+    const { fileId, chunks, tree } = makeContentAddressedFile(data);
+    await cache.putMetadata(fileId, {
+      filename: "incomplete.bin",
+      size: 50,
+      mimeType: "application/octet-stream",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: Date.now(),
+    });
+    // No chunks stored — cache miss
+
+    const file = await simulateDownload(
+      handler,
+      fileId,
+      { chunks, tree },
+      { filename: "server-fallback.bin", size: 50, mimeType: "application/octet-stream" },
+      "doc-1",
+    );
+
+    expect(file.name).toBe("server-fallback.bin");
+    expect(file.size).toBe(50);
+  });
+
+  it("no cache configured: upload and download work normally", async () => {
+    const handlers = getFileClientHandlers({}); // no cache
+    const handler = handlers.fileUpload as any;
+
+    const data = makeFileData(100);
+    const file = new File([data] as BlobPart[], "no-cache.bin", {
+      type: "application/octet-stream",
+    });
+
+    const { fileId } = await simulateUpload(handler, file, "doc-1");
+    expect(fileId).toBeTruthy();
+
+    // Cache is empty (none configured)
+    expect(cache.metadata.size).toBe(0);
+    expect(cache.chunks.size).toBe(0);
+  });
+
+  it("30MB upload with rate-limit nacks retransmits and completes", async () => {
+    const FILE_SIZE = 30 * 1024 * 1024; // 30 MB
+    const EXPECTED_CHUNKS = Math.ceil(FILE_SIZE / CHUNK_SIZE); // 480
+
+    const handlers = getFileClientHandlers({ cache });
+    const handler = handlers.fileUpload as any;
+
+    // Token-bucket rate limiter: ACK the first `bucketSize` chunks per burst,
+    // nack the rest with retryAfter. Refill the bucket each retransmission round.
+    const BUCKET_SIZE = 200;
+    let tokensRemaining = BUCKET_SIZE;
+    const ackedChunks = new Set<number>();
+    let nackedCount = 0;
+    let retransmitCount = 0;
+
+    handler.setRpcClient(
+      {
+        sendRequest: async () => {},
+        sendStream: async () => {},
+      },
+      async (msg: Message<any>) => {
+        if (!(msg instanceof RpcMessage) || msg.requestType !== "stream") return;
+
+        const payload = msg.payload?.payload as Record<string, unknown> | undefined;
+        if (!payload || payload.chunkIndex === undefined) return;
+
+        const chunkIndex = payload.chunkIndex as number;
+
+        // Already ACKed (retransmission of a chunk we already accepted)
+        if (ackedChunks.has(chunkIndex)) {
+          queueMicrotask(() => {
+            handler.handleAck(new AckMessage({ type: "ack", messageId: msg.id }));
+          });
+          return;
+        }
+
+        if (tokensRemaining > 0) {
+          tokensRemaining--;
+          ackedChunks.add(chunkIndex);
+          queueMicrotask(() => {
+            handler.handleAck(new AckMessage({ type: "ack", messageId: msg.id }));
+          });
+        } else {
+          nackedCount++;
+          queueMicrotask(() => {
+            handler.handleAck(new AckMessage({ type: "ack", messageId: msg.id, retryAfter: 1 }));
+          });
+        }
+      },
+    );
+
+    const data = new Uint8Array(FILE_SIZE);
+    const file = new File([data] as BlobPart[], "large.bin", {
+      type: "application/octet-stream",
+    });
+
+    const uploadPromise = handler.uploadFile(file, "doc-1");
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const uploadId = [...handler.activeUploads.keys()][0];
+    handler.handleResponse(
+      new RpcMessage<any>(
+        "doc-1",
+        { type: "success", payload: { fileId: uploadId } },
+        "fileUpload",
+        "response",
+        uploadId,
+      ),
+    );
+
+    // Refill the bucket whenever the retransmit loop fires so it
+    // eventually accepts all remaining chunks.
+    const refillInterval = setInterval(() => {
+      if (tokensRemaining === 0) {
+        tokensRemaining = BUCKET_SIZE;
+        retransmitCount++;
+      }
+    }, 5);
+
+    const fileId = await uploadPromise;
+    clearInterval(refillInterval);
+
+    expect(fileId).toBeTruthy();
+    expect(ackedChunks.size).toBe(EXPECTED_CHUNKS);
+    expect(nackedCount).toBeGreaterThan(0);
+    expect(retransmitCount).toBeGreaterThan(0);
+
+    // Verify cache was populated
+    const meta = await cache.getMetadata(fileId);
+    expect(meta).not.toBeNull();
+    expect(meta!.totalChunks).toBe(EXPECTED_CHUNKS);
+    expect(meta!.filename).toBe("large.bin");
+  }, 30_000);
+});

--- a/src/protocols/file/index.ts
+++ b/src/protocols/file/index.ts
@@ -1,7 +1,7 @@
 export { getFileRpcHandlers, FileHandler } from "./server";
 export { getFileClientHandlers } from "./transfer";
 export { createFileRpc } from "./client";
-export type { FileRpc, FileRpcOptions } from "./client";
+export type { FileRpc, FileRpcOptions, FileUploadOptions, FileDownloadOptions } from "./client";
 
 export { fileProtocol, fileUpload, fileDownload } from "./methods";
 
@@ -15,3 +15,5 @@ export type {
   FileDownloadResponse,
   FilePartStream,
 } from "./methods";
+
+export type { FileCache, CachedFileMetadata } from "../../storage/idb/file-cache";

--- a/src/protocols/file/methods.ts
+++ b/src/protocols/file/methods.ts
@@ -49,6 +49,7 @@ export type FileUploadResponse = {
   allowed: boolean;
   reason?: string;
   statusCode?: number;
+  existingChunks?: number[];
 };
 
 export type FileDownloadRequest = {

--- a/src/protocols/file/server.ts
+++ b/src/protocols/file/server.ts
@@ -3,7 +3,11 @@ import type { Message } from "teleportal/protocol";
 import type { ServerContext } from "teleportal";
 import type { FileStorage, TemporaryUploadStorage } from "teleportal/storage";
 import { emitWideEvent } from "teleportal/server";
-import { buildMerkleTree, generateMerkleProof } from "teleportal/merkle-tree";
+import {
+  buildMerkleTree,
+  deserializeMerkleTree,
+  generateMerkleProof,
+} from "teleportal/merkle-tree";
 import {
   type FileUploadRequest,
   type FileDownloadResponse,
@@ -192,7 +196,9 @@ export class FileHandler {
     });
 
     const chunks = file.chunks;
-    const merkleTree = buildMerkleTree(chunks);
+    const merkleTree = file.serializedMerkleTree
+      ? deserializeMerkleTree(file.serializedMerkleTree, chunks.length)
+      : buildMerkleTree(chunks);
     let bytesSent = 0;
 
     for (let i = 0; i < chunks.length; i++) {
@@ -214,6 +220,7 @@ export class FileHandler {
 
   /**
    * Initiate an upload session.
+   * Returns the list of chunk indexes already stored (for resumable uploads).
    */
   async initiateUpload(
     fileId: string,
@@ -224,7 +231,7 @@ export class FileHandler {
       encrypted: boolean;
     },
     document: string,
-  ): Promise<void> {
+  ): Promise<{ existingChunks: number[] }> {
     if (!this.#temporaryUploadStorage) {
       throw new Error("File uploads are not enabled: missing fileStorage.temporaryUploadStorage");
     }
@@ -242,14 +249,20 @@ export class FileHandler {
       documentId: document,
     });
 
+    const progress = await this.#temporaryUploadStorage.getUploadProgress(fileId);
+    const existingChunks = progress ? [...progress.chunks.keys()] : [];
+
     emitWideEvent("info", {
-      event_type: "file_upload_initiated",
+      event_type: existingChunks.length > 0 ? "file_upload_resumed" : "file_upload_initiated",
       timestamp: new Date().toISOString(),
       file_id: fileId,
       document_id: document,
       filename: metadata.filename,
       size: metadata.size,
+      existing_chunks: existingChunks.length,
     });
+
+    return { existingChunks };
   }
 
   /**
@@ -343,7 +356,7 @@ export function getFileRpcHandlers(
             });
           }
 
-          await fileHandler.initiateUpload(
+          const { existingChunks } = await fileHandler.initiateUpload(
             payload.fileId,
             {
               filename: payload.filename,
@@ -357,6 +370,7 @@ export function getFileRpcHandlers(
           return ok({
             fileId: payload.fileId,
             allowed: true,
+            existingChunks: existingChunks.length > 0 ? existingChunks : undefined,
           });
         },
         streamHandler: async (payload, context, messageId, sendMessage) => {

--- a/src/protocols/file/transfer.ts
+++ b/src/protocols/file/transfer.ts
@@ -13,6 +13,10 @@ import type { FilePartStream } from "./methods";
 import type { ClientRpcHandler } from "../../providers/rpc-handlers";
 import type { Provider } from "../../providers/provider";
 import type { RpcClient } from "../../providers/rpc-client";
+import type { FileCache } from "../../storage/idb/file-cache";
+
+/** Max retransmission rounds per upload before giving up. */
+const MAX_RETRANSMIT_ROUNDS = 8;
 
 interface UploadState {
   resolve: (fileId: string) => void;
@@ -20,11 +24,19 @@ interface UploadState {
   uploadId: string;
   file: File;
   fileId: string | null;
-  sentChunks: Set<string>;
+  /** Maps messageId → chunkIndex for outstanding ACKs. */
+  sentChunks: Map<string, number>;
+  /** Chunk data kept for retransmission, keyed by chunkIndex. */
+  unackedChunks: Map<number, FilePartStream>;
   document: string;
   encryptionKey?: CryptoKey;
+  context?: any;
+  originalRequestId?: string;
   /** True when all chunks have been sent (file streaming complete) */
   allChunksSent: boolean;
+  skipCache?: boolean;
+  /** Whether a background retransmit loop is already running. */
+  retransmitting: boolean;
 }
 
 interface DownloadState {
@@ -35,6 +47,7 @@ interface DownloadState {
   fileId: string;
   timeoutId: ReturnType<typeof setTimeout> | null;
   encryptionKey?: CryptoKey;
+  skipCache?: boolean;
 }
 
 /**
@@ -46,6 +59,13 @@ export interface FileClientHandlerOptions {
    * Can be overridden per-operation.
    */
   encryptionKey?: CryptoKey;
+
+  /**
+   * Optional persistent file cache (e.g. IndexedDB-backed).
+   * When provided, uploaded files are cached optimistically and
+   * downloads are served from cache when available.
+   */
+  cache?: FileCache;
 }
 
 class FileClientHandler implements ClientRpcHandler {
@@ -55,9 +75,11 @@ class FileClientHandler implements ClientRpcHandler {
   #rpcClient: RpcClient | null = null;
   #sendStreamMessage: ((message: Message<any>) => Promise<void>) | null = null;
   #encryptionKey?: CryptoKey;
+  #cache?: FileCache;
 
   constructor(options?: FileClientHandlerOptions) {
     this.#encryptionKey = options?.encryptionKey;
+    this.#cache = options?.cache;
   }
 
   init(_provider: Provider<any>): void {
@@ -86,6 +108,7 @@ class FileClientHandler implements ClientRpcHandler {
     document: string,
     fileId: string = uuidv4(),
     encryptionKey?: CryptoKey,
+    skipCache?: boolean,
   ): Promise<string> {
     if (!this.#rpcClient) {
       throw new Error("File handler not initialized: RPC client not set");
@@ -103,10 +126,13 @@ class FileClientHandler implements ClientRpcHandler {
         uploadId: fileId,
         fileId: null,
         file,
-        sentChunks: new Set(),
+        sentChunks: new Map(),
+        unackedChunks: new Map(),
         document,
         encryptionKey: key,
         allChunksSent: false,
+        skipCache,
+        retransmitting: false,
       });
     });
 
@@ -151,6 +177,7 @@ class FileClientHandler implements ClientRpcHandler {
     document: string,
     encryptionKey?: CryptoKey,
     timeout: number = 60000,
+    skipCache?: boolean,
   ): Promise<File> {
     if (!this.#rpcClient) {
       throw new Error("File handler not initialized");
@@ -158,10 +185,36 @@ class FileClientHandler implements ClientRpcHandler {
 
     const key = encryptionKey ?? this.#encryptionKey;
 
-    // Check cache first
+    // Check in-memory dedup cache first
     const cached = this.#downloadCache.get(fileId);
     if (cached) {
       return cached;
+    }
+
+    // Check persistent cache (IDB)
+    if (this.#cache && !skipCache) {
+      const metadata = await this.#cache.getMetadata(fileId);
+      if (metadata) {
+        const chunks: Uint8Array[] = [];
+        let complete = true;
+        for (let i = 0; i < metadata.totalChunks; i++) {
+          const chunk = await this.#cache.getChunk(fileId, i);
+          if (!chunk) {
+            complete = false;
+            break;
+          }
+          chunks.push(chunk);
+        }
+        if (complete) {
+          const decryptedParts: Uint8Array[] = [];
+          for (const chunk of chunks) {
+            decryptedParts.push(key ? await decryptUpdate(key, chunk) : chunk);
+          }
+          return new File(decryptedParts as BlobPart[], metadata.filename, {
+            type: metadata.mimeType,
+          });
+        }
+      }
     }
 
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -186,6 +239,7 @@ class FileClientHandler implements ClientRpcHandler {
         fileId,
         timeoutId,
         encryptionKey: key,
+        skipCache,
       });
     });
 
@@ -232,6 +286,7 @@ class FileClientHandler implements ClientRpcHandler {
         filename?: string;
         size?: number;
         mimeType?: string;
+        existingChunks?: number[];
       };
       details?: string;
     };
@@ -258,7 +313,12 @@ class FileClientHandler implements ClientRpcHandler {
         // Start processing the file upload
         // We don't await this - it runs in the background and the upload promise
         // resolves when all ACKs are received. Errors are caught and the upload is rejected.
-        this.#processFileUpload(uploadHandler, message.context).catch((error) => {
+        this.#processFileUpload(
+          uploadHandler,
+          message.context,
+          undefined,
+          payload.payload.existingChunks,
+        ).catch((error) => {
           uploadHandler.reject(error);
           this.#activeUploads.delete(uploadHandler.uploadId);
         });
@@ -310,13 +370,22 @@ class FileClientHandler implements ClientRpcHandler {
     let handled = false;
 
     for (const handler of this.#activeUploads.values()) {
-      if (handler.sentChunks.delete(ackMessage.payload.messageId)) {
+      const chunkIndex = handler.sentChunks.get(ackMessage.payload.messageId);
+      if (chunkIndex !== undefined) {
+        handler.sentChunks.delete(ackMessage.payload.messageId);
         handled = true;
-        // Only resolve when ALL chunks have been sent AND all ACKs received
-        // This prevents premature resolution if ACKs arrive before all chunks are sent
-        if (handler.allChunksSent && handler.sentChunks.size === 0) {
-          handler.resolve(handler.fileId!);
-          this.#activeUploads.delete(handler.uploadId);
+
+        if (ackMessage.payload.retryAfter !== undefined) {
+          // Nack — server rate-limited this chunk.
+          // Kick off the background retransmit loop (idempotent — only one runs at a time).
+          this.#startRetransmitLoop(handler, ackMessage.payload.retryAfter);
+        } else {
+          // Positive ACK — chunk accepted.
+          handler.unackedChunks.delete(chunkIndex);
+          if (handler.allChunksSent && handler.unackedChunks.size === 0) {
+            handler.resolve(handler.fileId!);
+            this.#activeUploads.delete(handler.uploadId);
+          }
         }
       }
     }
@@ -324,10 +393,19 @@ class FileClientHandler implements ClientRpcHandler {
     return handled;
   }
 
-  async #processFileUpload(uploadState: UploadState, context?: any, originalRequestId?: string) {
+  async #processFileUpload(
+    uploadState: UploadState,
+    context?: any,
+    originalRequestId?: string,
+    existingChunks?: number[],
+  ) {
     if (!this.#sendStreamMessage) {
       throw new Error("File handler not initialized");
     }
+
+    const skipChunks = new Set(existingChunks);
+    const cache = this.#cache && !uploadState.skipCache ? this.#cache : undefined;
+    const cachedChunks: { index: number; data: Uint8Array }[] = [];
 
     const parts = chunkFile(
       uploadState.file.stream(),
@@ -342,6 +420,15 @@ class FileClientHandler implements ClientRpcHandler {
         uploadState.fileId = toBase64(chunk.rootHash);
       }
 
+      if (cache) {
+        cachedChunks.push({ index: chunk.chunkIndex, data: chunk.chunkData });
+      }
+
+      // Skip chunks the server already has (resumable upload)
+      if (skipChunks.has(chunk.chunkIndex)) {
+        continue;
+      }
+
       const filePart: FilePartStream = {
         fileId: uploadState.uploadId,
         chunkIndex: chunk.chunkIndex,
@@ -352,29 +439,122 @@ class FileClientHandler implements ClientRpcHandler {
         encrypted: chunk.encrypted,
       };
 
+      uploadState.unackedChunks.set(chunk.chunkIndex, filePart);
+      uploadState.context = context ?? { documentId: uploadState.document };
+      uploadState.originalRequestId = originalRequestId ?? uploadState.uploadId;
+
       const message = new RpcMessage<any>(
         uploadState.document,
         { type: "success", payload: filePart },
         "fileUpload",
         "stream",
-        originalRequestId ?? uploadState.uploadId,
-        context ?? { documentId: uploadState.document },
+        uploadState.originalRequestId,
+        uploadState.context,
         chunk.encrypted,
       );
 
-      uploadState.sentChunks.add(message.id);
+      uploadState.sentChunks.set(message.id, chunk.chunkIndex);
 
       await this.#sendStreamMessage(message);
+    }
+
+    // Optimistic cache write — before ACKs arrive
+    if (cache && uploadState.fileId) {
+      const fileId = uploadState.fileId;
+      const totalChunks = cachedChunks.length;
+      Promise.all([
+        ...cachedChunks.map((c) => cache.putChunk(fileId, c.index, c.data)),
+        cache.putMetadata(fileId, {
+          filename: uploadState.file.name,
+          size: uploadState.file.size,
+          mimeType: uploadState.file.type || "application/octet-stream",
+          encrypted: !!uploadState.encryptionKey,
+          totalChunks,
+          lastModified: uploadState.file.lastModified,
+        }),
+      ]).catch(() => {});
     }
 
     // Mark all chunks as sent - upload can now resolve when all ACKs received
     uploadState.allChunksSent = true;
 
     // If all ACKs have already been received, resolve now
-    if (uploadState.sentChunks.size === 0) {
+    if (uploadState.unackedChunks.size === 0) {
       uploadState.resolve(uploadState.fileId!);
       this.#activeUploads.delete(uploadState.uploadId);
     }
+  }
+
+  /**
+   * Start a background loop that retransmits unacked chunks with backoff.
+   * Idempotent — if a loop is already running for this upload, this is a no-op.
+   * The loop exits when all chunks are ACKed or max rounds are exhausted.
+   */
+  #startRetransmitLoop(handler: UploadState, retryAfterMs: number) {
+    if (handler.retransmitting || !this.#sendStreamMessage) return;
+    handler.retransmitting = true;
+
+    const sendStream = this.#sendStreamMessage;
+    let delay = Math.max(retryAfterMs, 200);
+
+    const loop = async () => {
+      for (let round = 0; round < MAX_RETRANSMIT_ROUNDS; round++) {
+        await new Promise((r) => setTimeout(r, delay));
+
+        if (!this.#activeUploads.has(handler.uploadId)) return;
+        if (handler.unackedChunks.size === 0) break;
+
+        for (const [chunkIndex, filePart] of handler.unackedChunks) {
+          if (!this.#activeUploads.has(handler.uploadId)) return;
+
+          const message = new RpcMessage<any>(
+            handler.document,
+            { type: "success", payload: filePart },
+            "fileUpload",
+            "stream",
+            handler.originalRequestId ?? handler.uploadId,
+            handler.context ?? { documentId: handler.document },
+            filePart.encrypted,
+          );
+          handler.sentChunks.set(message.id, chunkIndex);
+          try {
+            await sendStream(message);
+          } catch {
+            break;
+          }
+        }
+
+        // Wait for ACKs/nacks before next round
+        await new Promise((r) => setTimeout(r, delay));
+
+        if (!this.#activeUploads.has(handler.uploadId)) return;
+        if (handler.unackedChunks.size === 0) break;
+
+        delay = Math.min(delay * 2, 10_000);
+      }
+
+      handler.retransmitting = false;
+
+      if (!this.#activeUploads.has(handler.uploadId)) return;
+
+      if (handler.unackedChunks.size === 0) {
+        if (handler.allChunksSent) {
+          handler.resolve(handler.fileId!);
+          this.#activeUploads.delete(handler.uploadId);
+        }
+      } else {
+        handler.reject(
+          new Error(
+            `Upload failed: ${handler.unackedChunks.size} chunks unacknowledged after ${MAX_RETRANSMIT_ROUNDS} retransmission rounds`,
+          ),
+        );
+        this.#activeUploads.delete(handler.uploadId);
+      }
+    };
+
+    loop().catch(() => {
+      handler.retransmitting = false;
+    });
   }
 
   #verifyChunk(chunk: FilePartStream, fileId: string): boolean {
@@ -392,6 +572,14 @@ class FileClientHandler implements ClientRpcHandler {
       return;
     }
 
+    if (handler.chunks.has(payload.chunkIndex)) return;
+
+    // Kick off async decrypt before sync verify — Web Crypto runs in native
+    // code so the decrypt progresses while we SHA-256 the chunk on the main thread.
+    const decryptPromise = handler.encryptionKey
+      ? decryptUpdate(handler.encryptionKey, payload.chunkData)
+      : null;
+
     const isValid = this.#verifyChunk(payload, handler.fileId);
     if (!isValid) {
       handler.reject(new Error(`Chunk ${payload.chunkIndex} failed merkle proof verification`));
@@ -402,16 +590,19 @@ class FileClientHandler implements ClientRpcHandler {
       return;
     }
 
-    if (!handler.chunks.has(payload.chunkIndex)) {
-      if (handler.encryptionKey) {
-        payload.chunkData = await decryptUpdate(handler.encryptionKey, payload.chunkData);
-      }
-      handler.chunks.set(payload.chunkIndex, payload.chunkData);
-      await this.#checkDownloadCompletion(handler);
+    // Cache the verified ciphertext chunk (before decryption)
+    if (this.#cache && !handler.skipCache) {
+      this.#cache.putChunk(payload.fileId, payload.chunkIndex, payload.chunkData).catch(() => {});
     }
+
+    handler.chunks.set(
+      payload.chunkIndex,
+      decryptPromise ? await decryptPromise : payload.chunkData,
+    );
+    this.#checkDownloadCompletion(handler);
   }
 
-  async #checkDownloadCompletion(handler: DownloadState) {
+  #checkDownloadCompletion(handler: DownloadState) {
     if (!handler.fileMetadata) {
       return;
     }
@@ -420,19 +611,32 @@ class FileClientHandler implements ClientRpcHandler {
       handler.fileMetadata.size === 0 ? 1 : Math.ceil(handler.fileMetadata.size / chunkSize);
     if (handler.chunks.size >= expectedChunks) {
       try {
-        const fileData = new Uint8Array(expectedChunks * CHUNK_SIZE);
-        let offset = 0;
+        const parts: Uint8Array[] = [];
         for (let i = 0; i < expectedChunks; i++) {
           const chunk = handler.chunks.get(i);
           if (!chunk) {
             throw new Error(`Missing chunk ${i}`);
           }
-          fileData.set(chunk, offset);
-          offset += chunk.length;
+          parts.push(chunk);
         }
-        const file = new File([fileData.slice(0, offset)], handler.fileMetadata.filename, {
+        const file = new File(parts as BlobPart[], handler.fileMetadata.filename, {
           type: handler.fileMetadata.mimeType,
         });
+
+        // Write metadata to persistent cache (chunks were written in #handleFilePart)
+        if (this.#cache && !handler.skipCache) {
+          this.#cache
+            .putMetadata(handler.fileId, {
+              filename: handler.fileMetadata.filename,
+              size: handler.fileMetadata.size,
+              mimeType: handler.fileMetadata.mimeType,
+              encrypted: !!handler.encryptionKey,
+              totalChunks: expectedChunks,
+              lastModified: file.lastModified,
+            })
+            .catch(() => {});
+        }
+
         handler.resolve(file);
       } catch (err) {
         handler.reject(err as Error);

--- a/src/protocols/file/transfer.ts
+++ b/src/protocols/file/transfer.ts
@@ -2,7 +2,7 @@ import { toBase64, fromBase64 } from "lib0/buffer";
 import { uuidv4 } from "lib0/random";
 import {
   CHUNK_SIZE,
-  createMerkleTreeTransformStream,
+  chunkFile,
   ENCRYPTED_CHUNK_SIZE,
   verifyMerkleProof,
 } from "teleportal/merkle-tree";
@@ -329,51 +329,43 @@ class FileClientHandler implements ClientRpcHandler {
       throw new Error("File handler not initialized");
     }
 
-    const transformStream = createMerkleTreeTransformStream(
+    const parts = chunkFile(
+      uploadState.file.stream(),
       uploadState.file.size,
       uploadState.encryptionKey
         ? (chunk: Uint8Array) => encryptUpdate(uploadState.encryptionKey!, chunk)
         : undefined,
     );
 
-    await uploadState.file
-      .stream()
-      .pipeThrough(transformStream)
-      .pipeTo(
-        new WritableStream({
-          write: async (chunk) => {
-            if (chunk.rootHash.length > 0 && !uploadState.fileId) {
-              uploadState.fileId = toBase64(chunk.rootHash);
-            }
+    for await (const chunk of parts) {
+      if (chunk.rootHash.length > 0 && !uploadState.fileId) {
+        uploadState.fileId = toBase64(chunk.rootHash);
+      }
 
-            const filePart: FilePartStream = {
-              fileId: uploadState.uploadId,
-              chunkIndex: chunk.chunkIndex,
-              chunkData: chunk.chunkData,
-              merkleProof: chunk.merkleProof,
-              totalChunks: chunk.totalChunks,
-              bytesUploaded: chunk.bytesProcessed,
-              encrypted: chunk.encrypted,
-            };
+      const filePart: FilePartStream = {
+        fileId: uploadState.uploadId,
+        chunkIndex: chunk.chunkIndex,
+        chunkData: chunk.chunkData,
+        merkleProof: chunk.merkleProof,
+        totalChunks: chunk.totalChunks,
+        bytesUploaded: chunk.bytesProcessed,
+        encrypted: chunk.encrypted,
+      };
 
-            const message = new RpcMessage<any>(
-              uploadState.document,
-              { type: "success", payload: filePart },
-              "fileUpload",
-              "stream",
-              originalRequestId ?? uploadState.uploadId,
-              context ?? { documentId: uploadState.document },
-              chunk.encrypted,
-            );
-
-            uploadState.sentChunks.add(message.id);
-
-            if (this.#sendStreamMessage) {
-              await this.#sendStreamMessage(message);
-            }
-          },
-        }),
+      const message = new RpcMessage<any>(
+        uploadState.document,
+        { type: "success", payload: filePart },
+        "fileUpload",
+        "stream",
+        originalRequestId ?? uploadState.uploadId,
+        context ?? { documentId: uploadState.document },
+        chunk.encrypted,
       );
+
+      uploadState.sentChunks.add(message.id);
+
+      await this.#sendStreamMessage(message);
+    }
 
     // Mark all chunks as sent - upload can now resolve when all ACKs received
     uploadState.allChunksSent = true;

--- a/src/protocols/milestone/README.md
+++ b/src/protocols/milestone/README.md
@@ -117,9 +117,9 @@ try {
   await provider.rpc.milestones.create("v1");
 } catch (error) {
   if (error instanceof RpcOperationError) {
-    console.log(error.protocol);  // "milestone"
+    console.log(error.protocol); // "milestone"
     console.log(error.operation); // "create"
-    console.log(error.cause);     // underlying RPC error
+    console.log(error.cause); // underlying RPC error
   }
 }
 ```

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -50,7 +50,7 @@ export type DefaultTransportProperties = {
   };
 };
 
-export const teleportalEventClient = new EventClient<{
+type TeleportalEventMap = {
   "teleportal-provider:load-subdoc": {
     subdoc: Y.Doc;
     provider: Provider<any, any>;
@@ -86,9 +86,12 @@ export const teleportalEventClient = new EventClient<{
     provider: Provider<any, any>;
     connection: Connection;
   };
-}>({
-  pluginId: "teleportal-provider",
-});
+};
+
+export const teleportalEventClient: EventClient<TeleportalEventMap> =
+  new EventClient({
+    pluginId: "teleportal-provider",
+  });
 
 export type ProviderOptions<
   T extends Transport<ClientContext, DefaultTransportProperties> = Transport<

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -1211,7 +1211,9 @@ describe("Server", () => {
       // Create a transport that captures messages sent to client
       const transport = new MockTransport<ServerContext>();
       // Override write to capture messages
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = server.createClient({
         transport,
@@ -1247,7 +1249,9 @@ describe("Server", () => {
       // Create a transport that captures messages sent to client
       const transport = new MockTransport<ServerContext>();
       // Override write to capture messages
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = server.createClient({
         transport,
@@ -1298,7 +1302,9 @@ describe("Server", () => {
       // Create a transport that captures messages sent to client
       const transport = new MockTransport<ServerContext>();
       // Override write to capture messages
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = server.createClient({
         transport,
@@ -1349,7 +1355,9 @@ describe("Server", () => {
       });
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithFailingHandler.createClient({
         transport,
@@ -1407,7 +1415,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,
@@ -1455,7 +1465,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,
@@ -1514,7 +1526,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,
@@ -1571,7 +1585,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,
@@ -1628,7 +1644,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,
@@ -1686,7 +1704,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,
@@ -1762,7 +1782,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,
@@ -1835,7 +1857,9 @@ describe("Server", () => {
       const writtenMessages: Message<ServerContext>[] = [];
 
       const transport = new MockTransport<ServerContext>();
-      transport.write = (chunk: Message<ServerContext>) => { writtenMessages.push(chunk); };
+      transport.write = (chunk: Message<ServerContext>) => {
+        writtenMessages.push(chunk);
+      };
 
       const _client = serverWithToken.createClient({
         transport,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -572,7 +572,37 @@ export class Server<Context extends ServerContext> extends Observable<ServerEven
           }
           return false;
         },
-        onRateLimitExceeded: config.onRateLimitExceeded,
+        onRateLimitExceeded: (details) => {
+          emitWideEvent("error", {
+            event_type: "rate_limit_exceeded",
+            timestamp: new Date().toISOString(),
+            rule_id: details.ruleId,
+            user_id: details.userId,
+            document_id: details.documentId,
+            track_by: details.trackBy,
+            max_messages: details.maxMessages,
+            window_ms: details.windowMs,
+            reset_at: details.resetAt,
+            message_type: details.message.type,
+            rpc_method:
+              details.message.type === "rpc"
+                ? (details.message as RpcMessage<any>).rpcMethod
+                : undefined,
+          });
+          config.onRateLimitExceeded?.(details);
+        },
+        onRateLimitDrop: (message, exceeded, write) => {
+          const retryAfter = Math.max(0, exceeded.resetAt - Date.now());
+          Promise.resolve(
+            write(
+              new AckMessage({
+                type: "ack",
+                messageId: message.id,
+                retryAfter: retryAfter || exceeded.windowMs,
+              }),
+            ),
+          ).catch(() => {});
+        },
         onMessageSizeExceeded: config.onMessageSizeExceeded,
         metricsCollector: this.#metrics,
         eventEmitter: this as any,

--- a/src/storage/document-storage-sync.test.ts
+++ b/src/storage/document-storage-sync.test.ts
@@ -40,6 +40,7 @@ import {
 
 import type { AbstractDocumentStorage } from "./document-storage";
 import { MemoryDocumentStorage } from "./in-memory/document-storage";
+import { TieredDocumentStorage } from "./tiered/document-storage";
 import { UnstorageDocumentStorage } from "./unstorage/document-storage";
 
 // ── Backend harness ───────────────────────────────────────────────────────────
@@ -75,6 +76,25 @@ const backends: Backend[] = [
       return new UnstorageDocumentStorage(store, { encrypted: true });
     },
     cleanup: async () => {
+      await Promise.all(openStorages.splice(0).map((s) => s.dispose()));
+    },
+  },
+  {
+    name: "TieredDocumentStorage",
+    make: () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
+      const store = createStorage();
+      openStorages.push(store);
+      return new TieredDocumentStorage(
+        new MemoryDocumentStorage(true),
+        new UnstorageDocumentStorage(store, { encrypted: true }),
+        { persistIntervalMs: 60_000 },
+      );
+    },
+    cleanup: async () => {
+      MemoryDocumentStorage.docs.clear();
+      MemoryDocumentStorage.attributionMaps.clear();
       await Promise.all(openStorages.splice(0).map((s) => s.dispose()));
     },
   },

--- a/src/storage/document-storage-sync.test.ts
+++ b/src/storage/document-storage-sync.test.ts
@@ -356,9 +356,44 @@ describe.each(backends)("AbstractDocumentStorage encrypted sync ($name)", (backe
     expect(reconstructed.getMap("root").get("key-3")).toBe(3);
   });
 
-  // ── 4. No-op update ────────────────────────────────────────────────────────
+  // ── 3c. Delete-only update persists and round-trips correctly ──────────────
 
-  it("no-op update does not append a sidecar or change the state vector", async () => {
+  it("delete-only update is persisted and a fresh client sees the deletion", async () => {
+    const docKey = "doc-delete";
+
+    // Client inserts "Hello World".
+    const doc = new Y.Doc();
+    doc.clientID = 111;
+    doc.getText("body").insert(0, "Hello World");
+    const svAfterInsert = Y.encodeStateVector(doc);
+    await storage.handleUpdate(
+      docKey,
+      await makeEncryptedUpdate(key, Y.encodeStateAsUpdateV2(doc)),
+    );
+
+    // Client deletes "World" — this update carries only a delete set, no
+    // new struct items, so the state vector does NOT advance.
+    doc.getText("body").delete(6, 5);
+    expect(doc.getText("body").toString()).toBe("Hello ");
+    const deleteOnlyDiff = Y.encodeStateAsUpdateV2(doc, svAfterInsert);
+    await storage.handleUpdate(docKey, await makeEncryptedUpdate(key, deleteOnlyDiff));
+
+    // The stored state should reflect the deletion: a fresh client syncing
+    // from scratch must see "Hello ", not "Hello World".
+    const result = await storage.handleSyncStep1(docKey, getEmptyStateVector());
+    const restored = await decryptPayload(key, result.content.update);
+    const reconstructed = applyV2(restored);
+    expect(reconstructed.getText("body").toString()).toBe("Hello ");
+
+    // No spurious sidecar growth — the delete-only update has no new
+    // encrypted content, so only the original sidecar should remain.
+    const state = await storage.getDocumentState(docKey);
+    expect(state!.sidecars.length).toBe(1);
+  });
+
+  // ── 4. Re-applied update ───────────────────────────────────────────────────
+
+  it("re-applied insert update is idempotent on state vector (sidecar compaction handles dup ciphertexts)", async () => {
     const docKey = "doc-noop";
 
     const doc = new Y.Doc();
@@ -372,21 +407,21 @@ describe.each(backends)("AbstractDocumentStorage encrypted sync ($name)", (backe
     const svFirst = Y.encodeStateVectorFromUpdateV2(first!.update);
     expect(first!.sidecars.length).toBe(1);
 
-    // Re-apply the exact same update — adds no new state.
+    // Re-apply the exact same update. The CRDT state is idempotent under the
+    // merge, so the state vector does not change. Sidecars DO accumulate
+    // (deterring duplicates cheaply on the hot path costs an O(doc) byte
+    // compare, which doesn't scale to large docs — compaction is the
+    // mechanism for cleaning these up).
     await storage.handleUpdate(docKey, update);
     const second = await storage.getDocumentState(docKey);
     const svSecond = Y.encodeStateVectorFromUpdateV2(second!.update);
-
-    // No new sidecar appended, state vector unchanged.
-    expect(second!.sidecars.length).toBe(1);
     expect(new Uint8Array(svSecond)).toEqual(new Uint8Array(svFirst));
 
     // A re-encrypted (different ciphertext) but content-identical update is
-    // also a no-op — proves dedup is keyed on CRDT state, not bytes.
+    // also CRDT-idempotent.
     const reEncrypted = await makeEncryptedUpdate(key, v2);
     await storage.handleUpdate(docKey, reEncrypted);
     const third = await storage.getDocumentState(docKey);
-    expect(third!.sidecars.length).toBe(1);
     expect(new Uint8Array(Y.encodeStateVectorFromUpdateV2(third!.update))).toEqual(
       new Uint8Array(svFirst),
     );

--- a/src/storage/document-storage.ts
+++ b/src/storage/document-storage.ts
@@ -81,7 +81,7 @@ export abstract class AbstractDocumentStorage implements DocumentStorage {
   abstract writeDocumentMetadata(key: string, metadata: DocumentMetadata): Promise<void>;
   abstract deleteDocument(key: string): Promise<void>;
 
-  protected async storeAttribution(_key: string, _attribution: EncodedContentMap): Promise<void> {}
+  async storeAttribution(_key: string, _attribution: EncodedContentMap): Promise<void> {}
 
   transaction<T>(_key: string, cb: () => Promise<T>): Promise<T> {
     return cb();

--- a/src/storage/document-storage.ts
+++ b/src/storage/document-storage.ts
@@ -149,11 +149,18 @@ export abstract class AbstractDocumentStorage implements DocumentStorage {
 
       const incomingMeta = Y.parseUpdateMetaV2(decoded.structureUpdate);
       const index = buildSidecarIndexFromUpdateMeta(incomingMeta);
-      const incomingSidecars: IndexedSidecar[] = decoded.encryptedSidecars.map((encrypted) => ({
-        encrypted,
-        index,
-        hash: hashSidecar(encrypted),
-      }));
+      // An empty index means the incoming update carries no insert structs
+      // (e.g. a delete-only diff). Any encrypted sidecars on such a payload
+      // are guaranteed to encode zero content entries, so drop them rather
+      // than persist empty sidecars that would only grow storage.
+      const incomingSidecars: IndexedSidecar[] =
+        index.length === 0
+          ? []
+          : decoded.encryptedSidecars.map((encrypted) => ({
+              encrypted,
+              index,
+              hash: hashSidecar(encrypted),
+            }));
 
       const now = Date.now();
       const existing = await this.getDocumentState(key);
@@ -162,17 +169,16 @@ export abstract class AbstractDocumentStorage implements DocumentStorage {
       let newSidecars: IndexedSidecar[];
 
       if (existing) {
+        // Merge unconditionally and persist the result. Y.mergeUpdatesV2 is
+        // idempotent, so a re-sent or already-known update produces an
+        // equivalent merged structure with no extra logical state. We don't
+        // try to detect that case: comparing state vectors misses delete-only
+        // updates (the SV doesn't advance), and byte-comparing the merged
+        // binary against `existing.update` is O(doc size) — expensive for
+        // large documents and the very thing this check is trying to avoid.
+        // True empty diffs already short-circuited at the
+        // `structureUpdate.length === 0` check above.
         merged = Y.mergeUpdatesV2([existing.update, decoded.structureUpdate]);
-
-        const svBefore = Y.encodeStateVectorFromUpdateV2(existing.update);
-        const svAfter = Y.encodeStateVectorFromUpdateV2(merged);
-        const isNoOp = arraysEqual(svBefore, svAfter);
-        if (isNoOp && !decoded.compaction) return;
-
-        // When the update adds no new state, keep the existing update unchanged
-        // and don't append a sidecar for the empty diff.
-        if (isNoOp) merged = existing.update;
-        const appendedSidecars = isNoOp ? [] : incomingSidecars;
 
         if (decoded.compaction) {
           const matchedIndices = new Set<number>();
@@ -188,12 +194,12 @@ export abstract class AbstractDocumentStorage implements DocumentStorage {
               hash: decoded.compaction.hash,
             };
             const keptSidecars = existing.sidecars.filter((_, i) => !matchedIndices.has(i));
-            newSidecars = [compactedSidecar, ...keptSidecars, ...appendedSidecars];
+            newSidecars = [compactedSidecar, ...keptSidecars, ...incomingSidecars];
           } else {
-            newSidecars = [...existing.sidecars, ...appendedSidecars];
+            newSidecars = [...existing.sidecars, ...incomingSidecars];
           }
         } else {
-          newSidecars = [...existing.sidecars, ...appendedSidecars];
+          newSidecars = [...existing.sidecars, ...incomingSidecars];
         }
       } else {
         merged = decoded.structureUpdate;

--- a/src/storage/document-storage.ts
+++ b/src/storage/document-storage.ts
@@ -110,12 +110,19 @@ export abstract class AbstractDocumentStorage implements DocumentStorage {
     const diff = Y.diffUpdateV2(state.update, syncStep1);
     const serverSV = Y.encodeStateVectorFromUpdateV2(state.update) as StateVector;
 
-    const diffMeta = Y.parseUpdateMetaV2(diff);
-    const relevantSidecars = state.sidecars.filter((s) => sidecarOverlapsDiff(s.index, diffMeta));
+    let encryptedSidecars: Uint8Array[];
+    if (state.sidecars.length === 0) {
+      encryptedSidecars = [];
+    } else {
+      const diffMeta = Y.parseUpdateMetaV2(diff);
+      encryptedSidecars = state.sidecars
+        .filter((s) => sidecarOverlapsDiff(s.index, diffMeta))
+        .map((s) => s.encrypted);
+    }
 
     const update = encodeContentEncryptedPayload({
       structureUpdate: diff,
-      encryptedSidecars: relevantSidecars.map((s) => s.encrypted),
+      encryptedSidecars,
     }) as unknown as UpdateV2;
 
     return {
@@ -147,20 +154,25 @@ export abstract class AbstractDocumentStorage implements DocumentStorage {
       const decoded = decodeContentEncryptedPayload(update.data as EncryptedUpdatePayload);
       if (decoded.structureUpdate.length === 0) return;
 
-      const incomingMeta = Y.parseUpdateMetaV2(decoded.structureUpdate);
-      const index = buildSidecarIndexFromUpdateMeta(incomingMeta);
-      // An empty index means the incoming update carries no insert structs
-      // (e.g. a delete-only diff). Any encrypted sidecars on such a payload
-      // are guaranteed to encode zero content entries, so drop them rather
-      // than persist empty sidecars that would only grow storage.
-      const incomingSidecars: IndexedSidecar[] =
-        index.length === 0
-          ? []
-          : decoded.encryptedSidecars.map((encrypted) => ({
-              encrypted,
-              index,
-              hash: hashSidecar(encrypted),
-            }));
+      let incomingSidecars: IndexedSidecar[];
+      if (decoded.encryptedSidecars.length === 0) {
+        incomingSidecars = [];
+      } else {
+        const incomingMeta = Y.parseUpdateMetaV2(decoded.structureUpdate);
+        const index = buildSidecarIndexFromUpdateMeta(incomingMeta);
+        // An empty index means the incoming update carries no insert structs
+        // (e.g. a delete-only diff). Any encrypted sidecars on such a payload
+        // are guaranteed to encode zero content entries, so drop them rather
+        // than persist empty sidecars that would only grow storage.
+        incomingSidecars =
+          index.length === 0
+            ? []
+            : decoded.encryptedSidecars.map((encrypted) => ({
+                encrypted,
+                index,
+                hash: hashSidecar(encrypted),
+              }));
+      }
 
       const now = Date.now();
       const existing = await this.getDocumentState(key);
@@ -196,10 +208,16 @@ export abstract class AbstractDocumentStorage implements DocumentStorage {
             const keptSidecars = existing.sidecars.filter((_, i) => !matchedIndices.has(i));
             newSidecars = [compactedSidecar, ...keptSidecars, ...incomingSidecars];
           } else {
-            newSidecars = [...existing.sidecars, ...incomingSidecars];
+            newSidecars =
+              incomingSidecars.length === 0
+                ? existing.sidecars
+                : [...existing.sidecars, ...incomingSidecars];
           }
         } else {
-          newSidecars = [...existing.sidecars, ...incomingSidecars];
+          newSidecars =
+            incomingSidecars.length === 0
+              ? existing.sidecars
+              : [...existing.sidecars, ...incomingSidecars];
         }
       } else {
         merged = decoded.structureUpdate;

--- a/src/storage/idb/document-storage.test.ts
+++ b/src/storage/idb/document-storage.test.ts
@@ -93,7 +93,7 @@ describe("IDB-like storage round-trip (via MemoryDocumentStorage)", () => {
     expect(reconstructed.getText("body").toString()).toBe("encrypted content");
   });
 
-  it("empty/no-op updates do not cause growth", async () => {
+  it("re-applied update converges to the same CRDT state", async () => {
     const doc = new Y.Doc();
     doc.getText("body").insert(0, "base");
     const v2 = Y.encodeStateAsUpdateV2(doc);
@@ -102,17 +102,14 @@ describe("IDB-like storage round-trip (via MemoryDocumentStorage)", () => {
 
     const stateBefore = await storage.getDocument("doc-noop");
 
-    // Re-send the same update (no-op).
+    // Re-send the same update. CRDT merge is idempotent so the state vector
+    // does not advance; sidecars accumulate (compaction cleans them up).
     await storage.handleUpdate("doc-noop", envelopeUpdate(payload));
     const stateAfter = await storage.getDocument("doc-noop");
 
-    const decodedBefore = decodeContentEncryptedPayload(
-      stateBefore!.content.update as unknown as EncryptedUpdatePayload,
+    expect(new Uint8Array(stateAfter!.content.stateVector)).toEqual(
+      new Uint8Array(stateBefore!.content.stateVector),
     );
-    const decodedAfter = decodeContentEncryptedPayload(
-      stateAfter!.content.update as unknown as EncryptedUpdatePayload,
-    );
-    expect(decodedAfter.encryptedSidecars.length).toBe(decodedBefore.encryptedSidecars.length);
   });
 
   it("multiple incremental updates merge correctly", async () => {

--- a/src/storage/idb/file-cache.test.ts
+++ b/src/storage/idb/file-cache.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+// ───────────────────────────────────────────────────────────────────────────
+// In-memory mock of `lib0/indexeddb` — same approach as idb-storage.test.ts.
+// ───────────────────────────────────────────────────────────────────────────
+
+type Store = Map<string, unknown>;
+const databases = new Map<string, Map<string, Store>>();
+
+class FakeStore {
+  constructor(
+    public name: string,
+    public data: Store,
+  ) {}
+  clear() {
+    this.data.clear();
+    return { cleared: true };
+  }
+}
+
+mock.module("lib0/indexeddb", () => ({
+  openDB: async (name: string, initDB: (db: any) => void) => {
+    let stores = databases.get(name);
+    if (!stores) {
+      stores = new Map<string, Store>();
+      databases.set(name, stores);
+      initDB({
+        createObjectStore: (storeName: string) => {
+          stores!.set(storeName, new Map());
+        },
+        objectStoreNames: { contains: (n: string) => stores!.has(n) },
+        close: () => {},
+      });
+    }
+    return { __name: name, close: () => {} };
+  },
+  createStores: (db: any, defs: Array<Array<string>>) => {
+    for (const def of defs) db.createObjectStore(def[0]);
+  },
+  transact: (db: any, names: string[]) => {
+    const stores = databases.get(db.__name)!;
+    return names.map((n) => new FakeStore(n, stores.get(n)!));
+  },
+  get: async (store: FakeStore, key: string) => store.data.get(key),
+  put: async (store: FakeStore, item: unknown, key: string) => {
+    store.data.set(key, item);
+  },
+  del: async (store: FakeStore, key: string) => {
+    store.data.delete(key);
+  },
+  rtop: async (req: unknown) => req,
+}));
+
+const { IdbFileCache } = await import("./file-cache");
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function storeSizes(dbName: string) {
+  const stores = databases.get(dbName);
+  return {
+    files: stores?.get("files")?.size ?? 0,
+    chunks: stores?.get("chunks")?.size ?? 0,
+  };
+}
+
+function makeChunk(size: number, fill: number = 0xab): Uint8Array {
+  const data = new Uint8Array(size);
+  data.fill(fill);
+  return data;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("IdbFileCache (mocked lib0/indexeddb)", () => {
+  const DB_NAME = "test-file-cache";
+
+  beforeEach(() => {
+    databases.clear();
+  });
+
+  it("creates both object stores on first open", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    await cache.has("nonexistent");
+    expect(Array.from(databases.get(DB_NAME)!.keys()).sort()).toEqual(["chunks", "files"]);
+  });
+
+  it("putMetadata + getMetadata round-trip", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    const metadata = {
+      filename: "test.png",
+      size: 128000,
+      mimeType: "image/png",
+      encrypted: true,
+      totalChunks: 2,
+      lastModified: 1234567890,
+    };
+
+    await cache.putMetadata("file-abc", metadata);
+    const result = await cache.getMetadata("file-abc");
+    expect(result).toEqual(metadata);
+  });
+
+  it("getMetadata returns null for unknown fileId", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    expect(await cache.getMetadata("unknown")).toBeNull();
+  });
+
+  it("putChunk + getChunk round-trip", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    const chunk = makeChunk(64 * 1024);
+
+    await cache.putChunk("file-abc", 0, chunk);
+    const result = await cache.getChunk("file-abc", 0);
+
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(chunk.length);
+    expect(result!.every((b, i) => b === chunk[i])).toBe(true);
+  });
+
+  it("getChunk returns null for unknown chunk", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    expect(await cache.getChunk("unknown", 0)).toBeNull();
+  });
+
+  it("multi-chunk file round-trip", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    const chunks = [makeChunk(64 * 1024, 0x01), makeChunk(64 * 1024, 0x02), makeChunk(100, 0x03)];
+    const metadata = {
+      filename: "multi.bin",
+      size: chunks.reduce((s, c) => s + c.length, 0),
+      mimeType: "application/octet-stream",
+      encrypted: false,
+      totalChunks: 3,
+      lastModified: Date.now(),
+    };
+
+    await cache.putMetadata("file-multi", metadata);
+    for (let i = 0; i < chunks.length; i++) {
+      await cache.putChunk("file-multi", i, chunks[i]);
+    }
+
+    expect(storeSizes(DB_NAME)).toEqual({ files: 1, chunks: 3 });
+
+    const meta = await cache.getMetadata("file-multi");
+    expect(meta).toEqual(metadata);
+
+    for (let i = 0; i < chunks.length; i++) {
+      const result = await cache.getChunk("file-multi", i);
+      expect(result!.every((b, j) => b === chunks[i][j])).toBe(true);
+    }
+  });
+
+  it("has returns true/false correctly", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    expect(await cache.has("file-abc")).toBe(false);
+
+    await cache.putMetadata("file-abc", {
+      filename: "test.txt",
+      size: 100,
+      mimeType: "text/plain",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: Date.now(),
+    });
+    expect(await cache.has("file-abc")).toBe(true);
+  });
+
+  it("delete removes file metadata and all chunks", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    const metadata = {
+      filename: "del.txt",
+      size: 200,
+      mimeType: "text/plain",
+      encrypted: false,
+      totalChunks: 2,
+      lastModified: Date.now(),
+    };
+
+    await cache.putMetadata("file-del", metadata);
+    await cache.putChunk("file-del", 0, makeChunk(100));
+    await cache.putChunk("file-del", 1, makeChunk(100));
+    expect(storeSizes(DB_NAME)).toEqual({ files: 1, chunks: 2 });
+
+    await cache.delete("file-del");
+    expect(storeSizes(DB_NAME)).toEqual({ files: 0, chunks: 0 });
+    expect(await cache.has("file-del")).toBe(false);
+    expect(await cache.getChunk("file-del", 0)).toBeNull();
+  });
+
+  it("delete is a no-op for unknown fileId", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+    await cache.delete("nonexistent"); // should not throw
+  });
+
+  it("clear removes all files and chunks", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+
+    await cache.putMetadata("file-1", {
+      filename: "a.txt",
+      size: 100,
+      mimeType: "text/plain",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: Date.now(),
+    });
+    await cache.putChunk("file-1", 0, makeChunk(100));
+    await cache.putMetadata("file-2", {
+      filename: "b.txt",
+      size: 200,
+      mimeType: "text/plain",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: Date.now(),
+    });
+    await cache.putChunk("file-2", 0, makeChunk(200));
+
+    expect(storeSizes(DB_NAME)).toEqual({ files: 2, chunks: 2 });
+
+    await cache.clear();
+    expect(storeSizes(DB_NAME)).toEqual({ files: 0, chunks: 0 });
+  });
+
+  it("overwriting an existing file replaces metadata and chunks", async () => {
+    const cache = new IdbFileCache(DB_NAME);
+
+    await cache.putMetadata("file-ow", {
+      filename: "v1.txt",
+      size: 100,
+      mimeType: "text/plain",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: 1000,
+    });
+    await cache.putChunk("file-ow", 0, makeChunk(100, 0x01));
+
+    await cache.putMetadata("file-ow", {
+      filename: "v2.txt",
+      size: 200,
+      mimeType: "text/plain",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: 2000,
+    });
+    await cache.putChunk("file-ow", 0, makeChunk(200, 0x02));
+
+    const meta = await cache.getMetadata("file-ow");
+    expect(meta!.filename).toBe("v2.txt");
+    expect(meta!.size).toBe(200);
+
+    const chunk = await cache.getChunk("file-ow", 0);
+    expect(chunk!.length).toBe(200);
+    expect(chunk![0]).toBe(0x02);
+  });
+
+  it("persists across cache instances (simulated reload)", async () => {
+    const cache1 = new IdbFileCache(DB_NAME);
+    await cache1.putMetadata("file-persist", {
+      filename: "durable.txt",
+      size: 50,
+      mimeType: "text/plain",
+      encrypted: false,
+      totalChunks: 1,
+      lastModified: Date.now(),
+    });
+    await cache1.putChunk("file-persist", 0, makeChunk(50));
+    cache1.close();
+
+    const cache2 = new IdbFileCache(DB_NAME);
+    expect(await cache2.has("file-persist")).toBe(true);
+    const meta = await cache2.getMetadata("file-persist");
+    expect(meta!.filename).toBe("durable.txt");
+    const chunk = await cache2.getChunk("file-persist", 0);
+    expect(chunk!.length).toBe(50);
+  });
+});

--- a/src/storage/idb/file-cache.ts
+++ b/src/storage/idb/file-cache.ts
@@ -1,0 +1,146 @@
+import * as idb from "lib0/indexeddb";
+
+const FILES_STORE = "files";
+const CHUNKS_STORE = "chunks";
+
+export interface CachedFileMetadata {
+  filename: string;
+  size: number;
+  mimeType: string;
+  encrypted: boolean;
+  totalChunks: number;
+  lastModified: number;
+}
+
+export interface FileCache {
+  getMetadata(fileId: string): Promise<CachedFileMetadata | null>;
+  getChunk(fileId: string, chunkIndex: number): Promise<Uint8Array | null>;
+  putMetadata(fileId: string, metadata: CachedFileMetadata): Promise<void>;
+  putChunk(fileId: string, chunkIndex: number, data: Uint8Array): Promise<void>;
+  delete(fileId: string): Promise<void>;
+  has(fileId: string): Promise<boolean>;
+  clear(): Promise<void>;
+  close(): void;
+}
+
+export class IdbFileCache implements FileCache {
+  #db: IDBDatabase | null = null;
+  #dbPromise: Promise<IDBDatabase> | null = null;
+  readonly #dbName: string;
+  #queue: Promise<unknown> = Promise.resolve();
+
+  constructor(dbName: string = "teleportal-file-cache") {
+    this.#dbName = dbName;
+  }
+
+  #run<T>(fn: () => Promise<T>): Promise<T> {
+    const result = this.#queue.then(fn, fn);
+    this.#queue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  async #open(): Promise<IDBDatabase> {
+    if (this.#db) return this.#db;
+    if (this.#dbPromise) return this.#dbPromise;
+    this.#dbPromise = idb.openDB(this.#dbName, (db: IDBDatabase) => {
+      idb.createStores(db, [[FILES_STORE], [CHUNKS_STORE]]);
+    });
+    this.#db = await this.#dbPromise;
+    this.#dbPromise = null;
+    return this.#db;
+  }
+
+  #getStore(name: string, mode: "readonly" | "readwrite" = "readonly"): IDBObjectStore {
+    const db = this.#db;
+    if (!db) throw new Error("IdbFileCache: database not open");
+    const [store] = idb.transact(db, [name], mode);
+    return store;
+  }
+
+  async getMetadata(fileId: string): Promise<CachedFileMetadata | null> {
+    return this.#run(async () => {
+      await this.#open();
+      const store = this.#getStore(FILES_STORE);
+      const raw = (await idb.get(store, fileId)) as unknown as string | undefined;
+      if (!raw) return null;
+      return JSON.parse(raw) as CachedFileMetadata;
+    });
+  }
+
+  async getChunk(fileId: string, chunkIndex: number): Promise<Uint8Array | null> {
+    return this.#run(async () => {
+      await this.#open();
+      const store = this.#getStore(CHUNKS_STORE);
+      const raw = (await idb.get(store, `${fileId}:${chunkIndex}`)) as unknown as
+        | ArrayBuffer
+        | undefined;
+      return raw ? new Uint8Array(raw) : null;
+    });
+  }
+
+  async putMetadata(fileId: string, metadata: CachedFileMetadata): Promise<void> {
+    return this.#run(async () => {
+      await this.#open();
+      const store = this.#getStore(FILES_STORE, "readwrite");
+      await idb.put(store, JSON.stringify(metadata), fileId);
+    });
+  }
+
+  async putChunk(fileId: string, chunkIndex: number, data: Uint8Array): Promise<void> {
+    return this.#run(async () => {
+      await this.#open();
+      const store = this.#getStore(CHUNKS_STORE, "readwrite");
+      await idb.put(
+        store,
+        data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer,
+        `${fileId}:${chunkIndex}`,
+      );
+    });
+  }
+
+  async delete(fileId: string): Promise<void> {
+    return this.#run(async () => {
+      await this.#open();
+      const filesStore = this.#getStore(FILES_STORE, "readwrite");
+      const raw = (await idb.get(filesStore, fileId)) as unknown as string | undefined;
+      if (!raw) return;
+
+      const metadata = JSON.parse(raw) as CachedFileMetadata;
+      await idb.del(filesStore, fileId);
+
+      const chunksStore = this.#getStore(CHUNKS_STORE, "readwrite");
+      for (let i = 0; i < metadata.totalChunks; i++) {
+        await idb.del(chunksStore, `${fileId}:${i}`);
+      }
+    });
+  }
+
+  async has(fileId: string): Promise<boolean> {
+    return this.#run(async () => {
+      await this.#open();
+      const store = this.#getStore(FILES_STORE);
+      const raw = await idb.get(store, fileId);
+      return raw !== undefined;
+    });
+  }
+
+  async clear(): Promise<void> {
+    return this.#run(async () => {
+      await this.#open();
+      const filesStore = this.#getStore(FILES_STORE, "readwrite");
+      const chunksStore = this.#getStore(CHUNKS_STORE, "readwrite");
+      await idb.rtop(filesStore.clear());
+      await idb.rtop(chunksStore.clear());
+    });
+  }
+
+  close(): void {
+    if (this.#db) {
+      this.#db.close();
+      this.#db = null;
+    }
+  }
+}

--- a/src/storage/idb/index.ts
+++ b/src/storage/idb/index.ts
@@ -1,1 +1,2 @@
 export * from "./document-storage";
+export * from "./file-cache";

--- a/src/storage/in-memory/document-storage.test.ts
+++ b/src/storage/in-memory/document-storage.test.ts
@@ -713,7 +713,7 @@ describe("MemoryDocumentStorage (encrypted)", () => {
 
   // ── 6. Duplicate update is deduped ─────────────────────────────────────────
 
-  it("duplicate update is deduped (state vector unchanged)", async () => {
+  it("duplicate update is CRDT-idempotent (state vector unchanged)", async () => {
     const doc = new Y.Doc();
     doc.getMap("root").set("key", "value");
     const v2Update = Y.encodeStateAsUpdateV2(doc);
@@ -731,8 +731,9 @@ describe("MemoryDocumentStorage (encrypted)", () => {
     const svAfterSecond = Y.encodeStateVectorFromUpdateV2(stateAfterSecond!.update);
 
     expect(new Uint8Array(svAfterSecond)).toEqual(new Uint8Array(svAfterFirst));
-    // Sidecars should not accumulate on dedup
-    expect(stateAfterSecond!.sidecars.length).toBe(stateAfterFirst!.sidecars.length);
+    // Sidecars may accumulate on duplicate ciphertexts — cheap dedup at
+    // write time costs an O(doc-size) byte compare. Compaction is the
+    // mechanism that collapses redundant sidecars.
   });
 
   // ── 7. Multi-client updates merge correctly ────────────────────────────────
@@ -1022,7 +1023,7 @@ describe("MemoryDocumentStorage (encrypted)", () => {
     expect(document).not.toBeNull();
   });
 
-  it("handleSyncStep2 deduplicates (state unchanged on duplicate)", async () => {
+  it("handleSyncStep2 is CRDT-idempotent on duplicates", async () => {
     const doc = new Y.Doc();
     doc.getMap("root").set("synced", true);
     const v2Update = Y.encodeStateAsUpdateV2(doc);
@@ -1034,6 +1035,7 @@ describe("MemoryDocumentStorage (encrypted)", () => {
     } as unknown as VersionedSyncStep2Update);
 
     const stateAfterFirst = await storage.getDocumentState("doc-1");
+    const svAfterFirst = Y.encodeStateVectorFromUpdateV2(stateAfterFirst!.update);
 
     await storage.handleSyncStep2("doc-1", {
       version: 2,
@@ -1041,8 +1043,8 @@ describe("MemoryDocumentStorage (encrypted)", () => {
     } as unknown as VersionedSyncStep2Update);
 
     const stateAfterSecond = await storage.getDocumentState("doc-1");
-    // Sidecars should not accumulate on dedup
-    expect(stateAfterSecond!.sidecars.length).toBe(stateAfterFirst!.sidecars.length);
+    const svAfterSecond = Y.encodeStateVectorFromUpdateV2(stateAfterSecond!.update);
+    expect(new Uint8Array(svAfterSecond)).toEqual(new Uint8Array(svAfterFirst));
   });
 
   // ── 11. Compaction ─────────────────────────────────────────────────────────

--- a/src/storage/in-memory/document-storage.ts
+++ b/src/storage/in-memory/document-storage.ts
@@ -84,7 +84,7 @@ export class MemoryDocumentStorage extends AbstractDocumentStorage {
     });
   }
 
-  protected override async storeAttribution(
+  override async storeAttribution(
     key: string,
     attribution: EncodedContentMap,
   ): Promise<void> {

--- a/src/storage/in-memory/file-storage.ts
+++ b/src/storage/in-memory/file-storage.ts
@@ -61,6 +61,7 @@ export class InMemoryFileStorage implements FileStorage {
       metadata: uploadResult.progress.metadata,
       chunks,
       contentId: uploadResult.contentId,
+      serializedMerkleTree: uploadResult.serializedMerkleTree,
     };
 
     await this.storeFile(file);

--- a/src/storage/in-memory/temporary-upload-storage.ts
+++ b/src/storage/in-memory/temporary-upload-storage.ts
@@ -1,6 +1,6 @@
 import { toBase64 } from "lib0/buffer";
 import type { MerkleTree } from "teleportal/merkle-tree";
-import { buildMerkleTree, CHUNK_SIZE } from "teleportal/merkle-tree";
+import { buildMerkleTree, serializeMerkleTree, CHUNK_SIZE } from "teleportal/merkle-tree";
 import type {
   File,
   FileMetadata,
@@ -33,8 +33,10 @@ export class InMemoryTemporaryUploadStorage implements TemporaryUploadStorage {
   }
 
   async beginUpload(uploadId: string, metadata: FileMetadata): Promise<void> {
-    if (this.#sessions.has(uploadId)) {
-      throw new Error(`Upload session ${uploadId} already exists`);
+    const existing = this.#sessions.get(uploadId);
+    if (existing) {
+      existing.lastActivity = Date.now();
+      return;
     }
 
     this.#sessions.set(uploadId, {
@@ -142,6 +144,7 @@ export class InMemoryTemporaryUploadStorage implements TemporaryUploadStorage {
       progress,
       fileId: finalFileId,
       contentId: rootHash,
+      serializedMerkleTree: serializeMerkleTree(merkleTree),
       getChunk: async (chunkIndex: number) => {
         // Check if chunk was already fetched (one-time use)
         if (fetchedChunks.has(chunkIndex)) {

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -4,3 +4,4 @@ export * from "./unstorage";
 export * from "./in-memory";
 export * from "./idb";
 export * from "./virtual-storage";
+export * from "./tiered";

--- a/src/storage/tiered/document-storage.test.ts
+++ b/src/storage/tiered/document-storage.test.ts
@@ -1,0 +1,470 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as Y from "yjs";
+import { createStorage, type Storage } from "unstorage";
+import type { StateVector, Update, VersionedUpdate } from "teleportal";
+import {
+  encodeContentEncryptedPayload,
+  decodeContentEncryptedPayload,
+  type EncryptedUpdatePayload,
+} from "teleportal/protocol/encryption";
+import type { EncodedContentMap } from "../types";
+import { MemoryDocumentStorage } from "../in-memory/document-storage";
+import { UnstorageDocumentStorage } from "../unstorage/document-storage";
+import { TieredDocumentStorage } from "./document-storage";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function versionedUpdate(bytes: Uint8Array): VersionedUpdate {
+  const payload = encodeContentEncryptedPayload({
+    structureUpdate: bytes,
+    encryptedSidecars: [],
+  });
+  return { version: 2, data: payload as Update } as VersionedUpdate;
+}
+
+function makeUpdate(text: string): { v2: Uint8Array; versioned: VersionedUpdate } {
+  const doc = new Y.Doc();
+  doc.getText("text").insert(0, text);
+  const v2 = Y.encodeStateAsUpdateV2(doc);
+  return { v2, versioned: versionedUpdate(v2) };
+}
+
+function docFromStorageUpdate(update: Uint8Array): Y.Doc {
+  const { structureUpdate } = decodeContentEncryptedPayload(update as EncryptedUpdatePayload);
+  const doc = new Y.Doc();
+  if (structureUpdate.length > 0) Y.applyUpdateV2(doc, structureUpdate);
+  return doc;
+}
+
+// ── Test setup ───────────────────────────────────────────────────────────────
+
+describe("TieredDocumentStorage", () => {
+  let fast: MemoryDocumentStorage;
+  let slow: MemoryDocumentStorage;
+  let tiered: TieredDocumentStorage;
+
+  beforeEach(() => {
+    MemoryDocumentStorage.docs.clear();
+    MemoryDocumentStorage.attributionMaps.clear();
+
+    // Use separate backing maps so we can inspect each tier independently
+    const fastDocs = new Map<string, any>();
+    const slowDocs = new Map<string, any>();
+
+    fast = new MemoryDocumentStorage(false, {
+      write: async (key, doc) => { fastDocs.set(key, doc); },
+      fetch: async (key) => fastDocs.get(key),
+      delete: async (key) => { fastDocs.delete(key); },
+    });
+    slow = new MemoryDocumentStorage(false, {
+      write: async (key, doc) => { slowDocs.set(key, doc); },
+      fetch: async (key) => slowDocs.get(key),
+      delete: async (key) => { slowDocs.delete(key); },
+    });
+
+    tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 60_000, // long interval — we flush manually in tests
+      maxDirtyAgeMs: 60_000,
+    });
+  });
+
+  afterEach(async () => {
+    await tiered[Symbol.asyncDispose]();
+  });
+
+  // ── Basic round-trip ─────────────────────────────────────────────────────
+
+  it("round-trips a document through handleUpdate / getDocument", async () => {
+    const { versioned } = makeUpdate("hello");
+    await tiered.handleUpdate("doc1", versioned);
+
+    const doc = await tiered.getDocument("doc1");
+    expect(doc).not.toBeNull();
+    const yDoc = docFromStorageUpdate(doc!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("hello");
+  });
+
+  it("merges multiple updates", async () => {
+    const { versioned: u1 } = makeUpdate("hello ");
+    await tiered.handleUpdate("doc1", u1);
+
+    const doc2 = new Y.Doc();
+    const existing = await tiered.getDocument("doc1");
+    const { structureUpdate } = decodeContentEncryptedPayload(
+      existing!.content.update as EncryptedUpdatePayload,
+    );
+    Y.applyUpdateV2(doc2, structureUpdate);
+    doc2.getText("text").insert(6, "world");
+    const u2 = versionedUpdate(Y.encodeStateAsUpdateV2(doc2));
+    await tiered.handleUpdate("doc1", u2);
+
+    const result = await tiered.getDocument("doc1");
+    const yDoc = docFromStorageUpdate(result!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("hello world");
+  });
+
+  // ── Load from slow tier ──────────────────────────────────────────────────
+
+  it("loads a document from slow tier on first access", async () => {
+    // Pre-populate slow tier directly
+    const { versioned } = makeUpdate("from-slow");
+    await slow.handleUpdate("doc1", versioned);
+
+    // Verify fast tier is empty
+    expect(await fast.getDocumentState("doc1")).toBeNull();
+
+    // Read through tiered — should load from slow
+    const doc = await tiered.getDocument("doc1");
+    expect(doc).not.toBeNull();
+    const yDoc = docFromStorageUpdate(doc!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("from-slow");
+
+    // Fast tier should now have the document
+    expect(await fast.getDocumentState("doc1")).not.toBeNull();
+  });
+
+  it("uses fast tier for subsequent reads after loading", async () => {
+    const { versioned } = makeUpdate("initial");
+    await slow.handleUpdate("doc1", versioned);
+
+    // First read loads from slow
+    await tiered.getDocument("doc1");
+
+    // Modify slow tier directly (simulating external change)
+    const { versioned: v2 } = makeUpdate("changed-in-slow");
+    await slow.handleUpdate("doc1", v2);
+
+    // Second read should still return fast tier data (not re-loaded)
+    const doc = await tiered.getDocument("doc1");
+    const yDoc = docFromStorageUpdate(doc!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("initial");
+  });
+
+  // ── Dirty tracking + persist ─────────────────────────────────────────────
+
+  it("marks documents dirty on write and persists on flush", async () => {
+    const { versioned } = makeUpdate("dirty-doc");
+    await tiered.handleUpdate("doc1", versioned);
+
+    // Slow tier should be empty (not persisted yet)
+    expect(await slow.getDocumentState("doc1")).toBeNull();
+
+    // Flush
+    await tiered.flush("doc1");
+
+    // Now slow tier should have the document
+    const slowState = await slow.getDocumentState("doc1");
+    expect(slowState).not.toBeNull();
+  });
+
+  it("flushAll persists all dirty documents", async () => {
+    const { versioned: u1 } = makeUpdate("doc-a");
+    const { versioned: u2 } = makeUpdate("doc-b");
+    await tiered.handleUpdate("doc-a", u1);
+    await tiered.handleUpdate("doc-b", u2);
+
+    expect(await slow.getDocumentState("doc-a")).toBeNull();
+    expect(await slow.getDocumentState("doc-b")).toBeNull();
+
+    await tiered.flushAll();
+
+    expect(await slow.getDocumentState("doc-a")).not.toBeNull();
+    expect(await slow.getDocumentState("doc-b")).not.toBeNull();
+  });
+
+  it("flush is a no-op for clean documents", async () => {
+    const { versioned } = makeUpdate("clean");
+    await slow.handleUpdate("doc1", versioned);
+    await tiered.getDocument("doc1"); // load into fast
+
+    // Not dirty — flush should do nothing
+    await tiered.flush("doc1");
+    // Should not throw
+  });
+
+  // ── New document ─────────────────────────────────────────────────────────
+
+  it("handles a new document that does not exist in either tier", async () => {
+    const { versioned } = makeUpdate("brand-new");
+    await tiered.handleUpdate("new-doc", versioned);
+
+    const doc = await tiered.getDocument("new-doc");
+    expect(doc).not.toBeNull();
+    const yDoc = docFromStorageUpdate(doc!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("brand-new");
+
+    // Not in slow yet
+    expect(await slow.getDocumentState("new-doc")).toBeNull();
+
+    // After flush, in slow
+    await tiered.flush("new-doc");
+    expect(await slow.getDocumentState("new-doc")).not.toBeNull();
+  });
+
+  // ── Delete ───────────────────────────────────────────────────────────────
+
+  it("deletes from both tiers", async () => {
+    const { versioned } = makeUpdate("to-delete");
+    await tiered.handleUpdate("doc1", versioned);
+    await tiered.flush("doc1");
+
+    // Exists in both tiers
+    expect(await fast.getDocumentState("doc1")).not.toBeNull();
+    expect(await slow.getDocumentState("doc1")).not.toBeNull();
+
+    await tiered.deleteDocument("doc1");
+
+    expect(await fast.getDocumentState("doc1")).toBeNull();
+    expect(await slow.getDocumentState("doc1")).toBeNull();
+  });
+
+  it("delete works for a document only in fast tier", async () => {
+    const { versioned } = makeUpdate("fast-only");
+    await tiered.handleUpdate("doc1", versioned);
+
+    await tiered.deleteDocument("doc1");
+
+    expect(await fast.getDocumentState("doc1")).toBeNull();
+    expect(await tiered.getDocument("doc1")).toBeNull();
+  });
+
+  // ── Eviction ─────────────────────────────────────────────────────────────
+
+  it("evicts clean documents from fast tier after inactivity", async () => {
+    await tiered[Symbol.asyncDispose]();
+
+    tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 1,
+      maxDirtyAgeMs: 0,
+      evictAfterMs: 1,
+    });
+
+    const { versioned } = makeUpdate("evictable");
+    await tiered.handleUpdate("doc1", versioned);
+
+    // Wait for persist + eviction sweep
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    // Document should be evicted from fast but still in slow
+    expect(await fast.getDocumentState("doc1")).toBeNull();
+    expect(await slow.getDocumentState("doc1")).not.toBeNull();
+
+    // Re-access should reload from slow
+    const doc = await tiered.getDocument("doc1");
+    expect(doc).not.toBeNull();
+    const yDoc = docFromStorageUpdate(doc!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("evictable");
+  });
+
+  // ── Concurrent load dedup ────────────────────────────────────────────────
+
+  it("deduplicates concurrent loads of the same document", async () => {
+    const { versioned } = makeUpdate("concurrent");
+    await slow.handleUpdate("doc1", versioned);
+
+    // Install mock AFTER populating slow tier (handleUpdate internally
+    // calls getDocumentState, which would otherwise skew the count).
+    let loadCount = 0;
+    const originalGetState = slow.getDocumentState.bind(slow);
+    slow.getDocumentState = async (key: string) => {
+      loadCount++;
+      return originalGetState(key);
+    };
+
+    // Trigger two concurrent reads
+    const [doc1, doc2] = await Promise.all([
+      tiered.getDocument("doc1"),
+      tiered.getDocument("doc1"),
+    ]);
+
+    expect(doc1).not.toBeNull();
+    expect(doc2).not.toBeNull();
+    // #loadFromSlow calls slow.getDocumentState once. The dedup ensures
+    // the second concurrent getDocument reuses the same load promise.
+    expect(loadCount).toBe(1);
+  });
+
+  // ── Persist error handling ───────────────────────────────────────────────
+
+  it("calls onPersistError and leaves document dirty on persist failure", async () => {
+    await tiered[Symbol.asyncDispose]();
+
+    const errors: Array<{ documentId: string; error: unknown }> = [];
+    tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 60_000,
+      onPersistError: (documentId, error) => errors.push({ documentId, error }),
+    });
+
+    const { versioned } = makeUpdate("will-fail");
+    await tiered.handleUpdate("doc1", versioned);
+
+    // Make slow tier throw on write
+    slow.replaceDocumentState = async () => {
+      throw new Error("persist failed");
+    };
+
+    await tiered.flushAll();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].documentId).toBe("doc1");
+
+    // Document should still be in fast tier
+    const doc = await tiered.getDocument("doc1");
+    expect(doc).not.toBeNull();
+  });
+
+  // ── Metadata ─────────────────────────────────────────────────────────────
+
+  it("loads metadata from slow tier and persists changes on flush", async () => {
+    const { versioned } = makeUpdate("meta-test");
+    await slow.handleUpdate("doc1", versioned);
+    await slow.writeDocumentMetadata("doc1", {
+      createdAt: 1000,
+      updatedAt: 2000,
+      encrypted: false,
+      files: ["file-1"],
+    });
+
+    // Read through tiered
+    const meta = await tiered.getDocumentMetadata("doc1");
+    expect(meta.files).toEqual(["file-1"]);
+
+    // Update metadata
+    await tiered.writeDocumentMetadata("doc1", {
+      ...meta,
+      files: ["file-1", "file-2"],
+    });
+
+    // Not in slow yet
+    const slowMeta = await slow.getDocumentMetadata("doc1");
+    expect(slowMeta.files).toEqual(["file-1"]);
+
+    // Flush
+    await tiered.flush("doc1");
+    const flushedMeta = await slow.getDocumentMetadata("doc1");
+    expect(flushedMeta.files).toEqual(["file-1", "file-2"]);
+  });
+
+  // ── Attribution ──────────────────────────────────────────────────────────
+
+  // ── Dispose ──────────────────────────────────────────────────────────────
+
+  it("flushes all dirty documents on dispose", async () => {
+    const { versioned: u1 } = makeUpdate("dispose-a");
+    const { versioned: u2 } = makeUpdate("dispose-b");
+    await tiered.handleUpdate("doc-a", u1);
+    await tiered.handleUpdate("doc-b", u2);
+
+    expect(await slow.getDocumentState("doc-a")).toBeNull();
+    expect(await slow.getDocumentState("doc-b")).toBeNull();
+
+    await tiered[Symbol.asyncDispose]();
+
+    expect(await slow.getDocumentState("doc-a")).not.toBeNull();
+    expect(await slow.getDocumentState("doc-b")).not.toBeNull();
+  });
+
+  // ── Sync protocol ────────────────────────────────────────────────────────
+
+  it("handleSyncStep1 works through tiered storage", async () => {
+    const { versioned } = makeUpdate("sync-test");
+    await tiered.handleUpdate("doc1", versioned);
+
+    const emptyStateVector = Y.encodeStateVector(new Y.Doc()) as StateVector;
+    const doc = await tiered.handleSyncStep1("doc1", emptyStateVector);
+
+    expect(doc).not.toBeNull();
+    expect(doc.id).toBe("doc1");
+    expect(doc.content.update).toBeDefined();
+  });
+});
+
+// ── Integration with unstorage slow tier ─────────────────────────────────────
+
+describe("TieredDocumentStorage (unstorage slow tier)", () => {
+  const openStorages: Storage[] = [];
+
+  afterEach(async () => {
+    MemoryDocumentStorage.docs.clear();
+    MemoryDocumentStorage.attributionMaps.clear();
+    await Promise.all(openStorages.splice(0).map((s) => s.dispose()));
+  });
+
+  it("round-trips through memory fast + unstorage slow", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+
+    const fast = new MemoryDocumentStorage(false);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+    const tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const { versioned } = makeUpdate("unstorage-test");
+    await tiered.handleUpdate("doc1", versioned);
+    await tiered.flush("doc1");
+
+    // Verify slow tier has the data via a fresh read
+    const slowDoc = await slow.getDocument("doc1");
+    expect(slowDoc).not.toBeNull();
+    const yDoc = docFromStorageUpdate(slowDoc!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("unstorage-test");
+
+    await tiered[Symbol.asyncDispose]();
+  });
+
+  it("stores attribution in fast tier and forwards to slow on flush", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+
+    const fast = new MemoryDocumentStorage(false);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+    const tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const { versioned } = makeUpdate("attr-test");
+    const attribution = new Uint8Array([1, 2, 3]) as EncodedContentMap;
+
+    await tiered.handleUpdate("doc1", versioned, attribution);
+
+    // Attribution should be in fast tier
+    const fastAttr = await fast.retrieveAttribution("doc1");
+    expect(fastAttr).not.toBeNull();
+
+    // Not in slow yet (unstorage has separate storage)
+    const slowAttr = await slow.retrieveAttribution("doc1");
+    expect(slowAttr).toBeNull();
+
+    // Flush
+    await tiered.flush("doc1");
+
+    // Now in slow tier
+    const flushedAttr = await slow.retrieveAttribution("doc1");
+    expect(flushedAttr).not.toBeNull();
+
+    await tiered[Symbol.asyncDispose]();
+  });
+
+  it("loads from unstorage slow tier into memory fast tier", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+    const { versioned } = makeUpdate("load-from-unstorage");
+    await slow.handleUpdate("doc1", versioned);
+
+    MemoryDocumentStorage.docs.clear();
+    const fast = new MemoryDocumentStorage(false);
+    const tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const doc = await tiered.getDocument("doc1");
+    expect(doc).not.toBeNull();
+    const yDoc = docFromStorageUpdate(doc!.content.update);
+    expect(yDoc.getText("text").toString()).toBe("load-from-unstorage");
+
+    await tiered[Symbol.asyncDispose]();
+  });
+});

--- a/src/storage/tiered/document-storage.test.ts
+++ b/src/storage/tiered/document-storage.test.ts
@@ -446,6 +446,360 @@ describe("TieredDocumentStorage (unstorage slow tier)", () => {
     await tiered[Symbol.asyncDispose]();
   });
 
+  // ── Recovery & correctness ──────────────────────────────────────────────
+
+  it("recovers from slow tier after crash (unflushed data lost)", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    // Session 1: write "hello", flush, write " world" (NOT flushed)
+    const fast1 = new MemoryDocumentStorage(false);
+    const tiered1 = new TieredDocumentStorage(fast1, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const { versioned: u1 } = makeUpdate("hello");
+    await tiered1.handleUpdate("doc1", u1);
+    await tiered1.flush("doc1");
+
+    // Second update — not flushed (simulates crash)
+    const afterFlush = await tiered1.getDocument("doc1");
+    const doc2 = new Y.Doc();
+    const { structureUpdate } = decodeContentEncryptedPayload(
+      afterFlush!.content.update as EncryptedUpdatePayload,
+    );
+    Y.applyUpdateV2(doc2, structureUpdate);
+    doc2.getText("text").insert(5, " world");
+    await tiered1.handleUpdate("doc1", versionedUpdate(Y.encodeStateAsUpdateV2(doc2)));
+
+    // Verify fast tier has "hello world"
+    const beforeCrash = await tiered1.getDocument("doc1");
+    expect(docFromStorageUpdate(beforeCrash!.content.update).getText("text").toString()).toBe("hello world");
+
+    // "Crash" — dispose WITHOUT flushing (clear the timer, don't call flushAll)
+    // We can't prevent flushAll in dispose, so just create a new tiered without disposing.
+
+    // Session 2: fresh fast tier, same slow tier
+    MemoryDocumentStorage.docs.clear();
+    const fast2 = new MemoryDocumentStorage(false);
+    const tiered2 = new TieredDocumentStorage(fast2, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    // Should recover "hello" (the flushed state), not "hello world"
+    const recovered = await tiered2.getDocument("doc1");
+    expect(recovered).not.toBeNull();
+    const recoveredText = docFromStorageUpdate(recovered!.content.update).getText("text").toString();
+    expect(recoveredText).toBe("hello");
+
+    await tiered2[Symbol.asyncDispose]();
+  });
+
+  it("new updates merge correctly on top of recovered state", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    // Session 1: write and flush
+    const fast1 = new MemoryDocumentStorage(false);
+    const tiered1 = new TieredDocumentStorage(fast1, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const { versioned: u1 } = makeUpdate("aaa");
+    await tiered1.handleUpdate("doc1", u1);
+    await tiered1[Symbol.asyncDispose]();
+
+    // Session 2: recover, then apply new update
+    MemoryDocumentStorage.docs.clear();
+    const fast2 = new MemoryDocumentStorage(false);
+    const tiered2 = new TieredDocumentStorage(fast2, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const recovered = await tiered2.getDocument("doc1");
+    const base = new Y.Doc();
+    Y.applyUpdateV2(
+      base,
+      decodeContentEncryptedPayload(recovered!.content.update as EncryptedUpdatePayload).structureUpdate,
+    );
+    base.getText("text").insert(3, "bbb");
+    await tiered2.handleUpdate("doc1", versionedUpdate(Y.encodeStateAsUpdateV2(base)));
+
+    const merged = await tiered2.getDocument("doc1");
+    expect(docFromStorageUpdate(merged!.content.update).getText("text").toString()).toBe("aaabbb");
+
+    // Flush and verify slow tier has merged state
+    await tiered2.flush("doc1");
+    const slowDoc = await slow.getDocument("doc1");
+    expect(docFromStorageUpdate(slowDoc!.content.update).getText("text").toString()).toBe("aaabbb");
+
+    await tiered2[Symbol.asyncDispose]();
+  });
+
+  it("sync protocol works correctly after recovery", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    // Session 1: write and flush
+    const fast1 = new MemoryDocumentStorage(false);
+    const tiered1 = new TieredDocumentStorage(fast1, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const { versioned: u1 } = makeUpdate("sync-recover");
+    await tiered1.handleUpdate("doc1", u1);
+    await tiered1[Symbol.asyncDispose]();
+
+    // Session 2: recover, sync with empty client
+    MemoryDocumentStorage.docs.clear();
+    const fast2 = new MemoryDocumentStorage(false);
+    const tiered2 = new TieredDocumentStorage(fast2, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const emptySV = Y.encodeStateVector(new Y.Doc()) as StateVector;
+    const syncResult = await tiered2.handleSyncStep1("doc1", emptySV);
+
+    // Client should be able to reconstruct the document from the sync diff
+    const clientDoc = new Y.Doc();
+    const { structureUpdate } = decodeContentEncryptedPayload(
+      syncResult.content.update as EncryptedUpdatePayload,
+    );
+    if (structureUpdate.length > 0) Y.applyUpdateV2(clientDoc, structureUpdate);
+    expect(clientDoc.getText("text").toString()).toBe("sync-recover");
+
+    // Sync with a client that already has the data → should get empty diff
+    const fullSV = Y.encodeStateVector(clientDoc) as StateVector;
+    const noopSync = await tiered2.handleSyncStep1("doc1", fullSV);
+    const noopUpdate = decodeContentEncryptedPayload(
+      noopSync.content.update as EncryptedUpdatePayload,
+    ).structureUpdate;
+    // Applying an empty/noop diff to a doc with the same state should be harmless
+    const clientDoc2 = new Y.Doc();
+    Y.applyUpdateV2(clientDoc2, Y.encodeStateAsUpdateV2(clientDoc));
+    if (noopUpdate.length > 0) Y.applyUpdateV2(clientDoc2, noopUpdate);
+    expect(clientDoc2.getText("text").toString()).toBe("sync-recover");
+
+    await tiered2[Symbol.asyncDispose]();
+  });
+
+  it("multiple flush cycles produce correct state in slow tier", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    const fast = new MemoryDocumentStorage(false);
+    const tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    // Build up document incrementally with flushes between
+    const doc = new Y.Doc();
+    doc.getText("text").insert(0, "one");
+    await tiered.handleUpdate("doc1", versionedUpdate(Y.encodeStateAsUpdateV2(doc)));
+    await tiered.flush("doc1");
+
+    const sv1 = Y.encodeStateVector(doc);
+    doc.getText("text").insert(3, "-two");
+    await tiered.handleUpdate("doc1", versionedUpdate(Y.encodeStateAsUpdateV2(doc, sv1)));
+    await tiered.flush("doc1");
+
+    const sv2 = Y.encodeStateVector(doc);
+    doc.getText("text").insert(7, "-three");
+    await tiered.handleUpdate("doc1", versionedUpdate(Y.encodeStateAsUpdateV2(doc, sv2)));
+    await tiered.flush("doc1");
+
+    // Slow tier should have the fully merged state
+    const slowDoc = await slow.getDocument("doc1");
+    expect(docFromStorageUpdate(slowDoc!.content.update).getText("text").toString()).toBe("one-two-three");
+
+    // Fresh recovery should see the same
+    MemoryDocumentStorage.docs.clear();
+    const fast2 = new MemoryDocumentStorage(false);
+    const tiered2 = new TieredDocumentStorage(fast2, slow, {
+      persistIntervalMs: 60_000,
+    });
+    const recovered = await tiered2.getDocument("doc1");
+    expect(docFromStorageUpdate(recovered!.content.update).getText("text").toString()).toBe("one-two-three");
+
+    await tiered[Symbol.asyncDispose]();
+    await tiered2[Symbol.asyncDispose]();
+  });
+
+  it("partial flush — only flushed docs survive crash", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    const fast1 = new MemoryDocumentStorage(false);
+    const tiered1 = new TieredDocumentStorage(fast1, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    // Write two docs, flush only one
+    const { versioned: u1 } = makeUpdate("flushed");
+    const { versioned: u2 } = makeUpdate("not-flushed");
+    await tiered1.handleUpdate("doc-a", u1);
+    await tiered1.handleUpdate("doc-b", u2);
+    await tiered1.flush("doc-a"); // only doc-a flushed
+
+    // "Crash" — new session
+    MemoryDocumentStorage.docs.clear();
+    const fast2 = new MemoryDocumentStorage(false);
+    const tiered2 = new TieredDocumentStorage(fast2, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    // doc-a should be recoverable
+    const docA = await tiered2.getDocument("doc-a");
+    expect(docA).not.toBeNull();
+    expect(docFromStorageUpdate(docA!.content.update).getText("text").toString()).toBe("flushed");
+
+    // doc-b should be gone
+    const docB = await tiered2.getDocument("doc-b");
+    expect(docB).toBeNull();
+
+    await tiered2[Symbol.asyncDispose]();
+  });
+
+  it("metadata survives recovery via slow tier", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    const fast1 = new MemoryDocumentStorage(false);
+    const tiered1 = new TieredDocumentStorage(fast1, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const { versioned } = makeUpdate("meta-recovery");
+    await tiered1.handleUpdate("doc1", versioned);
+    await tiered1.writeDocumentMetadata("doc1", {
+      createdAt: 1000,
+      updatedAt: 2000,
+      encrypted: false,
+      files: ["file-a", "file-b"],
+    });
+    await tiered1[Symbol.asyncDispose](); // flushes
+
+    // Recover
+    MemoryDocumentStorage.docs.clear();
+    const fast2 = new MemoryDocumentStorage(false);
+    const tiered2 = new TieredDocumentStorage(fast2, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const meta = await tiered2.getDocumentMetadata("doc1");
+    expect(meta.files).toEqual(["file-a", "file-b"]);
+    expect(meta.createdAt).toBe(1000);
+
+    await tiered2[Symbol.asyncDispose]();
+  });
+
+  it("evict-then-reload produces same content as before eviction", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    MemoryDocumentStorage.docs.clear();
+    const fast = new MemoryDocumentStorage(false);
+    const tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 1,
+      maxDirtyAgeMs: 0,
+      evictAfterMs: 1,
+    });
+
+    // Write, let it persist + evict
+    const doc = new Y.Doc();
+    doc.getText("text").insert(0, "before-eviction");
+    await tiered.handleUpdate("doc1", versionedUpdate(Y.encodeStateAsUpdateV2(doc)));
+
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Confirm evicted from fast
+    expect(await fast.getDocumentState("doc1")).toBeNull();
+
+    // Reload by accessing
+    const reloaded = await tiered.getDocument("doc1");
+    expect(reloaded).not.toBeNull();
+    expect(docFromStorageUpdate(reloaded!.content.update).getText("text").toString()).toBe("before-eviction");
+
+    // Continue editing after reload
+    const base = new Y.Doc();
+    Y.applyUpdateV2(
+      base,
+      decodeContentEncryptedPayload(reloaded!.content.update as EncryptedUpdatePayload).structureUpdate,
+    );
+    const sv = Y.encodeStateVector(base);
+    base.getText("text").insert(15, "-after");
+    await tiered.handleUpdate("doc1", versionedUpdate(Y.encodeStateAsUpdateV2(base, sv)));
+
+    const final = await tiered.getDocument("doc1");
+    expect(docFromStorageUpdate(final!.content.update).getText("text").toString()).toBe("before-eviction-after");
+
+    await tiered[Symbol.asyncDispose]();
+  });
+
+  it("idempotent flush — flushing twice does not corrupt slow tier", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    const fast = new MemoryDocumentStorage(false);
+    const tiered = new TieredDocumentStorage(fast, slow, {
+      persistIntervalMs: 60_000,
+    });
+
+    const { versioned } = makeUpdate("idempotent");
+    await tiered.handleUpdate("doc1", versioned);
+
+    await tiered.flush("doc1");
+    await tiered.flush("doc1"); // second flush is a no-op (not dirty)
+
+    const slowDoc = await slow.getDocument("doc1");
+    expect(docFromStorageUpdate(slowDoc!.content.update).getText("text").toString()).toBe("idempotent");
+
+    await tiered[Symbol.asyncDispose]();
+  });
+
+  it("delete in slow tier is respected on fresh load", async () => {
+    const store = createStorage();
+    openStorages.push(store);
+    const slow = new UnstorageDocumentStorage(store, { encrypted: false });
+
+    // Session 1: create and flush
+    const fast1 = new MemoryDocumentStorage(false);
+    const tiered1 = new TieredDocumentStorage(fast1, slow, {
+      persistIntervalMs: 60_000,
+    });
+    const { versioned } = makeUpdate("will-be-deleted");
+    await tiered1.handleUpdate("doc1", versioned);
+    await tiered1[Symbol.asyncDispose]();
+
+    // Delete via tiered (removes from both tiers)
+    MemoryDocumentStorage.docs.clear();
+    const fast2 = new MemoryDocumentStorage(false);
+    const tiered2 = new TieredDocumentStorage(fast2, slow, {
+      persistIntervalMs: 60_000,
+    });
+    await tiered2.deleteDocument("doc1");
+    await tiered2[Symbol.asyncDispose]();
+
+    // Session 3: verify doc is gone
+    MemoryDocumentStorage.docs.clear();
+    const fast3 = new MemoryDocumentStorage(false);
+    const tiered3 = new TieredDocumentStorage(fast3, slow, {
+      persistIntervalMs: 60_000,
+    });
+    const doc = await tiered3.getDocument("doc1");
+    expect(doc).toBeNull();
+
+    await tiered3[Symbol.asyncDispose]();
+  });
+
   it("loads from unstorage slow tier into memory fast tier", async () => {
     const store = createStorage();
     openStorages.push(store);

--- a/src/storage/tiered/document-storage.ts
+++ b/src/storage/tiered/document-storage.ts
@@ -1,0 +1,302 @@
+import type { IndexedSidecar } from "../../lib/protocol/encryption/content-cipher";
+import { AbstractDocumentStorage, type DocumentState } from "../document-storage";
+import type { DocumentMetadata, DocumentStorage, EncodedContentMap } from "../types";
+
+export interface TieredDocumentStorageOptions {
+  /** Interval in ms between persist sweeps (default: 5000) */
+  persistIntervalMs?: number;
+  /** Max time in ms a document can stay dirty before forced persist (default: 30000) */
+  maxDirtyAgeMs?: number;
+  /** Max documents to persist per sweep (default: 50) */
+  persistBatchSize?: number;
+  /** Evict clean documents from fast tier after this many ms of inactivity (default: undefined = never) */
+  evictAfterMs?: number;
+  /** Callback for background persist failures */
+  onPersistError?: (documentId: string, error: unknown) => void;
+}
+
+const defaults = {
+  persistIntervalMs: 5000,
+  maxDirtyAgeMs: 30_000,
+  persistBatchSize: 50,
+} satisfies Partial<TieredDocumentStorageOptions>;
+
+/**
+ * Composes two {@link AbstractDocumentStorage} instances into a two-tier
+ * storage system following the yhub pattern:
+ *
+ * - **fast tier** (intermediate): quick-access store for active documents
+ *   (e.g. in-memory).
+ * - **slow tier** (persistence): durable store for all documents
+ *   (e.g. Redis/PostgreSQL via unstorage).
+ *
+ * Documents are loaded from the slow tier on first access. All subsequent
+ * reads/writes operate on the fast tier. Dirty documents are periodically
+ * flushed back to the slow tier for durability.
+ */
+export class TieredDocumentStorage extends AbstractDocumentStorage {
+  #fast: AbstractDocumentStorage;
+  #slow: AbstractDocumentStorage;
+  #options: Required<Pick<TieredDocumentStorageOptions, "persistIntervalMs" | "maxDirtyAgeMs" | "persistBatchSize">> &
+    Pick<TieredDocumentStorageOptions, "evictAfterMs" | "onPersistError">;
+
+  #loaded = new Set<string>();
+  #dirty = new Map<string, number>();
+  #lastAccess = new Map<string, number>();
+  #loading = new Map<string, Promise<void>>();
+  #pendingAttributions = new Map<string, EncodedContentMap[]>();
+  #attributionLoaded = new Set<string>();
+  #persistTimer: ReturnType<typeof setInterval> | null = null;
+  #disposed = false;
+
+  constructor(
+    fast: AbstractDocumentStorage,
+    slow: AbstractDocumentStorage,
+    options?: TieredDocumentStorageOptions,
+  ) {
+    super(fast.encrypted);
+    this.#fast = fast;
+    this.#slow = slow;
+    this.#options = {
+      persistIntervalMs: options?.persistIntervalMs ?? defaults.persistIntervalMs,
+      maxDirtyAgeMs: options?.maxDirtyAgeMs ?? defaults.maxDirtyAgeMs,
+      persistBatchSize: options?.persistBatchSize ?? defaults.persistBatchSize,
+      evictAfterMs: options?.evictAfterMs,
+      onPersistError: options?.onPersistError,
+    };
+
+    this.#startPersistTimer();
+  }
+
+  // ── Abstract method overrides ──────────────────────────────────────────
+
+  async getDocumentState(key: string): Promise<DocumentState | null> {
+    await this.#ensureLoaded(key);
+    return this.#fast.getDocumentState(key);
+  }
+
+  async replaceDocumentState(
+    key: string,
+    update: Uint8Array,
+    sidecars: IndexedSidecar[],
+  ): Promise<void> {
+    // Called by base class handleUpdate/handleCompaction after getDocumentState,
+    // which already ensured loading. Skip the redundant slow-tier check.
+    if (!this.#loaded.has(key)) {
+      this.#loaded.add(key);
+      this.#lastAccess.set(key, Date.now());
+    }
+    await this.#fast.replaceDocumentState(key, update, sidecars);
+    this.#markDirty(key);
+  }
+
+  async getDocumentMetadata(key: string): Promise<DocumentMetadata> {
+    await this.#ensureLoaded(key);
+    return this.#fast.getDocumentMetadata(key);
+  }
+
+  async writeDocumentMetadata(key: string, metadata: DocumentMetadata): Promise<void> {
+    await this.#ensureLoaded(key);
+    await this.#fast.writeDocumentMetadata(key, metadata);
+    this.#markDirty(key);
+  }
+
+  async deleteDocument(key: string): Promise<void> {
+    await Promise.all([this.#fast.deleteDocument(key), this.#slow.deleteDocument(key)]);
+    this.#loaded.delete(key);
+    this.#dirty.delete(key);
+    this.#lastAccess.delete(key);
+    this.#loading.delete(key);
+    this.#pendingAttributions.delete(key);
+    this.#attributionLoaded.delete(key);
+  }
+
+  // ── Transaction ────────────────────────────────────────────────────────
+
+  override async transaction<T>(key: string, cb: () => Promise<T>): Promise<T> {
+    return this.#fast.transaction(key, cb);
+  }
+
+  // ── Attribution ────────────────────────────────────────────────────────
+
+  override async storeAttribution(key: string, attribution: EncodedContentMap): Promise<void> {
+    await this.#fast.storeAttribution(key, attribution);
+
+    const existing = this.#pendingAttributions.get(key) ?? [];
+    existing.push(attribution);
+    this.#pendingAttributions.set(key, existing);
+    this.#markDirty(key);
+  }
+
+  async retrieveAttribution(documentId: string): Promise<EncodedContentMap | null> {
+    await this.#ensureLoaded(documentId);
+
+    // Lazy-load attribution from slow tier on first request. This avoids
+    // the expensive getKeys scan in #loadFromSlow for every document load.
+    if (!this.#attributionLoaded.has(documentId)) {
+      const slowAttr = await (this.#slow as DocumentStorage).retrieveAttribution?.(documentId);
+      if (slowAttr) {
+        await this.#fast.storeAttribution(documentId, slowAttr);
+      }
+      this.#attributionLoaded.add(documentId);
+    }
+
+    const fast = this.#fast as DocumentStorage;
+    if (fast.retrieveAttribution) {
+      return fast.retrieveAttribution(documentId);
+    }
+    return null;
+  }
+
+  // ── Load-on-first-access ───────────────────────────────────────────────
+
+  async #ensureLoaded(key: string): Promise<void> {
+    if (this.#loaded.has(key)) {
+      this.#lastAccess.set(key, Date.now());
+      return;
+    }
+
+    const inflight = this.#loading.get(key);
+    if (inflight) {
+      await inflight;
+      return;
+    }
+
+    const loadPromise = this.#loadFromSlow(key);
+    this.#loading.set(key, loadPromise);
+    try {
+      await loadPromise;
+    } finally {
+      this.#loading.delete(key);
+    }
+  }
+
+  async #loadFromSlow(key: string): Promise<void> {
+    // Load state + metadata in parallel. Attribution is loaded lazily
+    // in retrieveAttribution() to avoid expensive key scans on every load.
+    const [state, metadata] = await Promise.all([
+      this.#slow.getDocumentState(key),
+      this.#slow.getDocumentMetadata(key),
+    ]);
+
+    if (state) {
+      await this.#fast.replaceDocumentState(key, state.update, state.sidecars);
+      await this.#fast.writeDocumentMetadata(key, metadata);
+    }
+
+    this.#loaded.add(key);
+    this.#lastAccess.set(key, Date.now());
+  }
+
+  // ── Dirty tracking ─────────────────────────────────────────────────────
+
+  #markDirty(key: string) {
+    if (!this.#dirty.has(key)) {
+      this.#dirty.set(key, Date.now());
+    }
+    this.#lastAccess.set(key, Date.now());
+  }
+
+  // ── Persist (fast → slow) ──────────────────────────────────────────────
+
+  #startPersistTimer() {
+    if (this.#persistTimer) return;
+    this.#persistTimer = setInterval(() => {
+      void this.#persistSweep();
+    }, this.#options.persistIntervalMs);
+    if (typeof this.#persistTimer === "object" && "unref" in this.#persistTimer) {
+      (this.#persistTimer as { unref: () => void }).unref();
+    }
+  }
+
+  async #persistSweep(): Promise<void> {
+    if (this.#disposed) return;
+
+    const now = Date.now();
+    const toPersist: string[] = [];
+
+    for (const [key, dirtyTime] of this.#dirty) {
+      if (now - dirtyTime >= this.#options.maxDirtyAgeMs || toPersist.length < this.#options.persistBatchSize) {
+        toPersist.push(key);
+      }
+      if (toPersist.length >= this.#options.persistBatchSize) break;
+    }
+
+    for (const key of toPersist) {
+      try {
+        await this.#persistDocument(key);
+      } catch (error) {
+        this.#options.onPersistError?.(key, error);
+      }
+    }
+
+    if (this.#options.evictAfterMs != null) {
+      const evictBefore = now - this.#options.evictAfterMs;
+      for (const [key, lastAccess] of this.#lastAccess) {
+        if (lastAccess < evictBefore && !this.#dirty.has(key)) {
+          await this.#evictDocument(key);
+        }
+      }
+    }
+  }
+
+  async #persistDocument(key: string): Promise<void> {
+    const state = await this.#fast.getDocumentState(key);
+    const metadata = await this.#fast.getDocumentMetadata(key);
+
+    if (state) {
+      await this.#slow.transaction(key, async () => {
+        await this.#slow.replaceDocumentState(key, state.update, state.sidecars);
+        await this.#slow.writeDocumentMetadata(key, metadata);
+      });
+    }
+
+    const attributions = this.#pendingAttributions.get(key);
+    if (attributions?.length) {
+      for (const attr of attributions) {
+        await this.#slow.storeAttribution(key, attr);
+      }
+      this.#pendingAttributions.delete(key);
+    }
+
+    this.#dirty.delete(key);
+  }
+
+  async #evictDocument(key: string): Promise<void> {
+    if (this.#dirty.has(key)) return;
+    await this.#fast.deleteDocument(key);
+    this.#loaded.delete(key);
+    this.#lastAccess.delete(key);
+    this.#attributionLoaded.delete(key);
+  }
+
+  // ── Public flush / dispose ─────────────────────────────────────────────
+
+  /** Force-persist a single document immediately. */
+  async flush(documentId: string): Promise<void> {
+    if (this.#dirty.has(documentId)) {
+      await this.#persistDocument(documentId);
+    }
+  }
+
+  /** Force-persist all dirty documents. */
+  async flushAll(): Promise<void> {
+    const keys = [...this.#dirty.keys()];
+    for (const key of keys) {
+      try {
+        await this.#persistDocument(key);
+      } catch (error) {
+        this.#options.onPersistError?.(key, error);
+      }
+    }
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    this.#disposed = true;
+    if (this.#persistTimer) {
+      clearInterval(this.#persistTimer);
+      this.#persistTimer = null;
+    }
+    await this.flushAll();
+  }
+}

--- a/src/storage/tiered/document-storage.ts
+++ b/src/storage/tiered/document-storage.ts
@@ -1,6 +1,12 @@
 import type { IndexedSidecar } from "../../lib/protocol/encryption/content-cipher";
 import { AbstractDocumentStorage, type DocumentState } from "../document-storage";
-import type { DocumentMetadata, DocumentStorage, EncodedContentMap } from "../types";
+import type {
+  Document,
+  DocumentMetadata,
+  DocumentStorage,
+  EncodedContentMap,
+} from "../types";
+import type { StateVector, VersionedSyncStep2Update, VersionedUpdate } from "teleportal";
 
 export interface TieredDocumentStorageOptions {
   /** Interval in ms between persist sweeps (default: 5000) */
@@ -115,6 +121,42 @@ export class TieredDocumentStorage extends AbstractDocumentStorage {
 
   override async transaction<T>(key: string, cb: () => Promise<T>): Promise<T> {
     return this.#fast.transaction(key, cb);
+  }
+
+  // ── Hot-path overrides ────────────────────────────────────────────────
+  // The base class methods (handleUpdate, getDocument, handleSyncStep1)
+  // call multiple abstract methods (getDocumentState, replaceDocumentState,
+  // getDocumentMetadata, writeDocumentMetadata), each of which triggers
+  // #ensureLoaded. By ensuring load once and delegating to the fast tier
+  // directly, we eliminate 2–3 redundant async hops per operation.
+
+  override async handleUpdate(
+    key: string,
+    update: VersionedUpdate,
+    attribution?: EncodedContentMap,
+  ): Promise<void> {
+    await this.#ensureLoaded(key);
+    await this.#fast.handleUpdate(key, update);
+    this.#markDirty(key);
+    if (attribution) {
+      await this.storeAttribution(key, attribution);
+    }
+  }
+
+  override async getDocument(key: string): Promise<Document | null> {
+    await this.#ensureLoaded(key);
+    return this.#fast.getDocument(key);
+  }
+
+  override async handleSyncStep1(key: string, syncStep1: StateVector): Promise<Document> {
+    await this.#ensureLoaded(key);
+    return this.#fast.handleSyncStep1(key, syncStep1);
+  }
+
+  override async handleSyncStep2(key: string, syncStep2: VersionedSyncStep2Update): Promise<void> {
+    await this.#ensureLoaded(key);
+    await this.#fast.handleSyncStep2(key, syncStep2);
+    this.#markDirty(key);
   }
 
   // ── Attribution ────────────────────────────────────────────────────────

--- a/src/storage/tiered/index.ts
+++ b/src/storage/tiered/index.ts
@@ -1,0 +1,1 @@
+export { TieredDocumentStorage, type TieredDocumentStorageOptions } from "./document-storage";

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -56,6 +56,11 @@ export interface FileUploadResult {
    * Chunks can only be fetched once and are deleted after fetching.
    */
   getChunk: (chunkIndex: number) => Promise<Uint8Array>;
+  /**
+   * Serialized merkle tree built during completion.
+   * Stored alongside the file so downloads skip the tree rebuild.
+   */
+  serializedMerkleTree: Uint8Array;
 }
 
 /**
@@ -166,6 +171,10 @@ export interface File {
    * Merkle tree root hash (contentId)
    */
   contentId: Uint8Array;
+  /**
+   * Serialized merkle tree, cached at upload time so downloads skip the rebuild.
+   */
+  serializedMerkleTree?: Uint8Array;
 }
 
 export interface FileStorage {

--- a/src/storage/unstorage/document-storage.test.ts
+++ b/src/storage/unstorage/document-storage.test.ts
@@ -778,7 +778,7 @@ describe("UnstorageDocumentStorage (encrypted)", () => {
 
   // ── Dedup ──────────────────────────────────────────────────────────────────
 
-  it("deduplicates identical updates (no-op on second write)", async () => {
+  it("identical re-applied updates are CRDT-idempotent (state vector unchanged)", async () => {
     const v1 = makeYjsUpdate("hello");
     const payload = makeContentEncryptedUpdate(v1);
 
@@ -787,21 +787,23 @@ describe("UnstorageDocumentStorage (encrypted)", () => {
     // Get state after first write
     const stateAfterFirst = await storage.getDocumentState("doc-1");
     expect(stateAfterFirst).not.toBeNull();
+    const svAfterFirst = Y.encodeStateVectorFromUpdateV2(stateAfterFirst!.update);
 
-    // Sending the exact same update again -- state vector won't advance, so it's a no-op
+    // Sending the exact same update again -- merge is idempotent so the SV
+    // does not advance; sidecars may accumulate (compaction handles cleanup).
     await storage.handleUpdate("doc-1", envelopeUpdate(payload));
 
-    // State should be unchanged (same sidecars count)
     const stateAfterDup = await storage.getDocumentState("doc-1");
-    expect(stateAfterDup!.sidecars.length).toBe(stateAfterFirst!.sidecars.length);
+    const svAfterDup = Y.encodeStateVectorFromUpdateV2(stateAfterDup!.update);
+    expect(new Uint8Array(svAfterDup)).toEqual(new Uint8Array(svAfterFirst));
   });
 
-  it("accepts a new update after a duplicate is rejected", async () => {
+  it("accepts a new update after a duplicate", async () => {
     const v1 = makeYjsUpdate("hello", 1);
     const payload = makeContentEncryptedUpdate(v1);
 
     await storage.handleUpdate("doc-1", envelopeUpdate(payload));
-    // Duplicate -- no-op
+    // Duplicate -- CRDT-idempotent
     await storage.handleUpdate("doc-1", envelopeUpdate(payload));
 
     // Genuinely new update from a different client
@@ -810,8 +812,12 @@ describe("UnstorageDocumentStorage (encrypted)", () => {
     await storage.handleUpdate("doc-1", envelopeUpdate(payload2));
 
     const state = await storage.getDocumentState("doc-1");
-    // Should have 2 sidecars (one from first + one from third, duplicate was skipped)
-    expect(state!.sidecars.length).toBe(2);
+    // At least the two distinct clients' sidecars are present. The duplicate
+    // write also appends a sidecar; compaction is what collapses redundancy.
+    expect(state!.sidecars.length).toBeGreaterThanOrEqual(2);
+    // State vector reflects both clients.
+    const sv = Y.decodeStateVector(Y.encodeStateVectorFromUpdateV2(state!.update));
+    expect(sv.size).toBe(2);
   });
 
   // ── getDocument ────────────────────────────────────────────────────────────

--- a/src/storage/unstorage/document-storage.ts
+++ b/src/storage/unstorage/document-storage.ts
@@ -139,7 +139,7 @@ export class UnstorageDocumentStorage extends AbstractDocumentStorage {
     };
   }
 
-  protected override async storeAttribution(
+  override async storeAttribution(
     key: string,
     attribution: EncodedContentMap,
   ): Promise<void> {

--- a/src/storage/unstorage/file-storage.ts
+++ b/src/storage/unstorage/file-storage.ts
@@ -67,6 +67,7 @@ export class UnstorageFileStorage implements FileStorage {
       metadata: FileMetadata;
       contentId: number[];
       chunkKeys: string[];
+      serializedMerkleTree?: number[];
     }>(fileKey);
 
     if (!serialized) return null;
@@ -81,6 +82,9 @@ export class UnstorageFileStorage implements FileStorage {
       metadata: serialized.metadata,
       chunks: validChunks,
       contentId: new Uint8Array(serialized.contentId),
+      serializedMerkleTree: serialized.serializedMerkleTree
+        ? new Uint8Array(serialized.serializedMerkleTree)
+        : undefined,
     };
   }
 
@@ -116,11 +120,12 @@ export class UnstorageFileStorage implements FileStorage {
 
     const fileKey = this.#getFileKey(uploadResult.fileId);
 
-    // Store file metadata first
+    // Store file metadata + serialized merkle tree
     await this.#storage.setItem(fileKey, {
       metadata: uploadResult.progress.metadata,
       contentId: Array.from(uploadResult.contentId),
       chunkKeys: Array.from({ length: expectedChunks }, (_, i) => this.#getChunkKey(fileKey, i)),
+      serializedMerkleTree: Array.from(uploadResult.serializedMerkleTree),
     });
 
     // Fetch and store chunks incrementally

--- a/src/storage/unstorage/temporary-upload-storage.ts
+++ b/src/storage/unstorage/temporary-upload-storage.ts
@@ -1,6 +1,6 @@
 import { toBase64 } from "lib0/buffer";
 import type { MerkleTree } from "teleportal/merkle-tree";
-import { buildMerkleTree, CHUNK_SIZE } from "teleportal/merkle-tree";
+import { buildMerkleTree, serializeMerkleTree, CHUNK_SIZE } from "teleportal/merkle-tree";
 import type { Storage } from "unstorage";
 import type {
   File,
@@ -60,7 +60,11 @@ export class UnstorageTemporaryUploadStorage implements TemporaryUploadStorage {
     const sessionKey = this.#getUploadSessionKey(uploadId);
     const existing = await this.#storage.getItem(sessionKey);
     if (existing) {
-      throw new Error(`Upload session ${uploadId} already exists`);
+      await this.#storage.setItem(sessionKey, {
+        ...(existing as Record<string, unknown>),
+        lastActivity: Date.now(),
+      });
+      return;
     }
 
     await this.#storage.setItem(sessionKey, {
@@ -191,6 +195,7 @@ export class UnstorageTemporaryUploadStorage implements TemporaryUploadStorage {
       progress,
       fileId: finalFileId,
       contentId: rootHash,
+      serializedMerkleTree: serializeMerkleTree(merkleTree),
       getChunk: async (chunkIndex: number) => {
         // Check if chunk was already fetched (one-time use)
         if (fetchedChunks.has(chunkIndex)) {

--- a/src/transports/encrypted/e2e.test.ts
+++ b/src/transports/encrypted/e2e.test.ts
@@ -557,7 +557,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       enableOfflinePersistence: true,
       offlineStorage: makeStore(),
     });
-    cleanups.push(() => { p1.transport.synced?.catch(() => {}); p1.destroy(); });
+    cleanups.push(() => {
+      p1.transport.synced?.catch(() => {});
+      p1.destroy();
+    });
     await waitForSync(p1);
 
     p1.doc.getText("body").insert(0, "secret offline data");
@@ -586,7 +589,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       enableOfflinePersistence: true,
       offlineStorage: makeStore(),
     });
-    cleanups.push(() => { p2.transport.synced?.catch(() => {}); p2.destroy(); });
+    cleanups.push(() => {
+      p2.transport.synced?.catch(() => {});
+      p2.destroy();
+    });
 
     // `loaded` resolves from the local replay, independent of any server.
     await p2.loaded;
@@ -610,7 +616,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       enableOfflinePersistence: true,
       offlineStorage: makeStore(),
     });
-    cleanups.push(() => { p1.transport.synced?.catch(() => {}); p1.destroy(); });
+    cleanups.push(() => {
+      p1.transport.synced?.catch(() => {});
+      p1.destroy();
+    });
     await waitForSync(p1);
     p1.doc.getText("body").insert(0, "data while online");
     await waitUntil(
@@ -631,7 +640,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       enableOfflinePersistence: true,
       offlineStorage: makeStore(),
     });
-    cleanups.push(() => { p2.transport.synced?.catch(() => {}); p2.destroy(); });
+    cleanups.push(() => {
+      p2.transport.synced?.catch(() => {});
+      p2.destroy();
+    });
 
     // loaded resolves and the doc is restored from local storage...
     await p2.loaded;
@@ -747,7 +759,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: false,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p2.transport.synced?.catch(() => {}); p2.destroy(); });
+    cleanups.push(() => {
+      p2.transport.synced?.catch(() => {});
+      p2.destroy();
+    });
     await waitForSync(p2);
     await waitForContent(p2.doc, "body", (t) => t === "before disconnect");
 
@@ -805,7 +820,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: key,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p2.transport.synced?.catch(() => {}); p2.destroy(); });
+    cleanups.push(() => {
+      p2.transport.synced?.catch(() => {});
+      p2.destroy();
+    });
     await waitForSync(p2);
     await waitForContent(p2.doc, "body", (t) => t === "before disconnect");
 
@@ -854,7 +872,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: false,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { provider.transport.synced?.catch(() => {}); provider.destroy(); });
+    cleanups.push(() => {
+      provider.transport.synced?.catch(() => {});
+      provider.destroy();
+    });
 
     // Wait up to 3s — server must respond with sync-step-2 and sync-step-1
     const deadline = Date.now() + 3000;
@@ -942,7 +963,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: false,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p1.transport.synced?.catch(() => {}); p1.destroy(); });
+    cleanups.push(() => {
+      p1.transport.synced?.catch(() => {});
+      p1.destroy();
+    });
 
     const p2 = await Provider.create({
       connection: conn,
@@ -950,7 +974,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: false,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p2.transport.synced?.catch(() => {}); p2.destroy(); });
+    cleanups.push(() => {
+      p2.transport.synced?.catch(() => {});
+      p2.destroy();
+    });
 
     await waitForSync(p1);
     await waitForSync(p2);
@@ -970,7 +997,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: false,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p1b.transport.synced?.catch(() => {}); p1b.destroy(); });
+    cleanups.push(() => {
+      p1b.transport.synced?.catch(() => {});
+      p1b.destroy();
+    });
 
     const p2b = await Provider.create({
       connection: conn2,
@@ -978,7 +1008,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: false,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p2b.transport.synced?.catch(() => {}); p2b.destroy(); });
+    cleanups.push(() => {
+      p2b.transport.synced?.catch(() => {});
+      p2b.destroy();
+    });
 
     await waitForSync(p1b);
     await waitForSync(p2b);
@@ -1027,7 +1060,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: key,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p1.transport.synced?.catch(() => {}); p1.destroy(); });
+    cleanups.push(() => {
+      p1.transport.synced?.catch(() => {});
+      p1.destroy();
+    });
 
     const p2 = await Provider.create({
       connection: conn,
@@ -1035,7 +1071,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: key,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p2.transport.synced?.catch(() => {}); p2.destroy(); });
+    cleanups.push(() => {
+      p2.transport.synced?.catch(() => {});
+      p2.destroy();
+    });
 
     await waitForSync(p1);
     await waitForSync(p2);
@@ -1055,7 +1094,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: key,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p1b.transport.synced?.catch(() => {}); p1b.destroy(); });
+    cleanups.push(() => {
+      p1b.transport.synced?.catch(() => {});
+      p1b.destroy();
+    });
 
     const p2b = await Provider.create({
       connection: conn2,
@@ -1063,7 +1105,10 @@ describe("encrypted sync e2e: full WebSocket transport", () => {
       encryptionKey: key,
       enableOfflinePersistence: false,
     });
-    cleanups.push(() => { p2b.transport.synced?.catch(() => {}); p2b.destroy(); });
+    cleanups.push(() => {
+      p2b.transport.synced?.catch(() => {});
+      p2b.destroy();
+    });
 
     await waitForSync(p1b);
     await waitForSync(p2b);
@@ -1454,7 +1499,10 @@ describe("attribution e2e: full WebSocket transport", () => {
         attribution: createAttributionRpc,
       },
     });
-    cleanups.push(() => { provider.transport.synced?.catch(() => {}); provider.destroy(); });
+    cleanups.push(() => {
+      provider.transport.synced?.catch(() => {});
+      provider.destroy();
+    });
     return { provider, connection: conn };
   }
 

--- a/src/transports/rate-limiter/index.ts
+++ b/src/transports/rate-limiter/index.ts
@@ -1,4 +1,5 @@
 import type { Message, ServerContext, Transport } from "teleportal";
+import { RpcMessage } from "teleportal/protocol";
 import { mapMessages } from "../utils";
 import type { MetricsCollector } from "../../monitoring";
 import {
@@ -157,6 +158,16 @@ export interface RateLimitOptions<Context extends ServerContext> {
   }) => void;
 
   /**
+   * Called when an incoming message is dropped due to rate limiting.
+   * Use this to send a nack/response back to the client so it can back off.
+   */
+  onRateLimitDrop?: (
+    message: Message<Context>,
+    exceeded: RateLimitExceededData<Context>,
+    write: (msg: Message<Context>) => void | Promise<void>,
+  ) => void;
+
+  /**
    * Metrics collector for recording rate limit metrics
    */
   metricsCollector?: MetricsCollector;
@@ -189,6 +200,7 @@ export class RateLimitedTransport<
   private onRateLimitExceeded?: RateLimitOptions<Context>["onRateLimitExceeded"];
   private onMessageSizeExceeded?: RateLimitOptions<Context>["onMessageSizeExceeded"];
   private onPermissionDenied?: RateLimitOptions<Context>["onPermissionDenied"];
+  private onRateLimitDrop?: RateLimitOptions<Context>["onRateLimitDrop"];
   private metricsCollector?: MetricsCollector;
   private eventEmitter?: RateLimitEmitter<Context>;
 
@@ -210,6 +222,7 @@ export class RateLimitedTransport<
     this.onRateLimitExceeded = options.onRateLimitExceeded;
     this.onMessageSizeExceeded = options.onMessageSizeExceeded;
     this.onPermissionDenied = options.onPermissionDenied;
+    this.onRateLimitDrop = options.onRateLimitDrop;
     this.metricsCollector = options.metricsCollector;
     this.eventEmitter = options.eventEmitter;
 
@@ -219,8 +232,8 @@ export class RateLimitedTransport<
     this.checkPermission = options.checkPermission;
     this.shouldSkipRateLimitFunc = options.shouldSkipRateLimit;
 
-    this.source = this.createRateLimitedSource(transport.source);
     const originalWrite = transport.write.bind(transport);
+    this.source = this.createRateLimitedSource(transport.source, originalWrite);
     const originalClose = transport.close.bind(transport);
     this.write = async (message: Message<Context>) => {
       if (!this.checkMessageSize(message)) {
@@ -431,13 +444,24 @@ export class RateLimitedTransport<
    */
   private createRateLimitedSource(
     source: AsyncIterable<Message<Context>[]>,
+    write: (msg: Message<Context>) => void | Promise<void>,
   ): AsyncIterable<Message<Context>[]> {
     return mapMessages(async (msg: Message<Context>) => {
       if (!this.checkMessageSize(msg)) {
         throw new Error("Message size limit exceeded");
       }
-      // Rate-limited messages are silently dropped (returned as null).
-      return (await this.checkRateLimit(msg)) ? null : msg;
+      const exceeded = await this.checkRateLimit(msg);
+      if (exceeded) {
+        if (this.onRateLimitDrop) {
+          try {
+            this.onRateLimitDrop(msg, exceeded, write);
+          } catch {
+            // Swallow errors from the drop callback
+          }
+        }
+        return null;
+      }
+      return msg;
     })(source);
   }
 }
@@ -459,4 +483,49 @@ export function withRateLimit<
     write: rateLimited.write,
     close: rateLimited.close,
   };
+}
+
+/**
+ * Returns true if the message is a file transfer chunk (upload or download stream).
+ */
+export function isFileTransferMessage(message: Message<any>): boolean {
+  return (
+    message instanceof RpcMessage &&
+    (message.rpcMethod === "fileUpload" || message.rpcMethod === "fileDownload") &&
+    message.requestType === "stream"
+  );
+}
+
+/**
+ * Default rate limit rules with separate budgets for sync messages and file transfers.
+ *
+ * - Sync: 300 msgs/s per user, 1500 msgs/10s per document
+ * - File transfers: 50 chunks/s per user (≈ 3.2 MB/s at 64KB chunks)
+ *
+ * File initiation requests (non-stream RPC) count toward the sync budget.
+ */
+export function defaultRateLimitRules<Context extends ServerContext>(): RateLimitRule<Context>[] {
+  return [
+    {
+      id: "sync-per-user",
+      maxMessages: 300,
+      windowMs: 1000,
+      trackBy: "user",
+      shouldSkipRule: (msg) => isFileTransferMessage(msg),
+    },
+    {
+      id: "sync-per-document",
+      maxMessages: 1500,
+      windowMs: 10_000,
+      trackBy: "document",
+      shouldSkipRule: (msg) => isFileTransferMessage(msg),
+    },
+    {
+      id: "file-transfer-per-user",
+      maxMessages: 200,
+      windowMs: 1000,
+      trackBy: "user",
+      shouldSkipRule: (msg) => !isFileTransferMessage(msg),
+    },
+  ];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,5 +36,5 @@
     },
     "jsx": "react-jsx"
   },
-  "include": ["src", "playground", "examples", "guides"]
+  "include": ["src", "playground", "examples", "guides", "benchmarks"]
 }


### PR DESCRIPTION
## Summary

- **TieredDocumentStorage**: New two-tier (hot/cold) caching storage layer with yhub-style semantics, including comprehensive tests and recovery/correctness coverage.
- **Client-side IDB file cache**: IndexedDB-backed file cache with resumable uploads and rate-limit retransmission support for the file transfer protocol.
- **Benchmarks suite**: Added benchmarks for file transfers, protocol encoding, server operations, storage, sync, and tiered storage.
- **Performance**: Skip `parseUpdateMetaV2` for unencrypted docs and eliminate tiered delegation overhead. Replaced `TransformStream` with async generator in merkle-tree for simpler streaming.
- **Bug fixes**: Persist delete-only updates instead of discarding them, wire `withAckSink` into SSE reader so writer ACKs resolve, and playground layout fixes.

## Test plan

- [x] TieredDocumentStorage unit tests (recovery, correctness, sync)
- [x] IDB file cache tests
- [x] Existing storage and server test suites updated and passing
- [x] Benchmarks run without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)